### PR TITLE
Fix - Make required prop in Dropdown component an optional prop on the component level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## [1.6.1] - 2021-12-15
+## [1.7.0] - 2022-01-06
+### Changed
+- Add required prop to Dropdown instead of setting required directly on component
+## [1.6.1] - 2022-01-05
 ### Changed
 - Fix error state on outlined Text Input component
 ## [1.6.0] - 2021-12-15
@@ -220,6 +223,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[1.7.0]: https://github.com/marshmallow-insurance/smores-react/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/marshmallow-insurance/smores-react/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/marshmallow-insurance/smores-react/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/marshmallow-insurance/smores-react/compare/v1.5.0...v1.5.1

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -49,6 +49,8 @@ type DefaultProps = {
   outlined?: boolean
   /** onBlur listener */
   onBlur?: (e: FormEvent<HTMLSelectElement>) => void
+  /** required item */
+  required?: boolean
 }
 
 /** on change or on input required */
@@ -83,6 +85,7 @@ export const Dropdown: FC<Props> = ({
   errorMsg = '',
   onInputChange,
   onBlur,
+  required = true,
 }) => {
   const [key, setKey] = useState('')
   const [hasOptGroups, setHasOptGroups] = useState(false)
@@ -138,7 +141,7 @@ export const Dropdown: FC<Props> = ({
             onSelect && onSelect(e.currentTarget.value)
             onInputChange && onInputChange(e)
           }}
-          required
+          required={required}
           outlined={outlined}
           error={error}
           ref={ref}


### PR DESCRIPTION
## Screenshot / video

- No UI changes

## What does this do?

- Make required property a passed-in prop on the Dropdown component
- Defaulting to true preserves any existing functionality relying on this prop 
- Will disable the default required validation message when using the Dropdown with react-hook-forms and yup validation
