### PR TITLE
Forward Ref and default props for Button and Chip component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.3.0] - 2021-11-17
+### Changed
+- Updated Button and Chip components to allow forwarding of ref and other default properties like data and aria attributes
+
 ## [1.2.24] - 2021-11-12
 ### Changed
 - Added time and date as types in text input

--- a/src/Button/Button.stories.js
+++ b/src/Button/Button.stories.js
@@ -42,6 +42,8 @@ export const Primary = Template.bind({})
 
 Primary.args = {
   primary: true,
+  'data-testid': 'test',
+  'aria-label': 'primary-button',
 }
 
 export const PrimaryDisabled = Template.bind({})
@@ -49,6 +51,7 @@ export const PrimaryDisabled = Template.bind({})
 PrimaryDisabled.args = {
   primary: true,
   disabled: true,
+  'aria-disabled': 'true',
 }
 
 export const PrimaryLoading = Template.bind({})

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react'
+import React, { FC, ReactNode, ButtonHTMLAttributes, forwardRef } from 'react'
 import styled, { css } from 'styled-components'
 
 import { theme } from '../theme'
@@ -43,26 +43,35 @@ type Props = {
   type?: 'button' | 'submit' | 'reset'
 }
 
-export const Button: FC<Props> = ({
-  children,
-  id,
-  className = '',
-  color = 'blue',
-  block = false,
-  inverted = false,
-  disabled = false,
-  outlined = false,
-  handleClick,
-  loading = false,
-  primary = false,
-  secondary = false,
-  tertiary = false,
-  icon = '',
-  forcedWidth = '',
-  form,
-  type,
-}) => {
-  return (
+type ButtonProps = Props & ButtonHTMLAttributes<HTMLButtonElement>
+
+export const Button: FC<ButtonProps> = forwardRef<
+  HTMLButtonElement,
+  ButtonProps
+>(
+  (
+    {
+      children,
+      id,
+      className = '',
+      color = 'blue',
+      block = false,
+      inverted = false,
+      disabled = false,
+      outlined = false,
+      handleClick,
+      loading = false,
+      primary = false,
+      secondary = false,
+      tertiary = false,
+      icon = '',
+      forcedWidth = '',
+      form,
+      type,
+      ...props
+    },
+    ref,
+  ) => (
     <div>
       {primary || secondary || tertiary ? (
         <Container
@@ -80,6 +89,8 @@ export const Button: FC<Props> = ({
           forcedWidth={forcedWidth}
           {...(form ? { form } : {})}
           type={type}
+          {...props}
+          ref={ref}
         >
           {loading ? (
             <Loader
@@ -116,8 +127,10 @@ export const Button: FC<Props> = ({
         </LegacyButton>
       )}
     </div>
-  )
-}
+  ),
+)
+
+Button.displayName = 'Button'
 
 const Container = styled.button<IButton>(
   ({

--- a/src/CheckBox/__tests__/__snapshots__/CheckBox.js.snap
+++ b/src/CheckBox/__tests__/__snapshots__/CheckBox.js.snap
@@ -2,10 +2,10 @@
 
 exports[`renders 1`] = `
 <label
-  class="sc-dkPtRN bbcaiK"
+  class="sc-dlfnuX hhvaso"
 >
   <span
-    class="sc-bdvvtL gCEbaO"
+    class="sc-bdfBQB yOIav"
     color="blue7"
     cursor="inherit"
     title=""
@@ -14,7 +14,7 @@ exports[`renders 1`] = `
     type="checkbox"
   />
   <span
-    class="sc-gsDKAQ ePqjeo"
+    class="sc-gsTEea kJRpEE"
   />
 </label>
 `;

--- a/src/Chip/Chip.stories.js
+++ b/src/Chip/Chip.stories.js
@@ -15,6 +15,7 @@ Primary.args = {
   primary: true,
   children: 'Add',
   icon: 'plus',
+  'data-testid': 'works!',
 }
 
 export const Secondary = Template.bind({})

--- a/src/Chip/Chip.tsx
+++ b/src/Chip/Chip.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react'
+import React, { FC, ReactNode, ButtonHTMLAttributes, forwardRef } from 'react'
 import styled, { css } from 'styled-components'
 
 import { theme } from '../theme'
@@ -23,16 +23,22 @@ type Props = {
   loading?: boolean
 }
 
-export const Chip: FC<Props> = ({
-  children,
-  handleClick,
-  primary = false,
-  secondary = false,
-  disabled = false,
-  loading = false,
-  icon = '',
-}) => {
-  return (
+type ChipProps = Props & ButtonHTMLAttributes<HTMLButtonElement>
+
+export const Chip: FC<ChipProps> = forwardRef<HTMLButtonElement, ChipProps>(
+  (
+    {
+      children,
+      handleClick,
+      primary = false,
+      secondary = false,
+      disabled = false,
+      loading = false,
+      icon = '',
+      ...props
+    },
+    ref,
+  ) => (
     <Container
       primary={primary}
       secondary={secondary}
@@ -40,6 +46,8 @@ export const Chip: FC<Props> = ({
       $loading={loading}
       onClick={handleClick}
       icon={icon}
+      {...props}
+      ref={ref}
     >
       {loading ? (
         <Loader color={primary ? 'white' : 'pink5'} height="16" />
@@ -56,8 +64,10 @@ export const Chip: FC<Props> = ({
         </>
       )}
     </Container>
-  )
-}
+  ),
+)
+
+Chip.displayName = 'Chip'
 
 const Container = styled.button<IButton>(
   ({ primary, secondary, icon, $loading, disabled }) => css`

--- a/src/ConfirmationRadioButtons/__tests__/__snapshots__/Confirmation.js.snap
+++ b/src/ConfirmationRadioButtons/__tests__/__snapshots__/Confirmation.js.snap
@@ -2,43 +2,43 @@
 
 exports[`renders 1`] = `
 <div
-  class="sc-bdvvtL sc-jrQzAO gBhudd cSnzvp"
+  class="sc-bdfBQB sc-jrAFXE TqqZw eSyoGE"
 >
   <div
-    class="sc-iqseJM EKxTg"
+    class="sc-iqHYmW bpfviY"
   >
     <h3
-      class="sc-gsDKAQ MYwnP sc-kDTinF fvKitb"
+      class="sc-gsTEea loKXrH sc-kEjbQP cTfPNg"
       color="blue7"
       cursor="inherit"
       title=""
     />
   </div>
   <div
-    class="sc-gKclnd gUQszg"
+    class="sc-gKseQn hCfHHW"
   >
     <div
-      class="sc-iCfMLu hMAwuh"
+      class="sc-iBPTik kiaTVK"
     >
       <div
-        class="sc-furwcr jlBOWG"
+        class="sc-fubCzh fxJMmv"
       >
         <div
-          class="sc-bdvvtL bZqKJd"
+          class="sc-bdfBQB didYvo"
         >
           <input
-            class="sc-hKwDye eSvXef"
+            class="sc-hKgJUU erwJFP"
             type="radio"
             value=""
           />
           <label
-            class="sc-eCImPb nRbn"
+            class="sc-eCstlR hEsIPO"
           >
             <div
-              class="sc-dkPtRN bJYGke"
+              class="sc-dlfnuX jdTRqe"
             />
             <span
-              class="sc-jRQBWg cWZaCo"
+              class="sc-jSgvzq dZegDG"
             >
               Yes
             </span>
@@ -46,26 +46,26 @@ exports[`renders 1`] = `
         </div>
       </div>
       <div
-        class="sc-furwcr jlBOWG"
+        class="sc-fubCzh fxJMmv"
       >
         <div
-          class="sc-bdvvtL bZqKJd"
+          class="sc-bdfBQB didYvo"
         >
           <input
-            class="sc-hKwDye eSvXef"
+            class="sc-hKgJUU erwJFP"
             id="undefined-1"
             type="radio"
             value="undefined-1"
           />
           <label
-            class="sc-eCImPb nRbn"
+            class="sc-eCstlR hEsIPO"
             for="undefined-1"
           >
             <div
-              class="sc-dkPtRN bJYGke"
+              class="sc-dlfnuX jdTRqe"
             />
             <span
-              class="sc-jRQBWg cWZaCo"
+              class="sc-jSgvzq dZegDG"
             >
               No
             </span>


### PR DESCRIPTION
## Screenshot / video

<img width="371" alt="Screenshot 2021-11-17 at 12 36 00" src="https://user-images.githubusercontent.com/1053476/142202481-4c38d516-1fee-4bd6-b620-f56e5bae5af9.png">

## What does this do?

We can finally forward `ref` and any other default props (data and aria attributes for example) for `Button` and `Chip` components.
I've done these as a start since they are the most common use cases but if you think of any other that will need the same feel free to follow the same structure and improve them.
