### PR TITLE
Replace snyk with snyk/protect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.1.14",
       "license": "MIT",
       "dependencies": {
-        "@snyk/protect": "^1.880.0",
         "date-fns": "^2.16.1",
         "polished": "^4.1.3",
         "react": "^16.8.0",
@@ -24,6 +23,7 @@
         "@babel/preset-env": "^7.11.5",
         "@babel/preset-react": "^7.10.4",
         "@babel/preset-typescript": "^7.10.4",
+        "@snyk/protect": "^1.881.0",
         "@storybook/addon-essentials": "^6.2.6",
         "@storybook/react": "^6.2.6",
         "@storybook/storybook-deployer": "^2.8.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.1.14",
       "license": "MIT",
       "dependencies": {
+        "@snyk/protect": "^1.880.0",
         "date-fns": "^2.16.1",
         "polished": "^4.1.3",
         "react": "^16.8.0",
@@ -48,7 +49,6 @@
         "jest-styled-components": "^7.0.3",
         "lint-staged": "^12.0.2",
         "prettier": "^2.1.2",
-        "snyk": "^1.529.0",
         "storybook-addon-performance": "^0.16.1"
       }
     },
@@ -3310,6 +3310,17 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@snyk/protect": {
+      "version": "1.881.0",
+      "resolved": "https://registry.npmjs.org/@snyk/protect/-/protect-1.881.0.tgz",
+      "integrity": "sha512-zkYDqCrMV5C0obqidRwwyV39QNv/KIi903xs5ou5GQw8xy/QIdOSwCE8EdrRkR/lup/RQUWJiDD7vye3TBC8PQ==",
+      "bin": {
+        "snyk-protect": "bin/snyk-protect"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@storybook/addon-essentials": {
@@ -11768,9 +11779,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.42",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.42.tgz",
-      "integrity": "sha512-nuab3x3CpJ7VFeNA+3HTUuEkvClYHXqWtWd7Ud6AZYW7Z3NH9WKtgU+tFB0ZLcHq+niB/HnzLcaZPqMJ95+k5Q==",
+      "version": "17.0.41",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.41.tgz",
+      "integrity": "sha512-chYZ9ogWUodyC7VUTRBfblysKLjnohhFY9bGLwvnUFFy48+vB9DikmB3lW0qTFmBcKSzmdglcvkHK71IioOlDA==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -13025,13 +13036,13 @@
       }
     },
     "node_modules/babel-loader": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.4.tgz",
-      "integrity": "sha512-8dytA3gcvPPPv4Grjhnt8b5IIiTcq/zeXOPk4iTYI0SVXcsmuGg7JtBRDp8S9X+gJfhQ8ektjXZlDu1Bb33U8A==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.3.tgz",
+      "integrity": "sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==",
       "dev": true,
       "dependencies": {
         "find-cache-dir": "^3.3.1",
-        "loader-utils": "^2.0.0",
+        "loader-utils": "^1.4.0",
         "make-dir": "^3.1.0",
         "schema-utils": "^2.6.5"
       },
@@ -13041,20 +13052,6 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0",
         "webpack": ">=2"
