### PR TITLE
GRW 432 - Chip styling changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.66.0] - 2021-05-25
+### Changed
+- Chip component: cursor and border color
+
 ## [0.65.0] - 2021-05-04
 ### Added
 - New Chip component
@@ -38,6 +42,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[0.66.0]: https://github.com/marshmallow-insurance/smores-react/compare/v0.65.0...v0.66.0
 [0.65.0]: https://github.com/marshmallow-insurance/smores-react/compare/v0.64.0...v0.65.0
 [0.64.0]: https://github.com/marshmallow-insurance/smores-react/compare/v0.63.0...v0.64.0
 [0.63.0]: https://github.com/marshmallow-insurance/smores-react/compare/v0.62.0...v0.63.0

--- a/src/Chip/Chip.tsx
+++ b/src/Chip/Chip.tsx
@@ -50,7 +50,7 @@ const Container = styled.button<IButton>(
     background-color: ${theme.colors.pink5};
     border-radius: 100px;
     border-shadow: none;
-    border: 2px solid;
+    border: 2px solid ${theme.colors.pink5};
     color: ${theme.colors.white};
     display: flex;
     font-size: 16px;
@@ -58,6 +58,7 @@ const Container = styled.button<IButton>(
     line-height: 100%;
     padding: 8px 16px 8px ${icon ? '8px' : '16px'};
     width: 98px;
+    cursor: pointer;
 
     ${primary &&
     css`
@@ -69,7 +70,6 @@ const Container = styled.button<IButton>(
     ${secondary &&
     css`
       background-color: ${theme.colors.white};
-      border-color: ${theme.colors.pink5};
       color: ${theme.colors.pink5};
       &:hover {
         background-color: ${theme.colors.bg2};


### PR DESCRIPTION
## Screenshot
![image](https://user-images.githubusercontent.com/31040555/119514323-d1dd7000-bd6c-11eb-826e-a02f919e36d3.png)

## What does this do?
- Adds border color for both states 
- Adds cursor pointer