### PR TITLE
Add scrolling on desktop when content is too long

### DIFF
--- a/src/Modal/Modal.stories.tsx
+++ b/src/Modal/Modal.stories.tsx
@@ -3,8 +3,25 @@ import { Button } from '../Button'
 import { Box } from '../Box'
 import { Modal, ModalProps } from './Modal'
 
+const placeholderText =
+  "There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum generators on the Internet tend to repeat predefined chunks as necessary, making this the first true generator on the Internet."
+
 export default {
   title: 'Modal',
+  component: Modal,
+  argTypes: { handleClick: { action: 'Callback - `handleClick`' } },
+}
+
+export const Playground = Modal.bind({})
+
+Playground.args = {
+  icon: 'info',
+  title: 'What is Lorem Ipsum?',
+  showModal: true,
+  drawer: true,
+  cross: true,
+  width: '640px',
+  children: placeholderText,
 }
 
 const Template = (props: ModalProps) => {
@@ -15,28 +32,38 @@ const Template = (props: ModalProps) => {
   }
   return (
     <Box>
-      {showModal ? (
-        <Modal {...props} handleClick={handleClick} showModal={showModal}>
-          [A modal window] creates a mode that disables the main window, but
-          keeps it visible with the modal window as a child window in front of
-          it.
-        </Modal>
-      ) : (
-        <Button primary handleClick={handleClick}>
-          Show Modal with Mobile Drawer
-        </Button>
-      )}
+      <Modal {...props} handleClick={handleClick} showModal={showModal}>
+        [A modal window] creates a mode that disables the main window, but keeps
+        it visible with the modal window as a child window in front of it.
+      </Modal>
+      <Button primary handleClick={handleClick}>
+        Show Modal with Mobile Drawer
+      </Button>
     </Box>
   )
 }
 
-export const Default = Template.bind({})
+export const Interactive = Template.bind({})
 
-Default.args = {
+Interactive.args = {
   icon: 'calendar',
   title: "Hello world i'm a beautiful modal",
   showModal: false,
   drawer: true,
   cross: true,
   width: '640px',
+}
+
+export const WithLongContent = Modal.bind({})
+
+WithLongContent.args = {
+  icon: 'info',
+  title: 'What is Lorem Ipsum?',
+  showModal: true,
+  drawer: true,
+  cross: true,
+  width: '640px',
+  children: Array.from(Array(10))
+    .map((_, i) => placeholderText)
+    .join('\n'),
 }

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -75,7 +75,7 @@ const Wrapper = styled(Box)<IModalWrapper>(
     position: absolute;
     top: 0;
     left: 0;
-    height: calc(100vh);
+    height: 100vh;
     width: 100%;
     justify-content: center;
     align-items: center;
@@ -86,36 +86,35 @@ const Overlay = styled.div`
   position: fixed;
   background: ${theme.colors.secondary};
   opacity: 0.4;
-  height: calc(100vh);
-  width: 100%;
   top: 0;
+  bottom: 0;
   left: 0;
-  z-index: 999;
+  right: 0;
 `
 
 const Container = styled.div<IModalContainer>(
   ({ drawer, width }) => css`
     background: ${theme.colors.white};
-    z-index: 999;
     border: 1px solid ${theme.colors.outline};
     box-sizing: border-box;
     border-radius: 8px;
     padding: 24px;
     max-width: ${width};
     position: fixed;
+    max-height: calc(100vh - 64px);
+    overflow: auto;
 
     ${drawer === true &&
     css`
       @media (max-width: 768px) {
         max-width: none;
-        width: 100%;
-        left: 0;
         border-radius: 16px 16px 0px 0px;
         padding: 10% 24px;
-        overflow: scroll;
         max-height: 90vh;
+
         position: fixed;
-        top: auto;
+        right: 0;
+        left: 0;
         bottom: 0;
       }
     `}

--- a/src/Modal/__tests__/__snapshots__/Modal.js.snap
+++ b/src/Modal/__tests__/__snapshots__/Modal.js.snap
@@ -74,7 +74,7 @@ exports[`renders 1`] = `
   position: absolute;
   top: 0;
   left: 0;
-  height: calc(100vh);
+  height: 100vh;
   width: 100%;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -90,22 +90,22 @@ exports[`renders 1`] = `
   position: fixed;
   background: #112035;
   opacity: 0.4;
-  height: calc(100vh);
-  width: 100%;
   top: 0;
+  bottom: 0;
   left: 0;
-  z-index: 999;
+  right: 0;
 }
 
 .c2 {
   background: #FFFFFF;
-  z-index: 999;
   border: 1px solid #D2D2D2;
   box-sizing: border-box;
   border-radius: 8px;
   padding: 24px;
   max-width: 460px;
   position: fixed;
+  max-height: calc(100vh - 64px);
+  overflow: auto;
 }
 
 .c7 {
@@ -139,14 +139,12 @@ exports[`renders 1`] = `
 @media (max-width:768px) {
   .c2 {
     max-width: none;
-    width: 100%;
-    left: 0;
     border-radius: 16px 16px 0px 0px;
     padding: 10% 24px;
-    overflow: scroll;
     max-height: 90vh;
     position: fixed;
-    top: auto;
+    right: 0;
+    left: 0;
     bottom: 0;
   }
 }


### PR DESCRIPTION
## Screenshot / video

| BEFORE | AFTER |
| ------------- | ------------- |
| ![Screenshot 2022-04-21 at 12 26 09](https://user-images.githubusercontent.com/14129033/164448366-47409a99-4dca-4cea-b6d7-9ed9f0c2a863.png) | ![Screenshot 2022-04-21 at 12 19 30](https://user-images.githubusercontent.com/14129033/164447888-0f66d77f-e48b-497f-9c47-d3b8937ed230.png)  |


## What does this do?

- Add scrolling when the content is too long on desktop
- Updated scrolling property from `scroll` to `auto` on mobile, there should be no difference but this way, the scrolling bar isn't shown except when there is scrollable content