### PR TITLE
Button - Make `id` prop optional

### DIFF
--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, ButtonHTMLAttributes, forwardRef } from 'react'
+import React, { FC, ButtonHTMLAttributes, forwardRef } from 'react'
 import styled, { css } from 'styled-components'
 import { darken } from 'polished'
 
@@ -25,8 +25,7 @@ interface IButton {
 }
 
 type Props = {
-  children: ReactNode
-  id: string
+  id?: string
   className?: string
   color?: string
   block?: boolean

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ButtonHTMLAttributes, forwardRef } from 'react'
+import React, { FC, ReactNode, ButtonHTMLAttributes, forwardRef } from 'react'
 import styled, { css } from 'styled-components'
 import { darken } from 'polished'
 
@@ -25,6 +25,7 @@ interface IButton {
 }
 
 type Props = {
+  children: ReactNode
   id?: string
   className?: string
   color?: string

--- a/src/Button/LegacyButton.tsx
+++ b/src/Button/LegacyButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 
 import { theme } from '../theme'
@@ -21,6 +21,7 @@ interface IButton {
 }
 
 type Props = {
+  children: ReactNode
   id?: string
   className?: string
   color?: string

--- a/src/Button/LegacyButton.tsx
+++ b/src/Button/LegacyButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react'
+import React, { FC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { theme } from '../theme'
@@ -7,7 +7,7 @@ interface IButton {
   /** button color  */
   color: string
   /** unique id */
-  id: string
+  id?: string
   /** take full 100% width  */
   block: boolean
   /** invert bg and text colors */
@@ -21,8 +21,7 @@ interface IButton {
 }
 
 type Props = {
-  children: ReactNode
-  id: string
+  id?: string
   className?: string
   color?: string
   block?: boolean


### PR DESCRIPTION
Update to make the `id` optional
See [slack thread](https://eatmarshmallows.slack.com/archives/CG7VD0QMA/p1643823081317959) for more context