### PR TITLE
modified height of modal drawer

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -106,8 +106,9 @@ const Container = styled.div<IModalContainer>(
         padding: 10% 24px;
         overflow: scroll;
         max-height: 90vh;
-        height: 70vh;
-        top: 30vh;
+        position: fixed;
+        top: auto;
+        bottom: 0;
       }
     `}
   `,

--- a/src/Modal/__tests__/__snapshots__/Modal.js.snap
+++ b/src/Modal/__tests__/__snapshots__/Modal.js.snap
@@ -131,8 +131,9 @@ exports[`renders 1`] = `
     padding: 10% 24px;
     overflow: scroll;
     max-height: 90vh;
-    height: 70vh;
-    top: 30vh;
+    position: fixed;
+    top: auto;
+    bottom: 0;
   }
 }
 


### PR DESCRIPTION
## Screenshot

From:

![image](https://user-images.githubusercontent.com/17195367/103569002-75ada880-4ebe-11eb-846a-2a3053e8a32b.png)

To:

![image](https://user-images.githubusercontent.com/17195367/103569008-79412f80-4ebe-11eb-9a4a-e3c4eafb0db4.png)

## What does this do?

Changes the height of the modal to hug the bottom of the screen for better usability.

## What does it affect?

- Modal component