### PR TITLE
docs: remove yarn from installation part

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ components that conform to Marshmallow's Design System - "_S'mores_".
 ## Install
 
 ```bash
-$ yarn add @mrshmllw/smores-react
-# OR
-$ npm install @mrshmllw/smores-react
+npm install @mrshmllw/smores-react
 ```
 
 ## Release


### PR DESCRIPTION
Since we don't have a `yarn.lock` but have a `package-lock.json`, I guess we use npm only so we should probably remove `yarn` from the instruction?