### PR TITLE
Add bottom margin to label if text input is outlined

### DIFF
--- a/src/TextInput/TextInput.stories.js
+++ b/src/TextInput/TextInput.stories.js
@@ -68,6 +68,7 @@ WithLabel.args = {
   placeholder: 'Placeholder text',
   onChange: () => {},
   label: 'label',
+  outlined: false,
 }
 
 export const WithIcon = Template.bind({})

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -1,6 +1,7 @@
 import React, { FormEvent, FC } from 'react'
 import styled, { css } from 'styled-components'
 
+import { Box } from '../Box'
 import { Text } from '../Text'
 import { Icon } from '../Icon'
 
@@ -51,9 +52,11 @@ export const TextInput: FC<Props> = ({
 }) => (
   <Container className={className} hasLabel={!!label} hasError={!!errorMsg}>
     {label && (
-      <Text tag="label" color="grey4" typo="label">
-        {label}
-      </Text>
+      <Box mb={outlined ? '8px' : '0px'}>
+        <Text tag="label" color="grey4" typo="label">
+          {label}
+        </Text>
+      </Box>
     )}
 
     <Content outlined={outlined} error={error}>


### PR DESCRIPTION

<img width="782" alt="Screenshot 2021-09-22 at 16 47 22" src="https://user-images.githubusercontent.com/1053476/134378008-1e32853e-9966-47c2-bb32-720e057d5386.png">

Currently it looks like this - added a margin to space them out
