### PR TITLE
Use text cursor instead of pointer for Textarea component

### DIFF
--- a/src/Textarea/Textarea.tsx
+++ b/src/Textarea/Textarea.tsx
@@ -93,7 +93,7 @@ const Field = styled.textarea<ITextarea>`
   padding: 16px;
   color: ${theme.colors.blue7};
   resize: ${({ resize }) => resize};
-  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'text')};
   opacity: ${({ disabled }) => (disabled ? '0.5' : '1')};
   border-color: ${({ error }) => theme.colors[`${error ? 'red7' : 'grey4'}`]};
   outline: none;

--- a/src/Textarea/__tests__/__snapshots__/Textarea.js.snap
+++ b/src/Textarea/__tests__/__snapshots__/Textarea.js.snap
@@ -140,7 +140,7 @@ exports[`renders 1`] = `
   padding: 16px;
   color: #112035;
   resize: both;
-  cursor: pointer;
+  cursor: text;
   opacity: 1;
   border-color: #D2D2D2;
   outline: none;
@@ -233,7 +233,7 @@ exports[`renders with error 1`] = `
   padding: 16px;
   color: #112035;
   resize: both;
-  cursor: pointer;
+  cursor: text;
   opacity: 1;
   border-color: #B52525;
   outline: none;


### PR DESCRIPTION
## What does this do?

Changes the Textarea cursor to be text instead of pointer
