### PR TITLE
Accordion with fullBorder prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.5.0] - 2021-12-08
+### Changed
+- Added full border prop to accordion
 ## [1.4.0] - 2021-11-17
 ### Changed
 - Added new cancel-bw icon to Icon component
@@ -208,6 +211,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[1.5.0]: https://github.com/marshmallow-insurance/smores-react/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/marshmallow-insurance/smores-react/compare/v1.2.24...v1.4.0
 [1.2.24]: https://github.com/marshmallow-insurance/smores-react/compare/v1.2.23...v1.2.24
 [1.2.23]: https://github.com/marshmallow-insurance/smores-react/compare/v1.2.22...v1.2.23

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Every time you make changes in Smores and you wan’t to see it in local
 run 
 
 ```
-npm run build
 yalc publish —private
 ```
 

--- a/src/Accordion/Accordion.stories.js
+++ b/src/Accordion/Accordion.stories.js
@@ -13,3 +13,9 @@ const Template = (args) => (
 )
 
 export const Default = Template.bind({})
+
+export const SubTitle = Template.bind({})
+
+SubTitle.args = {
+  subTitle: 'subTitle',
+}

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -4,28 +4,43 @@ import styled, { css } from 'styled-components'
 import { Box } from '../Box'
 import { Icon } from '../Icon'
 import { theme } from '../theme'
+import { Text } from '../Text'
 
 type AccordionProps = {
   title: string
+  subTitle?: string
   borderTop?: boolean
+  fullBorder?: boolean
 }
 
 export const Accordion: FC<AccordionProps> = ({
   title,
   children,
   borderTop = false,
+  subTitle,
+  fullBorder = false,
 }) => {
   const [isOpen, setIsOpen] = useState(false)
 
   return (
-    <Wrapper isOpen={isOpen} borderTop={borderTop}>
+    <Wrapper isOpen={isOpen} borderTop={borderTop} fullBorder={fullBorder}>
       <TopContainer
         flex
         alignItems="center"
         justifyContent="space-between"
         onClick={() => setIsOpen(!isOpen)}
+        fullBorder={fullBorder}
+        isOpen={isOpen}
       >
-        <Title>{title}</Title>
+        <TitleContainer>
+          <Title>{title}</Title>
+          {subTitle && (
+            <Text tag="label" color="grey8" typo="label">
+              {subTitle}
+            </Text>
+          )}
+        </TitleContainer>
+
         <CaretIcon
           render="caret"
           size={24}
@@ -41,21 +56,46 @@ export const Accordion: FC<AccordionProps> = ({
 
 interface IAccordion {
   isOpen: boolean
-  borderTop: boolean
+  borderTop?: boolean
+  fullBorder?: boolean
 }
 
 const Wrapper = styled(Box)<IAccordion>(
-  ({ isOpen, borderTop }) => css`
+  ({ isOpen, borderTop, fullBorder }) => css`
     border-bottom: 1px solid ${theme.colors.grey3};
     padding-bottom: ${isOpen && '16px'};
     border-top: ${borderTop && `1px solid ${theme.colors.grey3}`};
+
+    ${fullBorder &&
+    css`
+      border: 1px solid ${theme.colors.grey3};
+      border-radius: 8px;
+      margin-bottom: 14px;
+      padding: 20px 15px;
+    `}
   `,
 )
 
-const TopContainer = styled(Box)`
-  padding: 15px 0;
-  cursor: pointer;
+const TitleContainer = styled.div`
+  display: flex;
+  flex-direction: column;
 `
+const TopContainer = styled(Box)<IAccordion>(
+  ({ isOpen, fullBorder }) => css`
+    padding: 15px 0px;
+    cursor: pointer;
+
+    ${fullBorder &&
+    css`
+      padding: 0px;
+    `}
+
+    ${isOpen &&
+    css`
+      margin-bottom: 14px;
+    `}
+  `,
+)
 
 const Title = styled.h2`
   color: ${theme.colors.blue7};


### PR DESCRIPTION
## Screenshot / video

Adding prop to Accordion to enable full border

![image](https://user-images.githubusercontent.com/17128906/145182207-d89bdff5-4004-43a3-b896-c9613c68f4a8.png)


## What does this do?

[A short description of what the PR changes and why it's necessary]

- Give the reviewers context
- Is the impact global or localised?
- Any tech debt created or discovered?
- Include links to Jira ticket and Figma file if applicable
