### PR TITLE
Added border and border color props for Message component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.67.2] - 2021-08-05
+### Added
+- Added new border and border color prop to Message component
+- Added option to specify any icon in Message type
+
 ## [0.67.1] - 2021-07-29
 ### Added
 - Added new prop sizeSmall to Message component
@@ -59,7 +64,7 @@
 ## [0.60.1] - 2021-04-09
 ### Changed
 - Updated Row padding, grid-gap and cursor
-- Updated Icon svgs for Info, Cross and Warning icons
+- Updated Icon SVGs for Info, Cross and Warning icons
 - Updated the size of the iconLeft in the Icon component to render a different size depending on screen width
 ## [0.60.0] - 2021-04-07
 ### Added
@@ -72,6 +77,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[0.67.2]: https://github.com/marshmallow-insurance/smores-react/compare/v0.67.1...v0.67.2
 [0.67.1]: https://github.com/marshmallow-insurance/smores-react/compare/v0.67.0...v0.67.1
 [0.67.0]: https://github.com/marshmallow-insurance/smores-react/compare/v0.66.6...v0.67.0
 [0.66.6]: https://github.com/marshmallow-insurance/smores-react/compare/v0.66.5...v0.66.6

--- a/src/Message/Message.stories.js
+++ b/src/Message/Message.stories.js
@@ -41,9 +41,12 @@ InfoBubbleSmall.args = {
   sizeSmall: true,
 }
 
-export const IconPlacement = Template.bind({})
+export const CardWithBorder = Template.bind({})
 
-IconPlacement.args = {
-  type: 'warning',
+CardWithBorder.args = {
+  type: 'card',
   alignIcon: 'flex-start',
+  backgroundColor: theme.colors.white,
+  hasBorder: true,
+  borderColor: theme.colors.blue7,
 }

--- a/src/Message/Message.tsx
+++ b/src/Message/Message.tsx
@@ -5,13 +5,17 @@ import { Box } from '../Box'
 import { Icon } from '../Icon'
 import { theme } from '../theme'
 
+type BorderProps =
+  | { hasBorder?: false; borderColor?: never }
+  | { hasBorder: true; borderColor: string }
+
 export type MessageProps = {
   children: ReactNode
-  type?: 'info' | 'warning' | 'warning-bubble'
+  type?: 'info' | 'warning' | 'warning-bubble' | string
   alignIcon?: 'center' | 'flex-start' | 'flex-end'
   backgroundColor?: string
   sizeSmall?: boolean
-}
+} & BorderProps
 
 export const Message: FC<MessageProps> = ({
   children,
@@ -19,8 +23,16 @@ export const Message: FC<MessageProps> = ({
   alignIcon = 'center',
   backgroundColor,
   sizeSmall,
+  hasBorder,
+  borderColor,
 }) => (
-  <Wrapper type={type} backgroundColor={backgroundColor} sizeSmall={sizeSmall}>
+  <Wrapper
+    type={type}
+    backgroundColor={backgroundColor}
+    sizeSmall={sizeSmall}
+    hasBorder={hasBorder}
+    borderColor={borderColor}
+  >
     <IconWrapper alignIcon={alignIcon}>
       <Icon
         size={sizeSmall ? 24 : 32}
@@ -38,9 +50,11 @@ interface IIconWrapper {
 }
 
 interface IWrapper {
-  type: 'info' | 'warning' | 'warning-bubble'
+  type: 'info' | 'warning' | 'warning-bubble' | string
   backgroundColor?: string
   sizeSmall?: boolean
+  hasBorder?: boolean
+  borderColor?: string
 }
 
 const IconWrapper = styled(Box)<IIconWrapper>`
@@ -49,7 +63,7 @@ const IconWrapper = styled(Box)<IIconWrapper>`
 `
 
 const Wrapper = styled.div<IWrapper>(
-  ({ type, backgroundColor, sizeSmall }) => css`
+  ({ type, backgroundColor, sizeSmall, hasBorder, borderColor }) => css`
     align-items: center;
     background-color: ${backgroundColor
       ? backgroundColor
@@ -57,6 +71,7 @@ const Wrapper = styled.div<IWrapper>(
       ? theme.colors.red2
       : theme.colors.blue2};
     box-sizing: border-box;
+    ${hasBorder && `border: 1px solid ${borderColor};`}
     border-radius: 8px;
     margin-bottom: 24px;
     padding: 16px;


### PR DESCRIPTION
## Screenshot / video

<img width="691" alt="Screenshot 2021-08-05 at 16 35 29" src="https://user-images.githubusercontent.com/1053476/128379800-6b6b3b81-9008-478e-b48c-863a55543df3.png">


## What does this do?

- Added linked properties for border and border color
- if `hasBorder` is true `borderColor` is required
- added string to `type` so we can use any icon we want
