### PR TITLE
Add additional breakpoint and scale padding/grid gaps

### DIFF
--- a/src/Datepicker/DatesList.tsx
+++ b/src/Datepicker/DatesList.tsx
@@ -27,10 +27,15 @@ export const DatesList: FC<Props> = ({ items, handleDateSelect }) => (
 
 const Container = styled.ul`
   display: grid;
-  grid-column-gap: 8px;
+  grid-column-gap: 4px;
   grid-row-gap: 8px;
   grid-template-columns: repeat(7, 1fr);
-  padding: 16px;
+  padding: 8px;
+
+  @media (min-width: 360px) {
+    grid-gap: 8px;
+    padding: 16px;
+  }
 
   @media (min-width: 768px) {
     grid-column-gap: 16px;


### PR DESCRIPTION
## Screenshot / video

![image](https://user-images.githubusercontent.com/34772985/107673648-18133580-6c8e-11eb-8f19-b666fea55b6d.png)

## What does this do?

Fixes an issue where the padding and grid gaps of the `DatesList` was breaking the UI on smaller screens. 
Grid-gaps and padding have now been adjusted for different media breakpoints.
