### PR TITLE
Add flex grow to children container button

### DIFF
--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -85,7 +85,7 @@ export const Button: FC<Props> = ({
               height="16"
             />
           ) : (
-            children
+            <ChildrenContainer>{children}</ChildrenContainer>
           )}
         </Container>
       ) : (
@@ -175,4 +175,8 @@ const Container = styled.button<IButton>(
 
 const IconContainer = styled(IconComponent)`
   margin-right: 10px;
+`
+
+const ChildrenContainer = styled.div`
+  flex-grow: 1;
 `


### PR DESCRIPTION
## Screenshot

![image](https://user-images.githubusercontent.com/25356097/104203975-a47ad000-5424-11eb-9272-05a939f76606.png)

![image](https://user-images.githubusercontent.com/25356097/104203821-7bf2d600-5424-11eb-9bf7-450135ace39f.png)

![image](https://user-images.githubusercontent.com/25356097/104203873-8a40f200-5424-11eb-8cc8-129d38720849.png)

## What does this do?

Adding flex grow 1 to children of button so that the the icon is kept to the left and text is centred, at Jason's request

## What does it affect?

- Buttons buttons butttons
