### PR TITLE
Add missing properties to Text component and link labels to input components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.1.0] - 2022-01-26
+### Added
+- Props on Text component; htmlFor attribute to link labels to input components
 ## [2.0.3] - 2022-01-26
 ### Added
 - Story for new colour palette
@@ -248,6 +251,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[2.1.0]: https://github.com/marshmallow-insurance/smores-react/compare/v2.0.3...v2.1.0
 [2.0.3]: https://github.com/marshmallow-insurance/smores-react/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/marshmallow-insurance/smores-react/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/marshmallow-insurance/smores-react/compare/v2.0.0...v2.0.1

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ yalc update
 When you’ve finished deving run the below in your project folder to remove all packages linked
 
 ```
-yalc remove —all
+yalc remove --all
 ```
 
 ## List of Components

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -120,7 +120,7 @@ export const Dropdown: FC<Props> = ({
     <Container className={className}>
       {label && (
         <Box mb={outlined ? '4px' : '0px'}>
-          <Text tag="label" color="subtext" typo="label">
+          <Text tag="label" color="subtext" typo="label" htmlFor={id}>
             {label}
           </Text>
         </Box>

--- a/src/NumberInput/NumberInput.tsx
+++ b/src/NumberInput/NumberInput.tsx
@@ -160,7 +160,7 @@ export const NumberInput: FC<NumberInputProps> = ({
     <Container className={className} hasLabel={!!label} hasError={!!errorMsg}>
       {label && (
         <Box mb={outlined ? '4px' : '0px'}>
-          <Text tag="label" color="subtext" typo="label">
+          <Text tag="label" color="subtext" typo="label" htmlFor={id}>
             {label}&nbsp;{required && <Asterisk>*</Asterisk>}
           </Text>
         </Box>

--- a/src/NumberInput/__tests__/__snapshots__/NumberInput.js.snap
+++ b/src/NumberInput/__tests__/__snapshots__/NumberInput.js.snap
@@ -204,6 +204,7 @@ exports[`renders - currency 1`] = `
       class="c2"
       color="subtext"
       cursor="inherit"
+      for="currencyInput"
       title=""
     >
       Currency
@@ -391,6 +392,7 @@ exports[`renders - disabled 1`] = `
       class="c2"
       color="subtext"
       cursor="inherit"
+      for="currencyInput"
       title=""
     >
       Currency
@@ -625,6 +627,7 @@ exports[`renders - error 1`] = `
       class="c2"
       color="subtext"
       cursor="inherit"
+      for="currencyInput"
       title=""
     >
       Currency
@@ -822,6 +825,7 @@ exports[`renders - number 1`] = `
       class="c2"
       color="subtext"
       cursor="inherit"
+      for="numberInput"
       title=""
     >
       Number
@@ -985,6 +989,7 @@ exports[`renders - tel 1`] = `
       class="c2"
       color="subtext"
       cursor="inherit"
+      for="tel"
       title=""
     >
       Telephone number
@@ -1154,6 +1159,7 @@ exports[`renders - with suffix 1`] = `
       class="c2"
       color="subtext"
       cursor="inherit"
+      for="currencyInput"
       title=""
     >
       Currency
@@ -1348,6 +1354,7 @@ exports[`renders - with trailing icon 1`] = `
       class="c2"
       color="subtext"
       cursor="inherit"
+      for="currencyInput"
       title=""
     >
       Currency

--- a/src/SearchInput/SearchInput.tsx
+++ b/src/SearchInput/SearchInput.tsx
@@ -106,7 +106,7 @@ export const SearchInput: FC<SearchInputProps> = ({
     <Container>
       {label && (
         <Box mb={outlined ? '4px' : '0px'}>
-          <Text tag="label" color="subtext" typo="label">
+          <Text tag="label" color="subtext" typo="label" htmlFor={id}>
             {label}
           </Text>
         </Box>

--- a/src/SearchInput/__tests__/__snapshots__/SearchInput.js.snap
+++ b/src/SearchInput/__tests__/__snapshots__/SearchInput.js.snap
@@ -129,6 +129,7 @@ exports[`renders 1`] = `
       class="c2"
       color="subtext"
       cursor="inherit"
+      for="days"
       title=""
     >
       Days

--- a/src/Text/Text.tsx
+++ b/src/Text/Text.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react'
+import React, { FC, forwardRef, LabelHTMLAttributes, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 
 import { theme } from '../theme'
@@ -26,28 +26,40 @@ type Props = {
   title?: string
 }
 
-export const Text: FC<Props> = ({
-  children,
-  typo,
-  className = '',
-  tag = 'p',
-  align = 'left',
-  color = 'secondary',
-  cursor = 'inherit',
-  title = '',
-}) => (
-  <Container
-    as={tag}
-    className={className}
-    typo={typo || 'base'}
-    align={align}
-    color={color}
-    cursor={cursor}
-    title={title}
-  >
-    {children}
-  </Container>
+type TextProps = Props & LabelHTMLAttributes<HTMLElement>
+
+export const Text: FC<TextProps> = forwardRef<HTMLElement, TextProps>(
+  (
+    {
+      children,
+      typo,
+      className = '',
+      tag = 'p',
+      align = 'left',
+      color = 'secondary',
+      cursor = 'inherit',
+      title = '',
+      ...props
+    },
+    ref,
+  ) => (
+    <Container
+      as={tag}
+      className={className}
+      typo={typo || 'base'}
+      align={align}
+      color={color}
+      cursor={cursor}
+      title={title}
+      {...props}
+      ref={ref}
+    >
+      {children}
+    </Container>
+  ),
 )
+
+Text.displayName = 'Text'
 
 const Container = styled.p<IText>(
   ({ align, color, cursor, typo }) => css`

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -74,7 +74,7 @@ export const TextInput: FC<Props> = ({
   <Container className={className} hasLabel={!!label} hasError={!!errorMsg}>
     {label && (
       <Box mb={outlined ? '4px' : '0px'}>
-        <Text tag="label" color="subtext" typo="label">
+        <Text tag="label" color="subtext" typo="label" htmlFor={id}>
           {label}
         </Text>
       </Box>

--- a/src/Textarea/Textarea.tsx
+++ b/src/Textarea/Textarea.tsx
@@ -73,7 +73,7 @@ export const Textarea: FC<Props> = ({
   <Box flex direction="column" className={className}>
     {label && (
       <Box mb="4px">
-        <Text tag="label" color="subtext" typo="label">
+        <Text tag="label" color="subtext" typo="label" htmlFor={id}>
           {label}
         </Text>
       </Box>

--- a/src/Textarea/__tests__/__snapshots__/Textarea.js.snap
+++ b/src/Textarea/__tests__/__snapshots__/Textarea.js.snap
@@ -75,6 +75,7 @@ exports[`disabled 1`] = `
       class="c2"
       color="subtext"
       cursor="inherit"
+      for="textarea_id"
       title=""
     >
       Textarea label
@@ -170,6 +171,7 @@ exports[`renders 1`] = `
       class="c2"
       color="subtext"
       cursor="inherit"
+      for="textarea_id"
       title=""
     >
       Textarea label
@@ -270,6 +272,7 @@ exports[`renders with error 1`] = `
       class="c2"
       color="subtext"
       cursor="inherit"
+      for="textarea_id"
       title=""
     >
       Textarea label


### PR DESCRIPTION
## Screenshot / video

- No UI changes

## What does this do?

- Add missing props and forwardRef to `Text` component
- This addition allows to add the `htmlFor` attribute to labels on input components to use as selectors for tests
