### PR TITLE
Fix - outlined text input error state

### DIFF
--- a/src/TextInput/TextInput.stories.js
+++ b/src/TextInput/TextInput.stories.js
@@ -71,6 +71,21 @@ WithOutline.args = {
   onBlur: () => {},
 }
 
+export const WithOutlineError = Template.bind({})
+
+WithOutlineError.args = {
+  id: 'textInput',
+  name: 'textInput',
+  outlined: true,
+  label: 'with outline',
+  placeholder: 'Placeholder text',
+  onChange: () => {},
+  onInputChange: () => {},
+  onBlur: () => {},
+  error: true,
+  errorMsg: 'Oh boy, something went wrong!',
+}
+
 export const WithLabel = Template.bind({})
 
 WithLabel.args = {

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -137,10 +137,10 @@ const Content = styled.div<IInputOutline>`
     border-color: ${({ error }) => theme.colors[`${error ? 'red7' : 'grey6'}`]};
   }
 
-  ${({ outlined }) =>
+  ${({ outlined, error }) =>
     outlined &&
     `
-      border: 2px solid ${theme.colors.grey4};
+      border: 2px solid ${error ? theme.colors.red7 : theme.colors.grey4};
       border-radius: 8px;
       padding: 16px 12px;
       height: auto;


### PR DESCRIPTION
## Screenshot / video

![Screenshot 2022-01-04 at 12 17 11](https://user-images.githubusercontent.com/12373062/148057887-9e023b7d-1f28-47f4-9116-66a55decac24.png)

## What does this do?

- Outlined text input was only red on hover
- Make outline red when errored
