### PR TITLE
Fix outline color on accordion component 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.4.5] - 2022-07-27
+### Changed 
+- Fix border colour on Accordion component
 ## [2.4.4] - 2022-07-22
 ### Changed 
 - Export Link component
@@ -406,6 +409,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[2.4.5]: https://github.com/marshmallow-insurance/smores-react/compare/v2.4.4...v2.4.5
 [2.4.4]: https://github.com/marshmallow-insurance/smores-react/compare/v2.4.3...v2.4.4
 [2.4.3]: https://github.com/marshmallow-insurance/smores-react/compare/v2.4.2...v2.4.3
 [2.4.2]: https://github.com/marshmallow-insurance/smores-react/compare/v2.4.1...v2.4.2

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -70,7 +70,7 @@ const Wrapper = styled(Box)<Omit<IAccordion, 'isOpen'>>(
 
     ${fullBorder &&
     css`
-      border: 1px solid ${theme.colors.subtext};
+      border: 1px solid ${theme.colors.outline};
       border-radius: 8px;
       margin-bottom: 14px;
       padding: 20px 15px;


### PR DESCRIPTION
- Border color was wrongly specified during the color migration
- Updated full border to match bottom border only 