### PR TITLE
Update warning Message style - ET-4458

### DIFF
--- a/src/Message/Message.tsx
+++ b/src/Message/Message.tsx
@@ -68,10 +68,12 @@ const Wrapper = styled.div<IWrapper>(
     background-color: ${backgroundColor
       ? backgroundColor
       : type === 'warning'
-      ? theme.colors.red2
+      ? theme.colors.white
       : theme.colors.blue2};
     box-sizing: border-box;
-    ${hasBorder && `border: 1px solid ${borderColor};`}
+    ${type === 'warning'
+      ? `border: 1px solid ${theme.colors.pink8};`
+      : hasBorder && `border: 1px solid ${borderColor};`}
     border-radius: 8px;
     margin-bottom: 24px;
     padding: 16px;

--- a/src/Message/__tests__/__snapshots__/Message.js.snap
+++ b/src/Message/__tests__/__snapshots__/Message.js.snap
@@ -226,8 +226,9 @@ exports[`warning renders correctly 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #FFDCDC;
+  background-color: #ffffff;
   box-sizing: border-box;
+  border: 1px solid #AB1D20;
   border-radius: 8px;
   margin-bottom: 24px;
   padding: 16px;


### PR DESCRIPTION
## Screenshot / video

![image](https://user-images.githubusercontent.com/34772985/134375573-6a522076-13e0-4a4d-92cd-a2d36fe90a65.png)

## What does this do?

Updates warning Message style to match new design.

Figma can be found [here](https://www.figma.com/file/FqSaizGOyOzXFZNmZ4X0LGMn/%F0%9F%8D%AC-S'mores?node-id=5361%3A7773)
