### PR TITLE
Change Confirmation component label/radio buttons layout

### DIFF
--- a/src/ConfirmationRadioButtons/Confirmation.tsx
+++ b/src/ConfirmationRadioButtons/Confirmation.tsx
@@ -124,9 +124,8 @@ const ErrorBox = styled.span`
 `
 
 const ConfirmationWrapper = styled(Box)`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  align-items: center;
+  display: flex;
+  flex-direction: column;
 `
 
 const SectionHeadingText = styled(Text)`
@@ -136,6 +135,7 @@ const SectionHeadingText = styled(Text)`
 const TextWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  margin-bottom: 8px;
 `
 
 const Asterisk = styled.span`

--- a/src/ConfirmationRadioButtons/__tests__/__snapshots__/Confirmation.js.snap
+++ b/src/ConfirmationRadioButtons/__tests__/__snapshots__/Confirmation.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders 1`] = `
 <div
-  class="sc-bczRLJ sc-crXcEl jxUsZa cHxJkJ"
+  class="sc-bczRLJ sc-crXcEl jxUsZa fEhkOw"
 >
   <div
     class="sc-papXJ cWKQiM"


### PR DESCRIPTION
## Screenshot / video

<img width="325" alt="Screenshot 2022-07-19 at 14 39 48" src="https://user-images.githubusercontent.com/12373062/179764497-7f6868b0-d501-45c5-b76e-a97d4599ac17.png">

## What does this do?

- Radio buttons and label are now stacked rather than inline
