### PR TITLE
Support message style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.4.2] - 2022-07-15
+### Changed 
+- SupportMessage: Handle custom description properly
+
 ## [2.4.1] - 2022-07-15
 ### Changed 
 - Added missing trailingIcon to textInput
@@ -391,6 +395,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[2.4.2]: https://github.com/marshmallow-insurance/smores-react/compare/v2.4.1...v2.4.2
 [2.4.1]: https://github.com/marshmallow-insurance/smores-react/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/marshmallow-insurance/smores-react/compare/v2.3.6...v2.4.0
 [2.3.6]: https://github.com/marshmallow-insurance/smores-react/compare/v2.3.5...v2.3.6

--- a/src/SupportMessage/Collection.tsx
+++ b/src/SupportMessage/Collection.tsx
@@ -3,86 +3,75 @@ import styled from 'styled-components'
 
 import { Text } from '../Text'
 import { Box } from '../Box'
-import { SupportMessage } from './SupportMessage'
+import { SupportMessage, SupportMessageProps } from './SupportMessage'
+
+const variationList: SupportMessageProps[] = [
+  {
+    type: 'info',
+    title: 'Additional information',
+    description: 'Information needs to be communicated to the user.',
+  },
+  {
+    type: 'info-outline',
+    title: 'Additional information',
+    description: 'Information needs to be communicated to the user.',
+  },
+  {
+    type: 'alert',
+    title: 'Potential issue',
+    description: 'The user should be aware and possibly exercise caution.',
+  },
+  {
+    type: 'warning',
+    title: 'Error encountered',
+    description: "An error has occurred, here's feedback on how to proceed.",
+  },
+]
 
 export const CollectionPage: FC = () => {
   return (
     <Box flex direction="column">
-      <ContainerBox>
-        <Label tag="span" typo="header-small">
-          Type info-outline
-        </Label>
-        <SupportMessage
-          type="info-outline"
-          description="Info support message"
-        />
-      </ContainerBox>
-
-      <ContainerBox>
-        <Label tag="span" typo="header-small">
-          Type info - Default
-        </Label>
-        <SupportMessage type="info" description="Info support message" />
-      </ContainerBox>
-
-      <ContainerBox>
-        <Label tag="span" typo="header-small">
-          Type info - With title
-        </Label>
-        <SupportMessage
-          type="info"
-          title="General info title"
-          description="Info support message"
-        />
-      </ContainerBox>
-
-      <ContainerBox>
-        <Label tag="span" typo="header-small">
-          Type alert - Default
-        </Label>
-        <SupportMessage type="alert" description="Alert support message" />
-      </ContainerBox>
-
-      <ContainerBox>
-        <Label tag="span" typo="header-small">
-          Type alert - With title
-        </Label>
-        <SupportMessage
-          type="alert"
-          title="General alert title"
-          description="Alert support message"
-        />
-      </ContainerBox>
-
-      <ContainerBox>
-        <Label tag="span" typo="header-small">
-          Type warning - Default
-        </Label>
-        <SupportMessage type="warning" description="Warning support message" />
-      </ContainerBox>
-
-      <ContainerBox>
-        <Label tag="span" typo="header-small">
-          Type warning - With title
-        </Label>
-        <SupportMessage
-          type="warning"
-          title="General warning title"
-          description="Warning support message"
-        />
-      </ContainerBox>
+      {variationList.map(({ type, title, description }) => {
+        return (
+          <Box key={type} flex direction="column" mb="32px">
+            <Title tag="span" typo="header-medium">
+              Type: {type}
+            </Title>
+            <Box flex>
+              <Label tag="span" typo="header-small">
+                Without title
+              </Label>
+              <SupportMessage type={type} description={description} />
+            </Box>
+            <Box flex mt="8px">
+              <Label tag="span" typo="header-small">
+                With title
+              </Label>
+              <SupportMessage
+                type={type}
+                title={title}
+                description={description}
+              />
+            </Box>
+          </Box>
+        )
+      })}
     </Box>
   )
 }
 
-const ContainerBox = styled(Box)`
-  margin-bottom: 16px;
-  display: flex;
-  align-items: center;
-  max-width: 550px;
+const LABEL_WIDTH = '140px'
+
+const Title = styled(Text)`
+  margin-bottom: 12px;
+  font-size: 18px;
+  line-height: 20px;
+  margin-left: ${LABEL_WIDTH};
 `
 
 const Label = styled(Text)`
-  margin-right: 12px;
-  width: 600px;
+  margin-bottom: 4px;
+  font-size: 14px;
+  width: ${LABEL_WIDTH};
+  flex-shrink: 0;
 `

--- a/src/SupportMessage/SupportMessage.tsx
+++ b/src/SupportMessage/SupportMessage.tsx
@@ -5,6 +5,7 @@ import { lighten } from 'polished'
 import { Box } from '../Box'
 import { Icon } from '../Icon'
 import { theme, Color } from '../theme'
+import { Text } from '../Text'
 
 type StylesItem = {
   iconColor: Color
@@ -58,10 +59,12 @@ export const SupportMessage: FC<SupportMessageProps> = ({
         color={styles[type].iconColor}
       />
     </IconWrapper>
-    <ContentBox flex direction="column">
+    <Box flex direction="column" ml="16px">
       {title && <Title>{title}</Title>}
-      {description}
-    </ContentBox>
+      <Description tag="p" typo="base">
+        {description}
+      </Description>
+    </Box>
   </Wrapper>
 )
 
@@ -85,16 +88,16 @@ const Wrapper = styled.div<IWrapper>(
   `,
 )
 
-const ContentBox = styled(Box)`
-  margin-left: 16px;
-  color: ${theme.colors.secondary};
-  font-size: 14px;
-`
-
 const Title = styled.p`
   font-size: 16px;
   font-weight: ${theme.font.weight.medium};
   color: ${theme.colors.secondary};
   line-height: 20.8px;
   margin-bottom: 4px;
+`
+
+const Description = styled(Text)`
+  color: ${theme.colors.secondary};
+  font-size: 14px;
+  line-height: 20px;
 `


### PR DESCRIPTION
## Screenshot / video

- **BEFORE**
<img width="608" alt="Screenshot 2022-07-15 at 11 57 39" src="https://user-images.githubusercontent.com/14129033/179213857-fe0c0541-57e2-44a8-bb68-728a3060313d.png">

- **AFTER**
<img width="611" alt="Screenshot 2022-07-15 at 12 00 35" src="https://user-images.githubusercontent.com/14129033/179213886-fdab8276-6491-4181-b7db-db833032f023.png">

## What does this do?

When using custom description, text were not handle properly