### PR TITLE
Proposal: update Prettier config and update options

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,17 +1,7 @@
 {
-  "arrowParens": "avoid",
   "bracketSpacing": false,
-  "htmlWhitespaceSensitivity": "css",
-  "insertPragma": false,
-  "jsxBracketSameLine": false,
-  "jsxSingleQuote": false,
   "proseWrap": "always",
-  "quoteProps": "as-needed",
-  "requirePragma": false,
   "semi": true,
   "singleQuote": true,
-  "tabWidth": 2,
-  "trailingComma": "all",
-  "useTabs": false,
-  "printWidth": 80
+  "trailingComma": "all"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "bracketSpacing": false,
+  "bracketSpacing": true,
   "proseWrap": "always",
   "semi": true,
   "singleQuote": true,

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "bracketSpacing": true,
   "proseWrap": "always",
-  "semi": true,
+  "semi": false,
   "singleQuote": true,
   "trailingComma": "all"
 }


### PR DESCRIPTION
## What does this do?

This is a proposal to update Prettier config and update the config to add spaces around arguments inside brackets (sensible whitespace) and remove semi-colons (as the compiler will add these on build when minimised).

## What does it affect?

- Remove reference to config options that are the `default` for Prettier
- Set `"bracketSpacing": true` to add spacing around arguments
- Set `"semi": false,` to remove semi-colons

## Review Checklist

- [x] Added and/or modified tests for affected areas
- [x] Squashed any extraneous commit messages
- [x] Ready to review
- [x] Ready to merge
