### PR TITLE
shift sunday correctly when first day of month

### DIFF
--- a/src/Datepicker/Datepicker.stories.js
+++ b/src/Datepicker/Datepicker.stories.js
@@ -15,5 +15,5 @@ Default.args = {
   disableWeekend: false,
   firstDayShift: true,
   range: 31,
-  fromDate: new Date('2021/03/14'),
+  fromDate: new Date('2021/07/14'),
 }

--- a/src/Datepicker/Datepicker.tsx
+++ b/src/Datepicker/Datepicker.tsx
@@ -63,7 +63,7 @@ export const Datepicker: FC<DatepickerProps> = ({
     if (firstDayShift) {
       const date = new Date(year, month, 1)
       const dayOfTheWeek = getISODay(date)
-      const blankDays = dayOfTheWeek === 7 ? 0 : dayOfTheWeek - 1
+      const blankDays = dayOfTheWeek - 1
 
       for (let i = 0; i < blankDays; i += 1) {
         filteredDays.push({


### PR DESCRIPTION
## Screenshot

bug: 
![image](https://user-images.githubusercontent.com/17195367/104576874-ae811680-5650-11eb-8c2c-5967337f8f63.png)

fix:
![image](https://user-images.githubusercontent.com/17195367/104576893-b8a31500-5650-11eb-8e70-f183ceb2d5a6.png)

## What does this do?

Fixes a bug where calendar dates are not shifted correctly when the first day of the month is a Sunday

## What does it affect?

- Date picker