### PR TITLE
More changelog fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -371,7 +371,7 @@
 
 ### Changed
 - Updated gap and styles on Row component
-[2.2.0]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.28...v2.3.0
+[2.3.0]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.28...v2.3.0
 [2.1.28]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.27...v2.1.28
 [2.1.27]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.26...v2.1.27
 [2.1.26]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.25...v2.1.26

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "2.1.28",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mrshmllw/smores-react",
-      "version": "2.1.28",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^2.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "2.1.28",
+  "version": "2.2.0",
   "main": "./dist/index.js",
   "description": "Collection of React components used by Marshmallow Technology",
   "keywords": [


### PR DESCRIPTION
@fleonard 

should it be this?
[2.3.0]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.28...v2.3.0
[2.1.28]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.27...v2.1.28


or this?
[2.3.0]: https://github.com/marshmallow-insurance/smores-react/compare/v2.2.0...v2.3.0
[2.2.0]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.28...v2.2.0
[2.1.28]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1.27...v2.1.28