### PR TITLE
Removes redundant margin and updates CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.1.19] - 2022-04-28
+### Changed
+- Removes redundant margin for Confirmation radio
+
 ## [2.1.18] - 2022-04-27
 ### Changed
 - Add label as optional prop to Confirmation
@@ -316,6 +320,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[2.1.19]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.18...v2.1.19
 [2.1.18]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.17...v2.1.18
 [2.1.17]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.16...v2.1.17
 [2.1.16]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.15...v2.1.16

--- a/src/ConfirmationRadioButtons/Confirmation.tsx
+++ b/src/ConfirmationRadioButtons/Confirmation.tsx
@@ -105,7 +105,7 @@ const RadioButtonWrapper = styled.div<FakeInput>`
   background-color: ${({ checked }: FakeInput) =>
     !checked && `${theme.colors.background}`};
   border: ${({ checked, error }: FakeInput) => getColor(checked, error)};
-  margin: 0px 10px;
+  margin-right: 10px;
   width: 139px;
   display: flex;
   align-items: center;

--- a/src/ConfirmationRadioButtons/__tests__/__snapshots__/Confirmation.js.snap
+++ b/src/ConfirmationRadioButtons/__tests__/__snapshots__/Confirmation.js.snap
@@ -14,7 +14,7 @@ exports[`renders 1`] = `
       class="sc-iBkjds ipBmMC"
     >
       <div
-        class="sc-ftvSup blNGbF"
+        class="sc-ftvSup ffgBDs"
       >
         <div
           class="sc-bczRLJ fTuaZS"
@@ -39,7 +39,7 @@ exports[`renders 1`] = `
         </div>
       </div>
       <div
-        class="sc-ftvSup blNGbF"
+        class="sc-ftvSup ffgBDs"
       >
         <div
           class="sc-bczRLJ fTuaZS"


### PR DESCRIPTION
## Screenshots
**Issue:**
<img width="364" alt="Screenshot 2022-04-28 at 17 10 57" src="https://user-images.githubusercontent.com/99182828/165797139-0f663173-a67d-4201-b46b-0eb029c01a3d.png">

**Fix:**
<img width="305" alt="Screenshot 2022-04-28 at 17 09 53" src="https://user-images.githubusercontent.com/99182828/165797151-3aff33aa-f262-4e82-ad09-f28c5b6a6f91.png">

## What does this do?
- Removes redundant margin left 