### PR TITLE
Grw 1483 - Optional label prop for Confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [2.1.18] - 2022-04-27
 ### Changed
 - Add label as optional prop to Confirmation
+- Adds new labelHidden prop to Confirmation
 
 ## [2.1.17] - 2022-04-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.1.18] - 2022-04-27
+### Changed
+- Add label as optional prop to Confirmation
+
 ## [2.1.17] - 2022-04-21
 ### Changed
 - Add z-index to Modal container
@@ -311,6 +315,8 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[2.1.17]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.17...v2.1.18
+[2.1.17]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.16...v2.1.17
 [2.1.16]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.15...v2.1.16
 [2.1.15]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.14...v2.1.15
 [2.1.14]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.13...v2.1.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,7 +315,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
-[2.1.17]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.17...v2.1.18
+[2.1.18]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.17...v2.1.18
 [2.1.17]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.16...v2.1.17
 [2.1.16]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.15...v2.1.16
 [2.1.15]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.14...v2.1.15

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mrshmllw/smores-react",
-      "version": "2.1.17",
+      "version": "2.1.18",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^2.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "main": "./dist/index.js",
   "description": "Collection of React components used by Marshmallow Technology",
   "keywords": [

--- a/src/ConfirmationRadioButtons/Confirmation.stories.tsx
+++ b/src/ConfirmationRadioButtons/Confirmation.stories.tsx
@@ -54,3 +54,12 @@ WithCustomLabel.args = {
   label: 'Do you like marshmallows?',
   yesLabel: 'Correct',
 }
+
+export const WithNoLabel = Template.bind({})
+
+WithNoLabel.args = {
+  id: 'radioButton',
+  onChange: noop,
+  checked: undefined,
+  yesLabel: 'Yes',
+}

--- a/src/ConfirmationRadioButtons/Confirmation.stories.tsx
+++ b/src/ConfirmationRadioButtons/Confirmation.stories.tsx
@@ -55,11 +55,12 @@ WithCustomLabel.args = {
   yesLabel: 'Correct',
 }
 
-export const WithNoLabel = Template.bind({})
+export const LabelHidden = Template.bind({})
 
-WithNoLabel.args = {
+LabelHidden.args = {
   id: 'radioButton',
   onChange: noop,
   checked: undefined,
   yesLabel: 'Yes',
+  labelHidden: true,
 }

--- a/src/ConfirmationRadioButtons/Confirmation.tsx
+++ b/src/ConfirmationRadioButtons/Confirmation.tsx
@@ -11,7 +11,7 @@ export type ConfirmationProps = {
   id: string
   error?: boolean
   errorMsg?: string
-  label: string
+  label?: string
   onBlur?: (e: FormEvent<HTMLInputElement>) => void
   sublabel?: string | ReactElement
   yesLabel?: string | ReactElement
@@ -32,14 +32,17 @@ export const Confirmation: FC<ConfirmationProps> = ({
 }: ConfirmationProps) => {
   return (
     <ConfirmationWrapper>
-      <TextWrapper>
-        <SectionHeadingText tag="h3">{label}</SectionHeadingText>
-        {sublabel && (
-          <Text tag="p" typo="base-small" color={theme.colors.subtext}>
-            {sublabel}
-          </Text>
-        )}
-      </TextWrapper>
+      {label ||
+        (sublabel && (
+          <TextWrapper>
+            {label && <SectionHeadingText tag="h3">{label}</SectionHeadingText>}
+            {sublabel && (
+              <Text tag="p" typo="base-small" color={theme.colors.subtext}>
+                {sublabel}
+              </Text>
+            )}
+          </TextWrapper>
+        ))}
       <RadioButtonGroupWrapper>
         <RadioButtonGroup>
           <RadioButtonWrapper checked={checked === true} error={error}>

--- a/src/ConfirmationRadioButtons/Confirmation.tsx
+++ b/src/ConfirmationRadioButtons/Confirmation.tsx
@@ -1,5 +1,5 @@
 import React, { FC, FormEvent, ReactElement } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { theme } from '../theme'
 import { Box } from '../Box'
 import { Text } from '../Text'
@@ -16,6 +16,7 @@ export type ConfirmationProps = {
   sublabel?: string | ReactElement
   yesLabel?: string | ReactElement
   noLabel?: string | ReactElement
+  labelHidden?: boolean
 }
 
 export const Confirmation: FC<ConfirmationProps> = ({
@@ -29,20 +30,24 @@ export const Confirmation: FC<ConfirmationProps> = ({
   sublabel,
   yesLabel = 'Yes',
   noLabel = 'No',
+  labelHidden = false,
 }: ConfirmationProps) => {
   return (
     <ConfirmationWrapper>
-      {label ||
-        (sublabel && (
-          <TextWrapper>
-            {label && <SectionHeadingText tag="h3">{label}</SectionHeadingText>}
-            {sublabel && (
-              <Text tag="p" typo="base-small" color={theme.colors.subtext}>
-                {sublabel}
-              </Text>
-            )}
-          </TextWrapper>
-        ))}
+      {!labelHidden && (
+        <TextWrapper>
+          {label && (
+            <SectionHeadingText tag="h3" labelHidden={labelHidden}>
+              {label}
+            </SectionHeadingText>
+          )}
+          {sublabel && (
+            <Text tag="p" typo="base-small" color={theme.colors.subtext}>
+              {sublabel}
+            </Text>
+          )}
+        </TextWrapper>
+      )}
       <RadioButtonGroupWrapper>
         <RadioButtonGroup>
           <RadioButtonWrapper checked={checked === true} error={error}>
@@ -70,6 +75,10 @@ export const Confirmation: FC<ConfirmationProps> = ({
       </RadioButtonGroupWrapper>
     </ConfirmationWrapper>
   )
+}
+
+interface ILabelHidden {
+  labelHidden?: boolean
 }
 
 const RadioButtonGroupWrapper = styled.div`
@@ -119,9 +128,22 @@ const ConfirmationWrapper = styled(Box)`
   align-items: center;
 `
 
-const SectionHeadingText = styled(Text)`
-  font-weight: bold;
-`
+const SectionHeadingText = styled(Text)<ILabelHidden>(
+  ({ labelHidden }) => css`
+    font-weight: bold;
+    ${labelHidden &&
+    `
+      clip: rect(1, 1, 1, 1);
+      clipPath: inset(50%);
+      height: 1;
+      margin: -1;
+      overflow: hidden;
+      padding: 0;
+      position: absolute;
+      width: 1;
+    `}
+  `,
+)
 
 const TextWrapper = styled.div`
   display: flex;

--- a/src/ConfirmationRadioButtons/__tests__/__snapshots__/Confirmation.js.snap
+++ b/src/ConfirmationRadioButtons/__tests__/__snapshots__/Confirmation.js.snap
@@ -5,16 +5,6 @@ exports[`renders 1`] = `
   class="sc-bczRLJ sc-jqUVSM fwUwPu dsgwcw"
 >
   <div
-    class="sc-iqcoie kvhLPP"
-  >
-    <h3
-      class="sc-gsnTZi jZrEYv sc-kDDrLX irRxpq"
-      color="secondary"
-      cursor="inherit"
-      title=""
-    />
-  </div>
-  <div
     class="sc-gKXOVf bLqwLA"
   >
     <div

--- a/src/ConfirmationRadioButtons/__tests__/__snapshots__/Confirmation.js.snap
+++ b/src/ConfirmationRadioButtons/__tests__/__snapshots__/Confirmation.js.snap
@@ -5,6 +5,9 @@ exports[`renders 1`] = `
   class="sc-bczRLJ sc-jqUVSM fwUwPu dsgwcw"
 >
   <div
+    class="sc-iqcoie kvhLPP"
+  />
+  <div
     class="sc-gKXOVf bLqwLA"
   >
     <div


### PR DESCRIPTION
## Screenshot
![Screenshot 2022-04-27 at 13 51 45](https://user-images.githubusercontent.com/99182828/165522466-578920ef-a137-4aea-b967-a83987e3425c.png)

## What does this do?
- Adds optional `label` prop for `Confirmation` component
- Updates `CHANGELOG` - adds missing version from previous version too
- Adds `With no label` definition in Storybook