### PR TITLE
🐛 removed hardcoded flex from modal

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -71,7 +71,6 @@ const Wrapper = styled(Box)<IModalWrapper>(
     left: 0;
     height: calc(100vh);
     width: 100%;
-    display: flex;
     justify-content: center;
     align-items: center;
   `,

--- a/src/Modal/__tests__/__snapshots__/Modal.js.snap
+++ b/src/Modal/__tests__/__snapshots__/Modal.js.snap
@@ -74,10 +74,6 @@ exports[`renders 1`] = `
   left: 0;
   height: calc(100vh);
   width: 100%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;


### PR DESCRIPTION
## What does this do?

Currently Modals will show by default, as the variable to show/hide is ignored by setting display twice.