### PR TITLE
Ft pagination handle smaller page numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.1.5] - 2022-02-23
+### Changed
+- Fix Pagination bug for small number of pages
 ## [2.1.4] - 2022-02-21
 ### Changed
 - Swapped 'included' and 'excluded' icons
@@ -264,6 +267,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[2.1.5]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.4...v2.1.5
 [2.1.4]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.3...v2.1.4
 [2.1.3]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.1...v2.1.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mrshmllw/smores-react",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^2.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "main": "./dist/index.js",
   "description": "Collection of React components used by Marshmallow Technology",
   "keywords": [

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -43,7 +43,7 @@ export const Pagination: FC<PaginationProps> = ({
     if (numberOfPages > 1) {
         setLastPage(numberOfPages)
     } else if(numberOfPages === 1) {
-        // Sets last page to be null to avoid duplicating the first page.
+        // Sets last page to be null to avoid the last page being kept from previous state.
         setLastPage(null);
     }
     if (numberOfPages > 2) {

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -41,7 +41,7 @@ export const Pagination: FC<PaginationProps> = ({
   useEffect(() => {
     const numberOfPages = Math.ceil(total / partition)
     if (numberOfPages > 1) {
-        setLastPage(numberOfPages);
+        setLastPage(numberOfPages)
     } else if(numberOfPages === 1) {
         // Sets last page to be null to avoid duplicating the first page.
         setLastPage(null);

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -39,15 +39,21 @@ export const Pagination: FC<PaginationProps> = ({
   }, [lastPage])
 
   useEffect(() => {
-    const numberOfPages = Math.ceil(total / partition)
+    const numberOfPages = Math.ceil(total / partition);
     if (numberOfPages > 1) {
-      setLastPage(numberOfPages)
+        setLastPage(numberOfPages);
+    } else if(numberOfPages === 1) {
+        // Sets last page to be null to avoid duplicating the first page.
+        setLastPage(null);
     }
     if (numberOfPages > 2) {
-      const allPages = Array.from({ length: numberOfPages }, (_, i) => i + 1)
-      setPages(allPages.slice(1, numberOfPages - 1))
+        const allPages = Array.from({ length: numberOfPages }, (_, i) => i + 1);
+        setPages(allPages.slice(1, numberOfPages - 1));
+    } else {
+      // Sets pages to empty to avoid using the previous state if pages set before. 
+        setPages([])
     }
-  }, [total, partition])
+}, [total, partition]);
 
   useEffect(() => {
     if (lastPage <= MAX_PAGES) {

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -39,7 +39,7 @@ export const Pagination: FC<PaginationProps> = ({
   }, [lastPage])
 
   useEffect(() => {
-    const numberOfPages = Math.ceil(total / partition);
+    const numberOfPages = Math.ceil(total / partition)
     if (numberOfPages > 1) {
         setLastPage(numberOfPages);
     } else if(numberOfPages === 1) {
@@ -47,13 +47,13 @@ export const Pagination: FC<PaginationProps> = ({
         setLastPage(null);
     }
     if (numberOfPages > 2) {
-        const allPages = Array.from({ length: numberOfPages }, (_, i) => i + 1);
-        setPages(allPages.slice(1, numberOfPages - 1));
+        const allPages = Array.from({ length: numberOfPages }, (_, i) => i + 1)
+        setPages(allPages.slice(1, numberOfPages - 1))
     } else {
       // Sets pages to empty to avoid using the previous state if pages set before. 
         setPages([])
     }
-}, [total, partition]);
+}, [total, partition])
 
   useEffect(() => {
     if (lastPage <= MAX_PAGES) {


### PR DESCRIPTION
## Screenshot / video

[if applicable for UI changes]

## What does this do?

[A short description of what the PR changes and why it's necessary]
- Fixes a bug with the pagination component where the last page is not updated if moving between a list that has more than 1 page and a list that has a single page.
- Fixes a bug with the pagination component where the "pages icons" are not updated if moving between a list that has more than 2 pages and a list that has two pages or less.
