### PR TITLE
added import icons workflow for initial test

### DIFF
--- a/.github/workflows/import_icons.yml
+++ b/.github/workflows/import_icons.yml
@@ -1,0 +1,14 @@
+name: Import Icons from Figma
+on:
+  workflow_dispatch:
+jobs:
+  all:
+    name: Figma Import
+    runs-on: ubuntu-latest
+    steps:
+      - uses: primer/figma-action@v1.0.0-alpha.3
+        with:
+          args: 'format=svg outputDir=./src/Icon/svgs'
+        env:
+          FIGMA_FILE_URL: 'https://www.figma.com/file/rnQu7stzZse0zw67V2tSy6/DS-Global-Brand-assets-and-colours?node-id=1%3A3'
+          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,10 @@
 module.exports = {
   stories: ['../src/**/*.stories.js'],
   addons: ['@storybook/addon-essentials'],
+  // This is needed until storybook will release a fix
+  // because it's breaking the build
+  //https://github.com/styleguidist/react-docgen-typescript/issues/356
+  typescript: {
+    reactDocgen: 'react-docgen',
+  },
 }


### PR DESCRIPTION
**This is a WIP test workflow**

As part of re-branding, the design team has organised a very nice page in Figma with all the new and refactored icons.
This workflow should export from that page all the icons in svg in the folder specified and it will be only triggered manually.

The reason behind is that when new icons come along we can create a new branch, trigger the workflow and then just import the new svgs in the existing `Icon` component that will then render.

**Next steps**
- when this is merged I'm gonna create a new branch to test the workflow and see if and how the import works
- if it's all good we can then think about all together how we want to clean up the old component and replace the hardcoded values with the new imported ones.

If you have any additional thoughts or suggestions on how to do it in a different way good to know. 
I'm a bit worried that this [workflow](https://github.com/marketplace/actions/figma-action) is no longer maintained so if something changes on Figma API this will break easily