### PR TITLE
Reset dropdown when the list changes

### DIFF
--- a/src/Dropdown/Dropdown.stories.js
+++ b/src/Dropdown/Dropdown.stories.js
@@ -72,4 +72,13 @@ storiesOf('Dropdown', module)
       list={days.slice(0, 1)}
       onSelect={e => console.log(e)}
     />
+  ))
+  .addWithJSX('empty list', () => (
+    <Dropdown
+      id="days"
+      label="Day"
+      placeholder="Select Day"
+      list={[]}
+      onSelect={e => console.log(e)}
+    />
   ));

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useEffect} from 'react';
+import React, {FC, useEffect, useState} from 'react';
 import styled from 'styled-components';
 
 import {Text} from '../Text';
@@ -14,7 +14,7 @@ export type DropdownItem = {
 type Props = {
   /** ID, usually used for tests  */
   id: string;
-  /** className attribute to apply classses from props */
+  /** className attribute to apply classes from props */
   className?: string;
   /** label displayed above the dropdown  */
   label?: string;
@@ -37,9 +37,17 @@ export const Dropdown: FC<Props> = ({
   list,
   onSelect,
 }) => {
+
+  const [value, setValue] = useState('');
+
   useEffect(() => {
-    if (list.length === 1) onSelect(list[0].value);
-  }, []);
+    if (list.length === 1) {
+      setValue(String(list[0].value));
+      onSelect(String(list[0].value));
+    } else {
+      setValue('');
+    }
+  }, [list]);
 
   return (
     <Container className={className}>
@@ -52,13 +60,14 @@ export const Dropdown: FC<Props> = ({
         <Select
           id={id}
           disabled={disabled}
-          defaultValue={list.length === 1 ? String(list[0].value) : placeholder}
-          onChange={(e: React.FormEvent<HTMLSelectElement>) =>
-            onSelect(e.currentTarget.value)
-          }
+          onChange={(e: React.FormEvent<HTMLSelectElement>) => {
+            setValue(e.currentTarget.value);
+            onSelect(e.currentTarget.value);
+          }}
           required
+          value={value}
         >
-          {list.length > 1 && (
+          {list.length !== 1 && (
             <option value="" hidden>
               {placeholder}
             </option>

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -8,7 +8,7 @@ import {theme} from '../theme';
 
 export type DropdownItem = {
   label: string;
-  value: string | number;
+  value: string;
 };
 
 type Props = {
@@ -25,7 +25,7 @@ type Props = {
   /** list of items for the dropdown list */
   list: DropdownItem[];
   /** onSelect handler */
-  onSelect: (element: string | number) => void;
+  onSelect: (element: string) => void;
 };
 
 export const Dropdown: FC<Props> = ({
@@ -45,7 +45,7 @@ export const Dropdown: FC<Props> = ({
 
   useEffect(() => {
     if (list.length === 1) {
-      setDropdownValue(String(list[0].value));
+      setDropdownValue(list[0].value);
     } else {
       setValue('');
     }
@@ -68,11 +68,9 @@ export const Dropdown: FC<Props> = ({
           required
           value={value}
         >
-          {list.length !== 1 && (
-            <option value="" hidden>
-              {placeholder}
-            </option>
-          )}
+          <option value="" hidden>
+            {placeholder}
+          </option>
           {list.map((el, i) => (
             <option key={i} value={el.value}>
               {el.label}

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -37,9 +37,8 @@ export const Dropdown: FC<Props> = ({
   list,
   onSelect,
 }) => {
-
   const [value, setValue] = useState('');
-  const setDropdownValue = (value : string) => {
+  const setDropdownValue = (value: string) => {
     setValue(value);
     onSelect(value);
   };

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -39,11 +39,14 @@ export const Dropdown: FC<Props> = ({
 }) => {
 
   const [value, setValue] = useState('');
+  const setDropdownValue = (value : string) => {
+    setValue(value);
+    onSelect(value);
+  };
 
   useEffect(() => {
     if (list.length === 1) {
-      setValue(String(list[0].value));
-      onSelect(String(list[0].value));
+      setDropdownValue(String(list[0].value));
     } else {
       setValue('');
     }
@@ -61,8 +64,7 @@ export const Dropdown: FC<Props> = ({
           id={id}
           disabled={disabled}
           onChange={(e: React.FormEvent<HTMLSelectElement>) => {
-            setValue(e.currentTarget.value);
-            onSelect(e.currentTarget.value);
+            setDropdownValue(e.currentTarget.value);
           }}
           required
           value={value}


### PR DESCRIPTION
## What does this do?

Ensure the dropdown resets to initial state, when the dropdown changes. Previously, if the user selected item 3 in the list, then the list changes, item 3 will still be selected even though the value and label has completely changed, because it's a new list.

## What does it affect?

The dropdown control used in Agent Portal and Customer Account
