### PR TITLE
Add font-weights to global theme and Button component

### DIFF
--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -1,36 +1,36 @@
-import React, {FC, ReactNode} from 'react';
-import styled, {css} from 'styled-components';
+import React, { FC, ReactNode } from 'react'
+import styled, { css } from 'styled-components'
 
-import {theme} from '../theme';
+import { theme } from '../theme'
 
 interface IButton {
   /** button color  */
-  color: string;
+  color: string
   /** unique id */
-  id: string;
+  id: string
   /** take full 100% width  */
-  block: boolean;
+  block: boolean
   /** invert bg and text colors */
-  inverted: boolean;
+  inverted: boolean
   /** disabled state */
-  disabled: boolean;
+  disabled: boolean
   /** outline styling */
-  outlined: boolean;
+  outlined: boolean
   /** onClick event handler */
-  onClick: (e: React.FormEvent<HTMLButtonElement>) => void;
+  onClick: (e: React.FormEvent<HTMLButtonElement>) => void
 }
 
 type Props = {
-  children: ReactNode;
-  id: string;
-  className?: string;
-  color?: string;
-  block?: boolean;
-  inverted?: boolean;
-  disabled?: boolean;
-  outlined?: boolean;
-  handleClick: (e: React.FormEvent<HTMLButtonElement>) => void;
-};
+  children: ReactNode
+  id: string
+  className?: string
+  color?: string
+  block?: boolean
+  inverted?: boolean
+  disabled?: boolean
+  outlined?: boolean
+  handleClick: (e: React.FormEvent<HTMLButtonElement>) => void
+}
 
 export const Button: FC<Props> = ({
   children,
@@ -55,9 +55,11 @@ export const Button: FC<Props> = ({
   >
     {children}
   </Container>
-);
+)
 
 const Container = styled.button<IButton>`
+  ${theme.fontStack}
+  font-weight: ${theme.font.weight.medium};
   position: relative;
   display: inline-block;
   box-sizing: border-box;
@@ -74,9 +76,11 @@ const Container = styled.button<IButton>`
   &:hover:not([disabled]) {
     background-color: ${p => theme.colors[`${p.color}6`]};
   }
+
   &:active:not([disabled]) {
     background-color: ${p => theme.colors[`${p.color}7`]};
   }
+
   &:disabled {
     opacity: 0.5;
     cursor: not-allowed;
@@ -101,4 +105,4 @@ const Container = styled.button<IButton>`
     padding: 19px 24px 15px;
     font-size: 16px;
   }
-`;
+`

--- a/src/Button/__tests__/__snapshots__/Button.js.snap
+++ b/src/Button/__tests__/__snapshots__/Button.js.snap
@@ -2,6 +2,8 @@
 
 exports[`renders 1`] = `
 .c0 {
+  font-family: Gordita,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 500;
   position: relative;
   display: inline-block;
   box-sizing: border-box;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -51,8 +51,25 @@ const colors = {
   red4: '#D7796A',
   red5: '#E06161',
   red7: '#D82C2C',
-};
+}
+
+const font = {
+  family: 'Gordita',
+
+  weight: {
+    normal: 400,
+    medium: 500,
+    bold: 500,
+  },
+
+  system:
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
+}
+
+const fontStack = `font-family: ${font.family}, ${font.system};`
 
 export const theme = {
   colors,
-};
+  font,
+  fontStack,
+}


### PR DESCRIPTION
## What does this do?

Add font-weight variables to the global theme and set the Button component to be medium weight and to have a fallback font.

## What does it affect?

- Adds font-weights to `theme.js`
- Add default font stack to `theme.js`
- Set Button component to be `500` weight

## Review Checklist

- [x] Added and/or modified tests for affected areas
- [x] Squashed any extraneous commit messages
- [x] Ready to review
- [ ] Ready to merge
