### PR TITLE
Remove unused codacy badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,10 @@
     <img alt="npm-version-badge" src="https://img.shields.io/npm/v/@mrshmllw/smores-react.svg?style=flat-square" /></a>
   <a href="https://github.com/marshmallow-insurance/smores-react/blob/master/LICENSE">
     <img alt="licence-badge" src="https://img.shields.io/github/license/marshmallow-insurance/smores-react.svg?style=flat-square" /></a>
-  <a href="https://travis-ci.com/marshmallow-insurance/smores-react">
-    <img alt="travis-build-badge" src="https://img.shields.io/travis/com/marshmallow-insurance/smores-react.svg?style=flat-square" /></a>
   <a href="https://david-dm.org/marshmallow-insurance/smores-react">
     <img alt="dependencies-badge" src="https://img.shields.io/david/marshmallow-insurance/smores-react.svg?style=flat-square" /></a>
   <a href="https://snyk.io//test/github/marshmallow-insurance/smores-react?targetFile=package.json">
     <img alt="snyk-badge" src="https://img.shields.io/snyk/vulnerabilities/github/marshmallow-insurance/smores-react?style=flat-square" /></a>
-    <img  alt="codacy-badge" src="https://img.shields.io/codacy/grade/e6e23095e1e64ca6bba6076b7589fa4a.svg?style=flat-square"/></a>
   <a href="https://prettier.io/">
     <img alt="prettier-badge" src="https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square" /></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
     <img alt="npm-version-badge" src="https://img.shields.io/npm/v/@mrshmllw/smores-react.svg?style=flat-square" /></a>
   <a href="https://github.com/marshmallow-insurance/smores-react/blob/master/LICENSE">
     <img alt="licence-badge" src="https://img.shields.io/github/license/marshmallow-insurance/smores-react.svg?style=flat-square" /></a>
-  <a href="https://david-dm.org/marshmallow-insurance/smores-react">
-    <img alt="dependencies-badge" src="https://img.shields.io/david/marshmallow-insurance/smores-react.svg?style=flat-square" /></a>
   <a href="https://snyk.io//test/github/marshmallow-insurance/smores-react?targetFile=package.json">
     <img alt="snyk-badge" src="https://img.shields.io/snyk/vulnerabilities/github/marshmallow-insurance/smores-react?style=flat-square" /></a>
   <a href="https://prettier.io/">


### PR DESCRIPTION
Mentioning it in the call earlier made me realise we still have some mentions in places which are way outdated.

Travis CI must also not be relevant anymore.
And I'm not sure about that David thing, but it seems we're not getting data anymore?