-      }
-    },
-    "node_modules/babel-loader/node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
       }
     },
     "node_modules/babel-plugin-add-react-displayname": {
@@ -26007,6 +26004,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
       "dev": true,
       "dependencies": {
         "atob": "^2.1.2",
@@ -26014,18 +26012,6 @@
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
         "urix": "^0.1.0"
-      }
-    },
-    "node_modules/snyk": {
-      "version": "1.881.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.881.0.tgz",
-      "integrity": "sha512-0dzvh3AxvbjelPNqTDWJXKdm6PnbdA+nDtRPUQJv2nKTPqLZt5fiKxB8JZ38cgAzhwputsETEWBRSQHz6v6rTA==",
-      "dev": true,
-      "bin": {
-        "snyk": "bin/snyk"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/source-list-map": {
@@ -26046,6 +26032,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
       "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
       "dev": true,
       "dependencies": {
         "atob": "^2.1.2",
@@ -26075,6 +26062,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
       "dev": true
     },
     "node_modules/space-separated-tokens": {
@@ -28724,7 +28712,7 @@
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
       "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-      "deprecated": "Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.",
+      "deprecated": "Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -32203,6 +32191,11 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "@snyk/protect": {
+      "version": "1.881.0",
+      "resolved": "https://registry.npmjs.org/@snyk/protect/-/protect-1.881.0.tgz",
+      "integrity": "sha512-zkYDqCrMV5C0obqidRwwyV39QNv/KIi903xs5ou5GQw8xy/QIdOSwCE8EdrRkR/lup/RQUWJiDD7vye3TBC8PQ=="
     },
     "@storybook/addon-essentials": {
       "version": "6.4.19",
@@ -38668,9 +38661,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.42",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.42.tgz",
-      "integrity": "sha512-nuab3x3CpJ7VFeNA+3HTUuEkvClYHXqWtWd7Ud6AZYW7Z3NH9WKtgU+tFB0ZLcHq+niB/HnzLcaZPqMJ95+k5Q==",
+      "version": "17.0.41",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.41.tgz",
+      "integrity": "sha512-chYZ9ogWUodyC7VUTRBfblysKLjnohhFY9bGLwvnUFFy48+vB9DikmB3lW0qTFmBcKSzmdglcvkHK71IioOlDA==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -39668,28 +39661,15 @@
       }
     },
     "babel-loader": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.4.tgz",
-      "integrity": "sha512-8dytA3gcvPPPv4Grjhnt8b5IIiTcq/zeXOPk4iTYI0SVXcsmuGg7JtBRDp8S9X+gJfhQ8ektjXZlDu1Bb33U8A==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.3.tgz",
+      "integrity": "sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==",
       "dev": true,
       "requires": {
         "find-cache-dir": "^3.3.1",
-        "loader-utils": "^2.0.0",
+        "loader-utils": "^1.4.0",
         "make-dir": "^3.1.0",
         "schema-utils": "^2.6.5"
-      },
-      "dependencies": {
-        "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        }
       }
     },
     "babel-plugin-add-react-displayname": {
@@ -49740,12 +49720,6 @@
           }
         }
       }
-    },
-    "snyk": {
-      "version": "1.881.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.881.0.tgz",
-      "integrity": "sha512-0dzvh3AxvbjelPNqTDWJXKdm6PnbdA+nDtRPUQJv2nKTPqLZt5fiKxB8JZ38cgAzhwputsETEWBRSQHz6v6rTA==",
-      "dev": true
     },
     "source-list-map": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:coverage": "jest --coverage --silent",
     "test:watch": "jest --watch --silent",
     "test": "jest --silent",
-    "snyk-protect": "snyk protect",
+    "snyk-protect": "snyk-protect",
     "prepare": "npm run snyk-protect && husky install",
     "pre-commit-lint": "npm run check-types && lint-staged"
   },
@@ -58,10 +58,10 @@
     "jest-styled-components": "^7.0.3",
     "lint-staged": "^12.0.2",
     "prettier": "^2.1.2",
-    "snyk": "^1.529.0",
     "storybook-addon-performance": "^0.16.1"
   },
   "dependencies": {
+    "@snyk/protect": "^1.880.0",
     "date-fns": "^2.16.1",
     "polished": "^4.1.3",
     "react": "^16.8.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",
+    "@snyk/protect": "^1.881.0",
     "@storybook/addon-essentials": "^6.2.6",
     "@storybook/react": "^6.2.6",
     "@storybook/storybook-deployer": "^2.8.7",
@@ -61,7 +62,6 @@
     "storybook-addon-performance": "^0.16.1"
   },
   "dependencies": {
-    "@snyk/protect": "^1.880.0",
     "date-fns": "^2.16.1",
     "polished": "^4.1.3",
     "react": "^16.8.0",


### PR DESCRIPTION
⚠ WARNING: Starting from 31 March 2022, the protect command will be removed.
Please use the @snyk/protect package instead.
For more info: https://snyk.co/ueln7