### PR TITLE
Improve typing for `RadioGroup` value

### DIFF
--- a/src/RadioGroup/RadioElement.tsx
+++ b/src/RadioGroup/RadioElement.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import { theme } from '../theme'
@@ -7,17 +7,18 @@ import { visuallyHidden } from '../utils/visuallyHidden'
 import { focusOutline } from '../utils/focusOutline'
 
 import { Box } from '../Box'
+import { BaseValueType } from './types'
 
-type RadioElementProps = {
+type RadioElementProps<Value extends BaseValueType> = {
   name: string
   id: string
-  value: string
+  value: Value
   checked: boolean
-  onChange: (value: string) => void
+  onChange: (value: Value) => void
   isError: boolean
 } & MarginProps
 
-export const RadioElement: FC<RadioElementProps> = ({
+export const RadioElement = <Value extends BaseValueType>({
   name,
   id,
   value,
@@ -25,14 +26,14 @@ export const RadioElement: FC<RadioElementProps> = ({
   onChange,
   isError,
   ...marginProps
-}) => {
+}: RadioElementProps<Value>) => {
   return (
     <>
       <StyledInput
         type="radio"
         name={name}
         id={id}
-        value={value}
+        value={`${value}`}
         checked={checked}
         onChange={() => onChange(value)}
       />

--- a/src/RadioGroup/RadioGroup.stories.tsx
+++ b/src/RadioGroup/RadioGroup.stories.tsx
@@ -54,7 +54,7 @@ WithError.args = {
   displayType: 'horizontal-card',
 }
 
-const InteractiveStory = (props: RadioGroupProps) => {
+const InteractiveStory = (props: RadioGroupProps<string>) => {
   const [value, setValue] = useState('')
 
   return (

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import { useUniqueId } from '../utils/id'
@@ -6,20 +6,20 @@ import { useUniqueId } from '../utils/id'
 import { Fieldset } from '../fields/Fieldset'
 import { CommonFieldProps } from '../fields/commonFieldTypes'
 import { RadioItem } from './RadioItem'
-import { DisplayType } from './types'
+import { BaseValueType, DisplayType } from './types'
 import { ITEM_GAP } from './constants'
 
-export type RadioGroupProps = {
+export type RadioGroupProps<Value extends BaseValueType = BaseValueType> = {
   options: Array<{
     label: string
-    value: string
+    value: Value
   }>
-  onChange: (value: string) => void
-  value: string
+  onChange: (value: Value) => void
+  value: Value
   displayType?: DisplayType
 } & CommonFieldProps
 
-export const RadioGroup: FC<RadioGroupProps> = ({
+export const RadioGroup = <Value extends BaseValueType>({
   options,
   onChange,
   value,
@@ -27,7 +27,7 @@ export const RadioGroup: FC<RadioGroupProps> = ({
   renderAsTitle = false,
   error = false,
   ...fieldProps
-}) => {
+}: RadioGroupProps<Value>) => {
   const name = useUniqueId()
 
   return (
@@ -35,7 +35,7 @@ export const RadioGroup: FC<RadioGroupProps> = ({
       <RadioItemList displayType={displayType}>
         {options.map((option) => (
           <RadioItem
-            key={option.value}
+            key={`${option.value}`}
             name={name}
             label={option.label}
             value={option.value}

--- a/src/RadioGroup/RadioItem.tsx
+++ b/src/RadioGroup/RadioItem.tsx
@@ -1,24 +1,24 @@
-import React, { FC } from 'react'
+import React from 'react'
 import styled, { css } from 'styled-components'
 
 import { useUniqueId } from '../utils/id'
 import { theme } from '../theme'
 
 import { RadioElement } from './RadioElement'
-import { DisplayType } from './types'
+import { BaseValueType, DisplayType } from './types'
 import { ITEM_GAP } from './constants'
 
-type RadioItemProps = {
+type RadioItemProps<Value extends BaseValueType = BaseValueType> = {
   name: string
-  value: string
+  value: Value
   label: string
   checked: boolean
-  onChange: (value: string) => void
+  onChange: (value: Value) => void
   displayType: DisplayType
   isError: boolean
 }
 
-export const RadioItem: FC<RadioItemProps> = ({
+export const RadioItem = <Value extends BaseValueType>({
   name,
   label,
   value,
@@ -26,7 +26,7 @@ export const RadioItem: FC<RadioItemProps> = ({
   onChange,
   displayType,
   isError,
-}) => {
+}: RadioItemProps<Value>) => {
   const id = useUniqueId()
   return (
     <Wrapper htmlFor={id} checked={checked} displayType={displayType}>

--- a/src/RadioGroup/types.ts
+++ b/src/RadioGroup/types.ts
@@ -1,1 +1,3 @@
 export type DisplayType = 'normal' | 'vertical-card' | 'horizontal-card'
+
+export type BaseValueType = string | boolean


### PR DESCRIPTION
## What does this do?

Improved typing for the prop `value`, it should now infer what is the correct type and can be more precise than `string` when possible. The type of `value` is shared and used for both the prop `value` and `onChange`

- When the type is only `string`
![Screenshot 2022-09-06 at 11 33 13](https://user-images.githubusercontent.com/14129033/188614767-777554ec-3086-4250-a23a-2d3f89eb7f25.png)

- Using `boolean` as value
![Screenshot 2022-09-06 at 11 32 45](https://user-images.githubusercontent.com/14129033/188614772-fbb1d2c8-c4e7-4443-b56f-0dc8ced4c08a.png)

- Having a subset of `string`
![Screenshot 2022-09-06 at 11 33 32](https://user-images.githubusercontent.com/14129033/188614763-8b0957cd-ece0-41c7-8ef2-026fbeb22595.png)


