### PR TITLE
Input component label enhancements

### DIFF
--- a/src/Dropdown/Dropdown.stories.js
+++ b/src/Dropdown/Dropdown.stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Dropdown } from './Dropdown'
 import { Container } from './Container'
+import { theme } from '../theme'
 
 const days = [
   {
@@ -164,6 +165,20 @@ WithOutline.args = {
   list: days,
   placeholder: 'Select Day',
   outlined: true,
+}
+
+export const WithHeaderLabel = Template.bind({})
+
+WithHeaderLabel.args = {
+  id: 'days',
+  list: days,
+  placeholder: 'Select Day',
+  outlined: true,
+  label: 'What day were you born?',
+  labelColor: theme.colors.secondary,
+  labelTypo: 'header-medium',
+  labelTag: 'h3',
+  outlinedLabelMargin: '16px',
 }
 
 export const WithOutlineWithGroups = Template.bind({})

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -29,6 +29,16 @@ type DefaultProps = {
   placeholder?: string
   /** label displayed above the dropdown  */
   label?: string
+  /** label typography displayed above input  */
+  labelTypo?: string
+  /** label tag displayed above input  */
+  labelTag?: string
+  /** label color displayed above input  */
+  labelColor?: string
+  /** margin below label, when input is outlined */
+  outlinedLabelMargin?: string
+  /** margin below label, when input is not outlined */
+  labelMargin?: string
   /** used for label - input connection */
   name?: string
   /** input value */
@@ -73,6 +83,11 @@ export const Dropdown: FC<Props> = ({
   className = '',
   ref,
   label,
+  labelTypo = 'label',
+  labelTag = 'label',
+  labelColor = 'subtext',
+  outlinedLabelMargin = '4px',
+  labelMargin = '0px',
   placeholder,
   name,
   value,
@@ -119,8 +134,8 @@ export const Dropdown: FC<Props> = ({
   return (
     <Container className={className}>
       {label && (
-        <Box mb={outlined ? '4px' : '0px'}>
-          <Text tag="label" color="subtext" typo="label" htmlFor={id}>
+        <Box mb={outlined ? outlinedLabelMargin : labelMargin}>
+          <Text tag={labelTag} color={labelColor} typo={labelTypo} htmlFor={id}>
             {label}
           </Text>
         </Box>

--- a/src/TextInput/TextInput.stories.js
+++ b/src/TextInput/TextInput.stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { TextInput } from './TextInput'
 import { Container } from './Container'
+import { theme } from '../theme'
 
 export default {
   title: 'Text Input',
@@ -97,6 +98,23 @@ WithLabel.args = {
   onBlur: () => {},
   label: 'label',
   outlined: false,
+}
+
+export const WithHeaderLabel = Template.bind({})
+
+WithHeaderLabel.args = {
+  id: 'textInput',
+  name: 'textInput',
+  placeholder: 'Placeholder text',
+  onChange: () => {},
+  onInputChange: () => {},
+  onBlur: () => {},
+  label: 'This is a header label',
+  labelColor: theme.colors.secondary,
+  labelTypo: 'header-medium',
+  labelTag: 'h3',
+  outlinedLabelMargin: '16px',
+  outlined: true,
 }
 
 export const WithIcon = Template.bind({})

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -22,6 +22,16 @@ type DefaultProps = {
   placeholder: string
   /** label displayed above the input  */
   label?: string
+  /** label typography displayed above input  */
+  labelTypo?: string
+  /** label tag displayed above input  */
+  labelTag?: string
+  /** label color displayed above input  */
+  labelColor?: string
+  /** margin below label, when input is outlined */
+  outlinedLabelMargin?: string
+  /** margin below label, when input is not outlined */
+  labelMargin?: string
   /** used for label - input connection */
   name?: string
   /** input value */
@@ -59,6 +69,11 @@ export const TextInput: FC<Props> = ({
   type = 'text',
   placeholder,
   label,
+  labelTypo = 'label',
+  labelTag = 'label',
+  labelColor = 'subtext',
+  outlinedLabelMargin = '4px',
+  labelMargin = '0px',
   name,
   value,
   outlined = false,
@@ -73,8 +88,8 @@ export const TextInput: FC<Props> = ({
 }) => (
   <Container className={className} hasLabel={!!label} hasError={!!errorMsg}>
     {label && (
-      <Box mb={outlined ? '4px' : '0px'}>
-        <Text tag="label" color="subtext" typo="label" htmlFor={id}>
+      <Box mb={outlined ? outlinedLabelMargin : labelMargin}>
+        <Text tag={labelTag} color={labelColor} typo={labelTypo} htmlFor={id}>
           {label}
         </Text>
       </Box>

--- a/src/Textarea/Textarea.stories.js
+++ b/src/Textarea/Textarea.stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Container } from './Container'
 import { Textarea } from './Textarea'
+import { theme } from '../theme'
 
 export default {
   title: 'Textarea',
@@ -44,6 +45,21 @@ Error.args = {
   resize: 'none',
   error: true,
   errorMsg: 'Something really quite terrible has gone wrong here!',
+}
+
+export const WithHeaderLabel = Template.bind({})
+
+WithHeaderLabel.args = {
+  id: 'textarea_id',
+  label: 'A big label',
+  value: '',
+  onChange: () => {},
+  resize: 'none',
+  placeholder: 'Here is some placeholder text.',
+  labelColor: theme.colors.secondary,
+  labelTypo: 'header-medium',
+  labelTag: 'h3',
+  labelMargin: '16px',
 }
 
 const WorkingExampleTemplate = (args) => <Container {...args} />

--- a/src/Textarea/Textarea.tsx
+++ b/src/Textarea/Textarea.tsx
@@ -17,6 +17,14 @@ type TextareaProps = {
   placeholder?: string
   /** label displayed above the input  */
   label?: string
+  /** label typography displayed above input  */
+  labelTypo?: string
+  /** label tag displayed above input  */
+  labelTag?: string
+  /** label color displayed above input  */
+  labelColor?: string
+  /** margin below label, when input is not outlined */
+  labelMargin?: string
   /** used for label - input connection */
   name?: string
   /** input value */
@@ -56,6 +64,10 @@ export const Textarea: FC<Props> = ({
   id,
   name,
   label,
+  labelTypo = 'label',
+  labelTag = 'label',
+  labelColor = 'subtext',
+  labelMargin = '4px',
   value,
   onChange,
   onInputChange,
@@ -72,8 +84,8 @@ export const Textarea: FC<Props> = ({
 }) => (
   <Box flex direction="column" className={className}>
     {label && (
-      <Box mb="4px">
-        <Text tag="label" color="subtext" typo="label" htmlFor={id}>
+      <Box mb={labelMargin}>
+        <Text tag={labelTag} color={labelColor} typo={labelTypo} htmlFor={id}>
           {label}
         </Text>
       </Box>


### PR DESCRIPTION
## Screenshot / video

![Screenshot 2022-01-28 at 17 17 37](https://user-images.githubusercontent.com/12373062/151592159-d77575a7-f3d0-4df4-b71c-98ccb9d3104d.png)



## What does this do?

- Add props allowing to customize label size and color on input components
- The input can now be selected by label for tests even when the header's design is not the traditional small label
