### PR TITLE
Add label-large for Text and add typo for Tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.63.0] - 2021-04-21
+### Added
+- Added label-large in typography for Text
+### Changed
+- Exposed typography in Tag
+
 ## [0.62.0] - 2021-04-21
 ### Added
 - New Icon svgs for Location, Policy-doc, Globe and Shield-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@
 ### Changed
 - Updated gap and styles on Row component
 
-[0.60.1]: https://github.com/marshmallow-insurance/smores-react/compare/v0.60.0...v0.62.0
+[0.63.0]: https://github.com/marshmallow-insurance/smores-react/compare/v0.62.0...v0.63.0
+[0.62.0]: https://github.com/marshmallow-insurance/smores-react/compare/v0.60.1...v0.62.0
 [0.60.1]: https://github.com/marshmallow-insurance/smores-react/compare/v0.60.0...v0.60.1
 [0.60.0]: https://github.com/marshmallow-insurance/smores-react/compare/v0.59.0...v0.60.0
 [0.59.0]: https://github.com/marshmallow-insurance/smores-react/compare/v0.58.0...v0.59.0

--- a/src/CheckBox/__tests__/__snapshots__/CheckBox.js.snap
+++ b/src/CheckBox/__tests__/__snapshots__/CheckBox.js.snap
@@ -5,7 +5,7 @@ exports[`renders 1`] = `
   class="sc-dkPtyc jFeFPm"
 >
   <span
-    class="sc-bdvvaa hsyBHm"
+    class="sc-bdvvaa bCbZdv"
     color="blue7"
     cursor="inherit"
     title=""

--- a/src/LabelledText/__tests__/__snapshots__/LabelledText.js.snap
+++ b/src/LabelledText/__tests__/__snapshots__/LabelledText.js.snap
@@ -3,7 +3,7 @@
 exports[`renders 1`] = `
 .c1 {
   font-size: 8px;
-  line-height: 9px;
+  line-height: 100%;
   font-weight: 700;
   text-transform: uppercase;
   -webkit-letter-spacing: 0.75px;
@@ -38,7 +38,6 @@ exports[`renders 1`] = `
 @media (min-width:768px) {
   .c1 {
     font-size: 10px;
-    line-height: 12px;
   }
 }
 

--- a/src/NumberInput/__tests__/__snapshots__/NumberInput.js.snap
+++ b/src/NumberInput/__tests__/__snapshots__/NumberInput.js.snap
@@ -3,7 +3,7 @@
 exports[`renders - currency 1`] = `
 .c1 {
   font-size: 8px;
-  line-height: 9px;
+  line-height: 100%;
   font-weight: 700;
   text-transform: uppercase;
   -webkit-letter-spacing: 0.75px;
@@ -181,7 +181,6 @@ exports[`renders - currency 1`] = `
 @media (min-width:768px) {
   .c1 {
     font-size: 10px;
-    line-height: 12px;
   }
 }
 
@@ -278,7 +277,7 @@ exports[`renders - currency 1`] = `
 exports[`renders - disabled 1`] = `
 .c1 {
   font-size: 8px;
-  line-height: 9px;
+  line-height: 100%;
   font-weight: 700;
   text-transform: uppercase;
   -webkit-letter-spacing: 0.75px;
@@ -367,7 +366,6 @@ exports[`renders - disabled 1`] = `
 @media (min-width:768px) {
   .c1 {
     font-size: 10px;
-    line-height: 12px;
   }
 }
 
@@ -403,7 +401,7 @@ exports[`renders - disabled 1`] = `
 exports[`renders - error 1`] = `
 .c1 {
   font-size: 8px;
-  line-height: 9px;
+  line-height: 100%;
   font-weight: 700;
   text-transform: uppercase;
   -webkit-letter-spacing: 0.75px;
@@ -588,7 +586,6 @@ exports[`renders - error 1`] = `
 @media (min-width:768px) {
   .c1 {
     font-size: 10px;
-    line-height: 12px;
   }
 }
 
@@ -690,7 +687,7 @@ exports[`renders - error 1`] = `
 exports[`renders - number 1`] = `
 .c1 {
   font-size: 8px;
-  line-height: 9px;
+  line-height: 100%;
   font-weight: 700;
   text-transform: uppercase;
   -webkit-letter-spacing: 0.75px;
@@ -784,7 +781,6 @@ exports[`renders - number 1`] = `
 @media (min-width:768px) {
   .c1 {
     font-size: 10px;
-    line-height: 12px;
   }
 }
 
@@ -824,7 +820,7 @@ exports[`renders - number 1`] = `
 exports[`renders - tel 1`] = `
 .c1 {
   font-size: 8px;
-  line-height: 9px;
+  line-height: 100%;
   font-weight: 700;
   text-transform: uppercase;
   -webkit-letter-spacing: 0.75px;
@@ -934,7 +930,6 @@ exports[`renders - tel 1`] = `
 @media (min-width:768px) {
   .c1 {
     font-size: 10px;
-    line-height: 12px;
   }
 }
 
@@ -987,7 +982,7 @@ exports[`renders - with suffix 1`] = `
 
 .c1 {
   font-size: 8px;
-  line-height: 9px;
+  line-height: 100%;
   font-weight: 700;
   text-transform: uppercase;
   -webkit-letter-spacing: 0.75px;
@@ -1097,7 +1092,6 @@ exports[`renders - with suffix 1`] = `
 @media (min-width:768px) {
   .c1 {
     font-size: 10px;
-    line-height: 12px;
   }
 }
 
@@ -1150,7 +1144,7 @@ exports[`renders - with suffix 1`] = `
 exports[`renders - with trailing icon 1`] = `
 .c1 {
   font-size: 8px;
-  line-height: 9px;
+  line-height: 100%;
   font-weight: 700;
   text-transform: uppercase;
   -webkit-letter-spacing: 0.75px;
@@ -1285,7 +1279,6 @@ exports[`renders - with trailing icon 1`] = `
 @media (min-width:768px) {
   .c1 {
     font-size: 10px;
-    line-height: 12px;
   }
 }
 

--- a/src/SearchInput/__tests__/__snapshots__/SearchInput.js.snap
+++ b/src/SearchInput/__tests__/__snapshots__/SearchInput.js.snap
@@ -3,7 +3,7 @@
 exports[`renders 1`] = `
 .c1 {
   font-size: 8px;
-  line-height: 9px;
+  line-height: 100%;
   font-weight: 700;
   text-transform: uppercase;
   -webkit-letter-spacing: 0.75px;
@@ -98,7 +98,6 @@ exports[`renders 1`] = `
 @media (min-width:768px) {
   .c1 {
     font-size: 10px;
-    line-height: 12px;
   }
 }
 

--- a/src/Tag/Tag.tsx
+++ b/src/Tag/Tag.tsx
@@ -10,6 +10,7 @@ type TagProps = {
   color: string
   bgColor: string
   borderColor: string
+  typo?: string
 }
 
 export const Tag: FC<TagProps> = ({
@@ -18,9 +19,10 @@ export const Tag: FC<TagProps> = ({
   borderColor,
   bgColor,
   className,
+  typo,
 }) => (
   <Wrapper bgColor={bgColor} className={className} borderColor={borderColor}>
-    <TagText tag="span" typo="label" color={color}>
+    <TagText tag="span" typo={typo ?? 'label'} color={color}>
       {label}
     </TagText>
   </Wrapper>

--- a/src/Tag/__tests__/__snapshots__/Tag.js.snap
+++ b/src/Tag/__tests__/__snapshots__/Tag.js.snap
@@ -3,7 +3,7 @@
 exports[`renders 1`] = `
 .c1 {
   font-size: 8px;
-  line-height: 9px;
+  line-height: 100%;
   font-weight: 700;
   text-transform: uppercase;
   -webkit-letter-spacing: 0.75px;
@@ -36,7 +36,6 @@ exports[`renders 1`] = `
 @media (min-width:768px) {
   .c1 {
     font-size: 10px;
-    line-height: 12px;
   }
 }
 

--- a/src/Text/README.md
+++ b/src/Text/README.md
@@ -36,3 +36,4 @@ const App = () => (
 | base-small | 12 | 14 | normal |
 | base-xsmall | 10 | 12 | normal |
 | label | 8 | 10 | bold |
+| label-large | 10 | 12 | bold |

--- a/src/Text/Text.tsx
+++ b/src/Text/Text.tsx
@@ -187,30 +187,24 @@ const Container = styled.p<IText>(
   ${typo === 'label' &&
     css`
       font-size: 8px;
-      line-height: 9px;
+      line-height: 100%;
       font-weight: 700;
       text-transform: uppercase;
       letter-spacing: 0.75px;
 
       @media (min-width: 768px) {
         font-size: 10px;
-        line-height: 12px;
       }
     `}
   
   /* Label Large */
   ${typo === 'label-large' &&
     css`
-      font-size: 10px;
-      line-height: 9px;
+      font-size: 12px;
+      line-height: 100%;
       font-weight: 700;
       text-transform: uppercase;
       letter-spacing: 0.75px;
-
-      @media (min-width: 768px) {
-        font-size: 12px;
-        line-height: 12px;
-      }
     `}
 
   margin: 0;

--- a/src/Text/Text.tsx
+++ b/src/Text/Text.tsx
@@ -197,6 +197,21 @@ const Container = styled.p<IText>(
         line-height: 12px;
       }
     `}
+  
+  /* Label Large */
+  ${typo === 'label-large' &&
+    css`
+      font-size: 10px;
+      line-height: 9px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.75px;
+
+      @media (min-width: 768px) {
+        font-size: 12px;
+        line-height: 12px;
+      }
+    `}
 
   margin: 0;
     padding: 0;

--- a/src/Textarea/__tests__/__snapshots__/Textarea.js.snap
+++ b/src/Textarea/__tests__/__snapshots__/Textarea.js.snap
@@ -3,7 +3,7 @@
 exports[`disabled 1`] = `
 .c1 {
   font-size: 8px;
-  line-height: 9px;
+  line-height: 100%;
   font-weight: 700;
   text-transform: uppercase;
   -webkit-letter-spacing: 0.75px;
@@ -58,7 +58,6 @@ exports[`disabled 1`] = `
 @media (min-width:768px) {
   .c1 {
     font-size: 10px;
-    line-height: 12px;
   }
 }
 
@@ -91,7 +90,7 @@ exports[`disabled 1`] = `
 exports[`renders 1`] = `
 .c1 {
   font-size: 8px;
-  line-height: 9px;
+  line-height: 100%;
   font-weight: 700;
   text-transform: uppercase;
   -webkit-letter-spacing: 0.75px;
@@ -146,7 +145,6 @@ exports[`renders 1`] = `
 @media (min-width:768px) {
   .c1 {
     font-size: 10px;
-    line-height: 12px;
   }
 }
 
@@ -178,7 +176,7 @@ exports[`renders 1`] = `
 exports[`renders with error 1`] = `
 .c1 {
   font-size: 8px;
-  line-height: 9px;
+  line-height: 100%;
   font-weight: 700;
   text-transform: uppercase;
   -webkit-letter-spacing: 0.75px;
@@ -239,7 +237,6 @@ exports[`renders with error 1`] = `
 @media (min-width:768px) {
   .c1 {
     font-size: 10px;
-    line-height: 12px;
   }
 }
 


### PR DESCRIPTION
## Screenshot / video

![image](https://user-images.githubusercontent.com/25356097/115566996-b0432180-a2b2-11eb-8231-f36030eb98e9.png)
![image](https://user-images.githubusercontent.com/25356097/115567045-bf29d400-a2b2-11eb-9a44-47aece23776a.png)

## What does this do?

Add `label-large` to the Text Component.
Add `typo` to the Tag Component to style the inner test.
