### PR TITLE
Tertiary button styling changes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,8 +34,7 @@
       "plugins": ["@typescript-eslint/eslint-plugin"],
       "extends": [
         "plugin:@typescript-eslint/eslint-recommended",
-        "plugin:@typescript-eslint/recommended",
-        "eslint-config-prettier/@typescript-eslint"
+        "plugin:@typescript-eslint/recommended"
       ],
       "rules": {
         "@typescript-eslint/explicit-function-return-type": ["off"],

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -164,13 +164,14 @@ const Container = styled.button<IButton>(
     `}
   ${tertiary &&
     css`
-      background-color: ${theme.colors.bg2};
+      background-color: ${theme.colors.bg4};
+      border: none;
 
       &:hover {
         background-color: ${!(disabled || isLoading) && theme.colors.grey2};
       }
       &:active {
-        background-color: ${theme.colors.grey3};
+        background-color: ${theme.colors.bg4};
       }
     `}
   `,

--- a/src/CheckBox/__tests__/__snapshots__/CheckBox.js.snap
+++ b/src/CheckBox/__tests__/__snapshots__/CheckBox.js.snap
@@ -2,10 +2,10 @@
 
 exports[`renders 1`] = `
 <label
-  class="sc-dlfnbm rlmgG"
+  class="sc-dkPtyc jFeFPm"
 >
   <span
-    class="sc-bdfBwQ jvAsmG"
+    class="sc-bdvvaa hsyBHm"
     color="blue7"
     cursor="inherit"
     title=""
@@ -14,7 +14,7 @@ exports[`renders 1`] = `
     type="checkbox"
   />
   <span
-    class="sc-gsTCUz iMmdmk"
+    class="sc-gsDJrp kNtSwe"
   />
 </label>
 `;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -4,6 +4,7 @@ const colors = {
   // Background
   bg2: '#F9F9F9',
   bg3: '#F8F6F6',
+  bg4: '#F4F4F4',
 
   // Grey
   grey2: '#ECECEC',


### PR DESCRIPTION
## Screenshot
![image](https://user-images.githubusercontent.com/31040555/115535304-86790300-a290-11eb-8e4e-bd4b9550058b.png)

## What does this do?
- Changes for tertiary button styling
- Added `bg4` theme colour
- Removes types/eslint-prettier (as prettier now offers this in their main module)
- Updates snapshot testing