### PR TITLE
Updated hover states for form fields and removed deprecated button stories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.1.9] - 2022-03-09
+### Changed
+- Fixed form fields hover states
+- Deleted stories for deprecated Button styles
 ## [2.1.8] - 2022-03-03
 ### Changed
 - Fix Button `loading` prop to be a transient prop internally
@@ -275,6 +279,10 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[2.1.9]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.8...v2.1.9
+[2.1.8]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.7...v2.1.8
+[2.1.7]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.6...v2.1.7
+[2.1.6]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.5...v2.1.6
 [2.1.5]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.4...v2.1.5
 [2.1.4]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.3...v2.1.4
 [2.1.3]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.2...v2.1.3

--- a/src/Button/Button.stories.js
+++ b/src/Button/Button.stories.js
@@ -11,40 +11,11 @@ export default {
 
 const Template = (args) => <Button {...args}>Get started</Button>
 
-export const Default = Template.bind({})
-
-Default.args = {
-  color: 'secondary',
-}
-
 const InteractivePlaygroundTemplate = (args) => (
   <InteractivePlayground {...args} />
 )
 
 export const Interactive = InteractivePlaygroundTemplate.bind({})
-
-export const Coloured = Template.bind({})
-
-Coloured.args = {
-  color: 'success',
-}
-
-export const Inverted = Template.bind({})
-
-Inverted.args = {
-  inverted: true,
-}
-export const Outlined = Template.bind({})
-
-Outlined.args = {
-  outlined: true,
-}
-
-export const Block = Template.bind({})
-
-Block.args = {
-  block: true,
-}
 
 export const Primary = Template.bind({})
 

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useEffect, useState, FormEvent, RefObject } from 'react'
 import styled from 'styled-components'
+import { darken } from 'polished'
 
 import { Text } from '../Text'
 import { Icon } from '../Icon'
@@ -245,7 +246,7 @@ const Select = styled.select<IUsesOutline>`
   &:focus-visible,
   &:checked {
     outline: none;
-    border-color: ${theme.colors.outline};
+    border-color: ${darken(0.1, theme.colors.outline)};
   }
 
   ${({ outlined }) =>

--- a/src/Dropdown/__tests__/__snapshots__/Dropdown.js.snap
+++ b/src/Dropdown/__tests__/__snapshots__/Dropdown.js.snap
@@ -76,7 +76,7 @@ exports[`rendersDropdown 1`] = `
 .c2:focus-visible,
 .c2:checked {
   outline: none;
-  border-color: #D2D2D2;
+  border-color: #b9b9b9;
 }
 
 .c3 {
@@ -243,7 +243,7 @@ exports[`rendersDropdownWithGroups 1`] = `
 .c2:focus-visible,
 .c2:checked {
   outline: none;
-  border-color: #D2D2D2;
+  border-color: #b9b9b9;
 }
 
 .c3 {

--- a/src/SearchInput/SearchInput.tsx
+++ b/src/SearchInput/SearchInput.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useState } from 'react'
 import styled from 'styled-components'
+import { darken } from 'polished'
 
 import { Text } from '../Text'
 import { Box } from '../Box'
@@ -172,7 +173,7 @@ const InputBox = styled.div<IShowIcon>`
   &:hover,
   &:focus,
   &:focus-within {
-    border-color: ${theme.colors.outline};
+    border-color: ${darken(0.1, theme.colors.outline)};
   }
 
   ${({ selected }) =>

--- a/src/SearchInput/__tests__/__snapshots__/SearchInput.js.snap
+++ b/src/SearchInput/__tests__/__snapshots__/SearchInput.js.snap
@@ -48,7 +48,7 @@ exports[`renders 1`] = `
 .c3:hover,
 .c3:focus,
 .c3:focus-within {
-  border-color: #D2D2D2;
+  border-color: #b9b9b9;
 }
 
 .c4 {

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -1,5 +1,6 @@
 import React, { FormEvent, FC, RefObject } from 'react'
 import styled from 'styled-components'
+import { darken } from 'polished'
 
 import { Box } from '../Box'
 import { Text } from '../Text'
@@ -10,7 +11,7 @@ import { theme } from '../theme'
 type DefaultProps = {
   /** ID, usually used for tests  */
   id: string
-  /** className attribute to apply classses from props */
+  /** className attribute to apply classes from props */
   className?: string
   /** ref attribute for input */
   ref?: RefObject<HTMLInputElement>
@@ -136,7 +137,7 @@ const Content = styled.div<IInput>`
   &:hover,
   &:focus-within {
     border-color: ${({ error }) =>
-      theme.colors[`${error ? 'error' : 'outline'}`]};
+      error ? theme.colors.error : darken(0.1, theme.colors.outline)};
   }
 
   ${({ outlined, error }) =>

--- a/src/TextInput/__tests__/__snapshots__/TextInput.js.snap
+++ b/src/TextInput/__tests__/__snapshots__/TextInput.js.snap
@@ -25,7 +25,7 @@ exports[`renders 1`] = `
 
 .c1:hover,
 .c1:focus-within {
-  border-color: #D2D2D2;
+  border-color: #b9b9b9;
 }
 
 .c2 {

--- a/src/Textarea/Textarea.tsx
+++ b/src/Textarea/Textarea.tsx
@@ -1,5 +1,6 @@
 import React, { FC, FormEvent, RefObject } from 'react'
 import styled from 'styled-components'
+import { darken } from 'polished'
 
 import { Text } from '../Text'
 import { Box } from '../Box'
@@ -132,7 +133,7 @@ const Field = styled.textarea<ITextarea>`
   &:focus,
   &:focus-visible {
     border-color: ${({ error }) =>
-      theme.colors[`${error ? 'error' : 'outline'}`]};
+      error ? theme.colors.error : darken(0.1, theme.colors.outline)};
   }
 
   ${({ value }) =>

--- a/src/Textarea/__tests__/__snapshots__/Textarea.js.snap
+++ b/src/Textarea/__tests__/__snapshots__/Textarea.js.snap
@@ -55,7 +55,7 @@ exports[`disabled 1`] = `
 .c3:hover,
 .c3:focus,
 .c3:focus-visible {
-  border-color: #D2D2D2;
+  border-color: #b9b9b9;
 }
 
 @media (min-width:768px) {
@@ -151,7 +151,7 @@ exports[`renders 1`] = `
 .c3:hover,
 .c3:focus,
 .c3:focus-visible {
-  border-color: #D2D2D2;
+  border-color: #b9b9b9;
 }
 
 @media (min-width:768px) {


### PR DESCRIPTION
## Screenshot / video


https://user-images.githubusercontent.com/1053476/157431724-8f50ae2b-fcf4-441f-b1b4-3fce901740b9.mov



## What does this do?

We lost hover state on form fields when we migrated to the new colour palette so I put it back in
