### PR TITLE
changed flex direciton to column in Modal

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -45,7 +45,7 @@ export const Modal: FC<ModalProps> = ({
           </IconContainer>
         )}
       </Box>
-      <Box flex direction="row">
+      <Box flex direction="column">
         {children}
       </Box>
     </Container>

--- a/src/Modal/__tests__/__snapshots__/Modal.js.snap
+++ b/src/Modal/__tests__/__snapshots__/Modal.js.snap
@@ -21,9 +21,9 @@ exports[`renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .c6 {
@@ -171,7 +171,7 @@ exports[`renders 1`] = `
     </div>
     <div
       class="c7"
-      direction="row"
+      direction="column"
     >
       Text inside
     </div>


### PR DESCRIPTION
## Screenshot

from: 
<img width="496" alt="Screenshot 2020-11-20 at 10 30 25" src="https://user-images.githubusercontent.com/17195367/99790110-8cb95680-2b1b-11eb-8df1-0b9a4706031f.png">

to:
<img width="480" alt="Screenshot 2020-11-20 at 10 31 04" src="https://user-images.githubusercontent.com/17195367/99790136-95aa2800-2b1b-11eb-95f3-bd343d5215e3.png">

## What does this do?

Fixed flex direction on Modal
