### PR TITLE
Setup `RadioGroup` structure

### DIFF
--- a/src/RadioGroup/RadioElement.tsx
+++ b/src/RadioGroup/RadioElement.tsx
@@ -1,0 +1,63 @@
+import React, { FC } from 'react'
+import styled from 'styled-components'
+import { MarginProps } from '../utils/space'
+import { theme } from '../theme'
+import { Box } from '../Box'
+import { visuallyHidden } from '../utils/visuallyHidden'
+import { focusOutline } from '../utils/focusOutline'
+
+type RadioElementProps = {
+  name: string
+  id: string
+  value: string
+  checked: boolean
+  onChange: (value: string) => void
+} & MarginProps
+
+export const RadioElement: FC<RadioElementProps> = ({
+  name,
+  id,
+  value,
+  checked,
+  onChange,
+  ...marginProps
+}) => {
+  return (
+    <>
+      <StyledInput
+        type="radio"
+        name={name}
+        id={id}
+        value={value}
+        checked={checked}
+        onChange={() => onChange(value)}
+      />
+      <RadioCircle {...marginProps} />
+    </>
+  )
+}
+
+const StyledInput = styled.input`
+  ${visuallyHidden}
+`
+
+const RADIO_SIZE = 24
+
+const RadioCircle = styled(Box)`
+  flex-shrink: 0;
+  width: ${RADIO_SIZE}px;
+  height: ${RADIO_SIZE}px;
+  border-radius: ${RADIO_SIZE}px;
+  background-color: ${theme.colors.white};
+  border: 2px solid ${theme.colors.subtext};
+
+  &:hover {
+    border: 2px solid ${theme.colors.secondary};
+  }
+
+  ${StyledInput}:checked + & {
+    border: 8px solid ${theme.colors.secondary};
+  }
+
+  ${focusOutline({ selector: `${StyledInput}:focus-visible + &` })}
+`

--- a/src/RadioGroup/RadioElement.tsx
+++ b/src/RadioGroup/RadioElement.tsx
@@ -1,10 +1,12 @@
 import React, { FC } from 'react'
 import styled from 'styled-components'
-import { MarginProps } from '../utils/space'
+
 import { theme } from '../theme'
-import { Box } from '../Box'
+import { MarginProps } from '../utils/space'
 import { visuallyHidden } from '../utils/visuallyHidden'
 import { focusOutline } from '../utils/focusOutline'
+
+import { Box } from '../Box'
 
 type RadioElementProps = {
   name: string

--- a/src/RadioGroup/RadioGroup.stories.tsx
+++ b/src/RadioGroup/RadioGroup.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { RadioGroup, RadioGroupProps } from './RadioGroup'
+
+export default {
+  title: 'RadioGroup',
+  component: RadioGroup,
+  argTypes: { onChange: { action: 'clicked' } },
+}
+
+const Template = (props: RadioGroupProps) => <RadioGroup {...props} />
+
+export const Default = Template.bind({})
+
+const options = [
+  { label: 'Social', value: 'social' },
+  { label: 'Social and commuting', value: 'social/commuting' },
+  {
+    label: 'All the above, and I drive for work',
+    value: 'social/commuting/work',
+  },
+  { label: 'It’s a commercial vehicle', value: 'commercial' },
+]
+
+Default.args = {
+  label: 'What do you use it for?',
+  onChange: (value: string) => console.log(value),
+  value: options[0].value,
+  options,
+}

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -1,7 +1,9 @@
 import React, { FC } from 'react'
-import { useUniqueId } from '../utils/id'
-import { RadioItem } from './RadioItem'
 import styled from 'styled-components'
+
+import { useUniqueId } from '../utils/id'
+
+import { RadioItem } from './RadioItem'
 
 export type RadioGroupProps = {
   options: Array<{

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -1,0 +1,41 @@
+import React, { FC } from 'react'
+import { useUniqueId } from '../utils/id'
+import { RadioItem } from './RadioItem'
+import styled from 'styled-components'
+
+export type RadioGroupProps = {
+  options: Array<{
+    label: string
+    value: string
+  }>
+  onChange: (value: string) => void
+  value: string
+}
+
+export const RadioGroup: FC<RadioGroupProps> = ({
+  options,
+  onChange,
+  value,
+}) => {
+  const name = useUniqueId()
+  return (
+    <RadioItemList>
+      {options.map((option) => (
+        <RadioItem
+          key={option.value}
+          name={name}
+          label={option.label}
+          value={option.value}
+          checked={option.value === value}
+          onChange={onChange}
+        />
+      ))}
+    </RadioItemList>
+  )
+}
+
+const RadioItemList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`

--- a/src/RadioGroup/RadioItem.tsx
+++ b/src/RadioGroup/RadioItem.tsx
@@ -1,0 +1,49 @@
+import React, { FC } from 'react'
+import { useUniqueId } from '../utils/id'
+import { RadioElement } from './RadioElement'
+import styled from 'styled-components'
+import { theme } from '../theme'
+
+type RadioItemProps = {
+  name: string
+  value: string
+  label: string
+  checked: boolean
+  onChange: (value: string) => void
+}
+
+export const RadioItem: FC<RadioItemProps> = ({
+  name,
+  label,
+  value,
+  checked,
+  onChange,
+}) => {
+  const id = useUniqueId()
+  return (
+    <Wrapper htmlFor={id}>
+      <RadioElement
+        name={name}
+        id={id}
+        value={value}
+        checked={checked}
+        onChange={onChange}
+        mr="8px"
+      />
+      <RadioText>{label}</RadioText>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.label`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`
+
+const RadioText = styled.span`
+  line-height: 16px;
+  font-size: 16px;
+  font-weight: ${theme.font.weight.medium};
+  color: ${theme.colors.secondary};
+`

--- a/src/RadioGroup/RadioItem.tsx
+++ b/src/RadioGroup/RadioItem.tsx
@@ -1,8 +1,10 @@
 import React, { FC } from 'react'
-import { useUniqueId } from '../utils/id'
-import { RadioElement } from './RadioElement'
 import styled from 'styled-components'
+
+import { useUniqueId } from '../utils/id'
 import { theme } from '../theme'
+
+import { RadioElement } from './RadioElement'
 
 type RadioItemProps = {
   name: string

--- a/src/utils/visuallyHidden.ts
+++ b/src/utils/visuallyHidden.ts
@@ -1,0 +1,13 @@
+/**
+ * Hide element visually but still have it accessible for assitive device
+ * @link https://www.a11yproject.com/posts/how-to-hide-content/
+ */
+export const visuallyHidden = `
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+`


### PR DESCRIPTION
## Screenshot / video

<img width="436" alt="Screenshot 2022-08-31 at 16 14 22" src="https://user-images.githubusercontent.com/14129033/187714534-2c84ad87-819b-4ca5-aac4-abecdadb5595.png">

## What does this do?

Still in WIP but can be merged for now as it isn't exported, works that still needs to be done:
- Use `Fieldset` with some update around label
- Add error state
- Implement `displayType`: `vertical-card` and `horizontal-card`

Those will be done in the next few PRs