### PR TITLE
Home-479 - Updated tag Component styles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,19 @@
 # Lines starting with '#' are comments.
+
 # Each line is a file pattern followed by one or more owners.
+
 # More details are here: https://help.github.com/articles/about-codeowners/
+
 # The '\*' pattern is global owners.
+
 # Order is important. The last matching pattern has the most precedence.
+
 # The folders are ordered as follows:
+
 # In each subsection folders are ordered first by depth, then alphabetically.
+
 # This should make it easy to add new rules without breaking existing ones.
+
 # Global - These owners will be the default owners for everything in the repo.
 
 -           @ellajay @fleonard @habin-isa @jsudufour @trcywu

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,5 +15,4 @@
 # This should make it easy to add new rules without breaking existing ones.
 
 # Global - These owners will be the default owners for everything in the repo.
-
--           @ellajay @fleonard @habin-isa @jsudufour @trcywu
+*           @ellajay @fleonard @habin-isa @jsudufour @trcywu

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,4 +4,3 @@ build
 README.md
 CHANGELOG.md
 src/assets/**/*
-.github

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ build
 README.md
 CHANGELOG.md
 src/assets/**/*
+.github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.21] - 2021-11-01
+### Added
+- Fixed Tag Styles
+
 ## [1.2.20] - 2021-11-01
 ### Added
 - Added new Icons
@@ -183,6 +187,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[1.2.21]: https://github.com/marshmallow-insurance/smores-react/compare/v1.2.19...v1.2.21
 [1.2.20]: https://github.com/marshmallow-insurance/smores-react/compare/v1.2.19...v1.2.20
 [1.2.19]: https://github.com/marshmallow-insurance/smores-react/compare/v1.2.18...v1.2.19
 [1.2.18]: https://github.com/marshmallow-insurance/smores-react/compare/v1.2.17...v1.2.18

--- a/src/Tag/Tag.tsx
+++ b/src/Tag/Tag.tsx
@@ -34,14 +34,18 @@ interface IWrapper {
 }
 
 const Wrapper = styled.div<IWrapper>`
-  display: inline-block;
   background-color: ${({ bgColor }) => theme.colors[bgColor]};
-  border: 1px solid ${({ borderColor }) => theme.colors[borderColor]};
-  padding: 2px 13px 4px 13px;
   border-radius: 8px;
+  border: 1px solid ${({ borderColor }) => theme.colors[borderColor]};
+  box-sizing: border-box;
+  display: inline-flex;
+  height: 23px;
+  padding: 5 12px;
 `
 
 const TagText = styled(Text)`
+  font-size: 10px;
   font-weight: 500;
+  line-height: 12px;
   text-transform: uppercase;
 `

--- a/src/Tag/__tests__/__snapshots__/Tag.js.snap
+++ b/src/Tag/__tests__/__snapshots__/Tag.js.snap
@@ -22,14 +22,21 @@ exports[`renders 1`] = `
 }
 
 .c0 {
-  display: inline-block;
-  border: 1px solid;
-  padding: 2px 13px 4px 13px;
   border-radius: 8px;
+  border: 1px solid;
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 23px;
+  padding: 5 12px;
 }
 
 .c2 {
+  font-size: 10px;
   font-weight: 500;
+  line-height: 12px;
   text-transform: uppercase;
 }
 


### PR DESCRIPTION
## Screenshot / video

<img width="155" alt="Screenshot 2021-11-01 at 15 42 51" src="https://user-images.githubusercontent.com/1053476/139705212-6109b7eb-98e4-454e-9140-eb5d984e7d1b.png">

## What does this do?

Fix styling to tag component / Mobile font was broken
