### PR TITLE
Add Tracy to Smores dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,10 +7,12 @@ update_configs:
       - 'ellajay'
       - 'habin-isa'
       - 'fleonard'
+      - 'trcywu'
     default_reviewers:
       - 'ellajay'
       - 'habin-isa'
       - 'fleonard'
+      - 'trcywu'
     automerged_updates:
       - match:
           dependency_type: 'development'


### PR DESCRIPTION
## What does this do?

Adds Tracy to dependabot default reviewers and default assignees
