### PR TITLE
stop always allowing today's date to be picked in datepicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
-## [2.1.26] - 2022-06-09
-### Changed
-- Stop always allowing today's date to be picked
-
 ## [2.1.25] - 2022-05-27
 ### Added
 - Make `id` optional on form fields
 - Creates new Support Message component with types: 'info', 'info-outline', 'alert' and 'warning'
+- Stop always allowing today's date to be picked
 
 ## [2.1.24] - 2022-05-25
 ### Added
@@ -352,7 +349,6 @@
 ### Changed
 - Updated gap and styles on Row component
 
-[2.1.26]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.25...v2.1.26
 [2.1.25]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.24...v2.1.25
 [2.1.24]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.23...v2.1.24
 [2.1.23]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.22...v2.1.23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [2.1.25] - 2022-05-27
+## [2.1.26] - 2022-06-09
 ### Changed
 - Stop always allowing today's date to be picked
 
@@ -352,6 +352,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[2.1.26]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.25...v2.1.26
 [2.1.25]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.24...v2.1.25
 [2.1.24]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.23...v2.1.24
 [2.1.23]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.22...v2.1.23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## [2.1.25] - 2022-05-27
+### Changed
+- Stop always allowing today's date to be picked
+
+## [2.1.25] - 2022-05-27
 ### Added
 - Make `id` optional on form fields
 - Creates new Support Message component with types: 'info', 'info-outline', 'alert' and 'warning'

--- a/src/Datepicker/Datepicker.tsx
+++ b/src/Datepicker/Datepicker.tsx
@@ -9,7 +9,6 @@ import {
   isSameDay,
   isWithinInterval,
   getDaysInMonth,
-  isToday,
   isWeekend,
 } from 'date-fns'
 
@@ -76,9 +75,8 @@ export const Datepicker: FC<DatepickerProps> = ({
         label: format(date, 'dd'),
         active: activeDay ? isSameDay(date, activeDay) : false,
         disabled:
-          (!isToday(date) &&
-            !isWithinInterval(date, { start: startDate, end: endDate })) ||
-          (disableWeekend && isWeekend(date)),
+          (!isWithinInterval(date, { start: startDate, end: endDate }))
+          || (disableWeekend && isWeekend(date)),
       })
     }
 


### PR DESCRIPTION
**Allowing 31 days to be selected from 15th June**

before:
<img width="409" alt="Screenshot 2022-06-09 at 09 06 51" src="https://user-images.githubusercontent.com/17195367/172797549-40e92665-debb-4ac2-8dda-4648dd5dab7d.png">

after:
<img width="402" alt="Screenshot 2022-06-09 at 09 07 17" src="https://user-images.githubusercontent.com/17195367/172797564-b8a49045-e592-4ac8-8ec5-5161598dc78a.png">

