### PR TITLE
position fixed for modal overlay

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -62,11 +62,14 @@ const Wrapper = styled(Box)<IModalWrapper>(
 )
 
 const Overlay = styled.div`
-  position: absolute;
+  position: fixed;
   background: ${theme.colors.blue7};
   opacity: 0.4;
   height: calc(100vh);
   width: 100%;
+  top: 0;
+  left: 0;
+  z-index: 999;
 `
 
 const Container = styled.div<IModalContainer>(

--- a/src/Modal/__tests__/__snapshots__/Modal.js.snap
+++ b/src/Modal/__tests__/__snapshots__/Modal.js.snap
@@ -79,11 +79,14 @@ exports[`renders 1`] = `
 }
 
 .c1 {
-  position: absolute;
+  position: fixed;
   background: #112035;
   opacity: 0.4;
   height: calc(100vh);
   width: 100%;
+  top: 0;
+  left: 0;
+  z-index: 999;
 }
 
 .c2 {


### PR DESCRIPTION
## Screenshot

### Before
![image](https://user-images.githubusercontent.com/17195367/99290354-188a6480-2836-11eb-9854-93ca24ac2e1c.png)

### After
![image](https://user-images.githubusercontent.com/17195367/99290374-1d4f1880-2836-11eb-8fb7-91f0132e7188.png)

## What does this do?

As mentioned with @habin-isa, changed position of Modal overlay to `fixed` to avoid width being set by the Wrapper component in the Router in customer-portal-www. Also added `z-index: 999` to overlay to show above the header.

## What does it affect?

- Modal

## Checklist

## Review Checklist

- [ ] Added and/or updated tests
- [ ] Ready to review
- [ ] Ready to merge
