### PR TITLE
Add Lost trailingIcon to textInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.4.1] - 2022-07-15
+### Changed 
+- Added missing trailingIcon to textInput
 ## [2.4.0] - 2022-07-12
 ### Changed 
 - Update to use spacing token for Box's margin and padding props
@@ -388,6 +391,8 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[2.4.1]: https://github.com/marshmallow-insurance/smores-react/compare/v2.4.0...v2.4.1
+[2.4.0]: https://github.com/marshmallow-insurance/smores-react/compare/v2.3.6...v2.4.0
 [2.3.6]: https://github.com/marshmallow-insurance/smores-react/compare/v2.3.5...v2.3.6
 [2.3.5]: https://github.com/marshmallow-insurance/smores-react/compare/v2.3.4...v2.3.5
 [2.3.4]: https://github.com/marshmallow-insurance/smores-react/compare/v2.3.3...v2.3.4

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -4,6 +4,7 @@ import { darken } from 'polished'
 
 import { theme } from '../theme'
 import { Field, CommonFieldTypes } from '../Field'
+import { Icon } from '../Icon'
 import { useUniqueId } from '../utils/id'
 
 interface Props extends CommonFieldTypes {
@@ -44,6 +45,7 @@ export const TextInput = forwardRef(function TextInput(
     onChange,
     onInputChange,
     disabled = false,
+    trailingIcon,
     ...fieldProps
   }: TextInputProps,
   ref: ForwardedRef<HTMLInputElement>,
@@ -78,6 +80,7 @@ export const TextInput = forwardRef(function TextInput(
             onBlur && onBlur(e)
           }}
         />
+        {trailingIcon && <StyledIcon render={trailingIcon} color="subtext" />}
       </>
     </Field>
   )
@@ -88,6 +91,7 @@ interface Input {
   disabled?: boolean
   value?: string
   outlined?: boolean
+  trailingIcon?: string
 }
 
 const StyledInput = styled.input<Input>`
@@ -116,11 +120,19 @@ const StyledInput = styled.input<Input>`
       border-radius: 8px;
       height: auto;
     `}
+
   ${({ value }) =>
     value &&
     value != '' &&
     `
       border-color: ${theme.colors.outline};
+    `}
+
+  ${({ trailingIcon }) =>
+    trailingIcon &&
+    trailingIcon != '' &&
+    `
+      padding-right: 24px;
     `}
 
   ${({ outlined }) =>
@@ -133,4 +145,9 @@ const StyledInput = styled.input<Input>`
   &::placeholder {
     color: ${theme.colors.subtext};
   }
+`
+
+const StyledIcon = styled(Icon)`
+  position: relative;
+  left: -24px;
 `


### PR DESCRIPTION
## Screenshot / video

Before:
<img width="789" alt="Screenshot 2022-07-15 at 08 22 23" src="https://user-images.githubusercontent.com/1053476/179173235-2e244ba0-b757-4cae-8ee5-401cd68278a3.png">

After: 
<img width="820" alt="Screenshot 2022-07-15 at 08 22 17" src="https://user-images.githubusercontent.com/1053476/179173256-bedb3ac7-dccf-4a27-839d-ea93432cc35f.png">

## What does this do?

[A short description of what the PR changes and why it's necessary]

- Give the reviewers context
- Is the impact global or localised?
- Any tech debt created or discovered?
- Include links to Jira ticket and Figma file if applicable
