### PR TITLE
Add missing event handlers to Dropdown

### DIFF
--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -22,12 +22,22 @@ type DefaultProps = {
   id: string
   /** className attribute to apply classes from props */
   className?: string
-  /** label displayed above the dropdown  */
-  label?: string
+  /** ref attribute for select input */
+  ref?: RefObject<HTMLSelectElement>
   /** Placeholder (initial state) */
   placeholder?: string
+  /** label displayed above the dropdown  */
+  label?: string
+  /** used for label - input connection */
+  name?: string
+  /** input value */
+  value: string
   /** Default value */
   defaultValue?: string
+  /** conditionally renders error message below dropdown */
+  error?: boolean
+  /** error message to be displayed */
+  errorMsg?: string
   /** Disabled flag */
   disabled?: boolean
   /** list of items for the dropdown list */
@@ -36,12 +46,6 @@ type DefaultProps = {
   onSelect: (element: string) => void
   /** Displays border */
   outlined?: boolean
-  /** conditionally renders error message below dropdown */
-  error?: boolean
-  /** error message to be displayed */
-  errorMsg?: string
-  /** ref attribute for select input */
-  ref?: RefObject<HTMLSelectElement>
   /** onBlur listener */
   onBlur?: (e: FormEvent<HTMLSelectElement>) => void
 }
@@ -64,8 +68,11 @@ type Props = DefaultProps & TruncateProps
 export const Dropdown: FC<Props> = ({
   id,
   className = '',
+  ref,
   label,
   placeholder,
+  name,
+  value,
   defaultValue,
   disabled = false,
   list,
@@ -74,7 +81,6 @@ export const Dropdown: FC<Props> = ({
   error = false,
   errorMsg = '',
   onInputChange,
-  ref,
   onBlur,
 }) => {
   const [key, setKey] = useState('')
@@ -120,6 +126,8 @@ export const Dropdown: FC<Props> = ({
           onBlur={(e) => {
             onBlur && onBlur(e)
           }}
+          name={name}
+          value={value}
         >
           <option value="" hidden>
             {placeholder}

--- a/src/Textarea/Textarea.tsx
+++ b/src/Textarea/Textarea.tsx
@@ -11,6 +11,8 @@ type TextareaProps = {
   id: string
   /** className attribute to apply classses from props */
   className?: string
+  /** ref attribute for input */
+  ref?: RefObject<HTMLTextAreaElement>
   /** Placeholder */
   placeholder?: string
   /** label displayed above the input  */
@@ -25,16 +27,14 @@ type TextareaProps = {
   errorMsg?: string
   /** Allow user to resize the textarea vertically and horizontally or not */
   resize?: 'none' | 'both'
-  /** onChange listener */
-  onChange: (e: string) => void
   /** Disabled flag */
   disabled?: boolean
   /** maxLength property */
   maxLength?: number
   /** onBlur listener */
   onBlur?: (e: FormEvent<HTMLTextAreaElement>) => void
-  /** ref attribute for input */
-  ref?: RefObject<HTMLTextAreaElement>
+  /** number of rows of input */
+  rows?: number
 }
 
 /** on change or on input required */
@@ -68,6 +68,7 @@ export const Textarea: FC<Props> = ({
   maxLength,
   onBlur,
   ref,
+  rows = 4,
 }) => (
   <Box flex direction="column" className={className}>
     {label && (
@@ -96,6 +97,7 @@ export const Textarea: FC<Props> = ({
         onBlur={(e) => {
           onBlur && onBlur(e)
         }}
+        rows={rows}
       />
     </Box>
     {error && <ErrorBox>{errorMsg}</ErrorBox>}

--- a/src/Textarea/__tests__/__snapshots__/Textarea.js.snap
+++ b/src/Textarea/__tests__/__snapshots__/Textarea.js.snap
@@ -89,6 +89,7 @@ exports[`disabled 1`] = `
       disabled=""
       id="textarea_id"
       placeholder="Placeholder text!"
+      rows="4"
     />
   </div>
 </div>
@@ -182,6 +183,7 @@ exports[`renders 1`] = `
       class="c3"
       id="textarea_id"
       placeholder="Placeholder text!"
+      rows="4"
     />
   </div>
 </div>
@@ -281,6 +283,7 @@ exports[`renders with error 1`] = `
       class="c3"
       id="textarea_id"
       placeholder="Placeholder text!"
+      rows="4"
     />
   </div>
   <span


### PR DESCRIPTION
## What does this do?

- Event handlers for use with hook forms
- Addition of `rows` prop to `TextArea` component to customize size of text input

