### PR TITLE
Update loading prop to be a transient prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.1.8] - 2022-03-03
+### Changed
+- Fix Button `loading` prop to be a transient prop internally
 ## [2.1.7] - 2022-03-01
 ### Fixed
 - Fix Button's layout shifting issue when having an icon or changing to a loading state

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -119,7 +119,7 @@ export const Button: FC<ButtonProps> = forwardRef<
             />
           </LoaderContainer>
         )}
-        <ContentContainer icon={icon} loading={loading}>
+        <ContentContainer icon={icon} $loading={loading}>
           {icon && (
             <IconContainer
               render={icon}
@@ -215,11 +215,13 @@ const LoaderContainer = styled.div`
   justify-content: center;
 `
 
-const ContentContainer = styled.div<Pick<ButtonProps, 'icon' | 'loading'>>`
+const ContentContainer = styled.div<
+  Pick<ButtonProps, 'icon'> & { $loading: boolean }
+>`
   display: flex;
   align-items: center;
   justify-content: ${({ icon }) => (icon ? 'space-evenly' : 'center')};
-  opacity: ${({ loading }) => (loading ? '0' : '1')};
+  opacity: ${({ $loading }) => ($loading ? '0' : '1')};
 `
 
 const IconContainer = styled(IconComponent)`


### PR DESCRIPTION
<img width="333" alt="Screenshot 2022-03-03 at 10 02 51" src="https://user-images.githubusercontent.com/14129033/156542167-69f38d88-4ed9-40b8-9467-e3ba07d8cf38.png">

No error but some warning that isn't necessary