### PR TITLE
Date picker shift days ignore weekends

### DIFF
--- a/src/Datepicker/Datepicker.stories.js
+++ b/src/Datepicker/Datepicker.stories.js
@@ -10,3 +10,9 @@ export default {
 const Template = (args) => <Datepicker {...args} />
 
 export const Default = Template.bind({})
+
+Default.args = {
+  disableWeekend: false,
+  firstDayShift: true,
+  range: 300
+}

--- a/src/Datepicker/Datepicker.tsx
+++ b/src/Datepicker/Datepicker.tsx
@@ -12,6 +12,8 @@ import {
   startOfMonth,
   getDaysInMonth,
   isToday,
+  isWeekend,
+  getDay,
 } from 'date-fns'
 
 import { Box } from '../Box'
@@ -23,11 +25,15 @@ import { DatesList } from './DatesList'
 import { Month } from './types'
 
 type DatepickerProps = {
+  disableWeekend?: boolean
+  firstDayShift?: boolean
   range?: number
   onDateSelect: (date: string) => void
 }
 
 export const Datepicker: FC<DatepickerProps> = ({
+  disableWeekend = true,
+  firstDayShift = false,
   range = 14,
   onDateSelect,
 }) => {
@@ -51,6 +57,19 @@ export const Datepicker: FC<DatepickerProps> = ({
     const daysInMonth = getDaysInMonth(startDay)
     const year = getYear(startDay)
     const filteredDays = []
+    if(firstDayShift) {
+      const firstDay = new Date(year, month, 0)
+      const blankDays = getDay(firstDay)
+  
+      for(let i = 0; i < blankDays; i += 1) {
+        filteredDays.push({
+          firstDay,
+          label: '',
+          active: false,
+          disabled: true
+        })
+      }
+    }
 
     for (let i = 1; i <= daysInMonth; i += 1) {
       const date = new Date(year, month, i)
@@ -61,7 +80,8 @@ export const Datepicker: FC<DatepickerProps> = ({
         active: activeDay ? isSameDay(date, activeDay) : false,
         disabled:
           !isToday(date) &&
-          !isWithinInterval(date, { start: startDay, end: endDay }),
+          !isWithinInterval(date, { start: startDay, end: endDay }) ||
+          (disableWeekend && isWeekend(date))
       })
     }
 
@@ -178,7 +198,7 @@ const Circle = styled.button`
   width: 32px;
   border-radius: 50%;
   border: none;
-  padding: 0;
+  padding: 0!important;
   cursor: pointer;
 
   :disabled {

--- a/src/Datepicker/Datepicker.tsx
+++ b/src/Datepicker/Datepicker.tsx
@@ -57,16 +57,17 @@ export const Datepicker: FC<DatepickerProps> = ({
     const daysInMonth = getDaysInMonth(startDay)
     const year = getYear(startDay)
     const filteredDays = []
-    if(firstDayShift) {
-      const firstDay = new Date(year, month, 0)
-      const blankDays = getDay(firstDay)
-  
-      for(let i = 0; i < blankDays; i += 1) {
+
+    if (firstDayShift) {
+      const date = new Date(year, month, 0)
+      const blankDays = getDay(date)
+
+      for (let i = 0; i < blankDays; i += 1) {
         filteredDays.push({
-          firstDay,
+          date,
           label: '',
           active: false,
-          disabled: true
+          disabled: true,
         })
       }
     }
@@ -79,9 +80,9 @@ export const Datepicker: FC<DatepickerProps> = ({
         label: format(date, 'dd'),
         active: activeDay ? isSameDay(date, activeDay) : false,
         disabled:
-          !isToday(date) &&
-          !isWithinInterval(date, { start: startDay, end: endDay }) ||
-          (disableWeekend && isWeekend(date))
+          (!isToday(date) &&
+            !isWithinInterval(date, { start: startDay, end: endDay })) ||
+          (disableWeekend && isWeekend(date)),
       })
     }
 
@@ -198,7 +199,7 @@ const Circle = styled.button`
   width: 32px;
   border-radius: 50%;
   border: none;
-  padding: 0!important;
+  padding: 0 !important;
   cursor: pointer;
 
   :disabled {


### PR DESCRIPTION
## Screenshot

![image](https://user-images.githubusercontent.com/17195367/104209823-186ba700-542a-11eb-892c-bad4a92f7e7a.png)

## What does this do?

- Added optional Props to DatePicker to disable picking weekends, and to shift the days along correctly (like a calendar). Shifting the days is necessary as otherwise weekends are in the middle sometimes (looks very odd)
- caret icons aren't displaying properly without adding !important to the padding on the styling here.

**I think shifting the days along correctly would be nice to have by default, but didn't want to break any existing layouts**

## What does it affect?

- Date Picker