### PR TITLE
fix Modal width

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -100,6 +100,7 @@ const Container = styled.div<IModalContainer>(
     box-sizing: border-box;
     border-radius: 8px;
     padding: 24px;
+    width: 100%;
     max-width: ${width};
     position: fixed;
     max-height: calc(100vh - 64px);

--- a/src/Modal/__tests__/__snapshots__/Modal.js.snap
+++ b/src/Modal/__tests__/__snapshots__/Modal.js.snap
@@ -93,6 +93,7 @@ exports[`renders 1`] = `
   box-sizing: border-box;
   border-radius: 8px;
   padding: 24px;
+  width: 100%;
   max-width: 460px;
   position: fixed;
   max-height: calc(100vh - 64px);


### PR DESCRIPTION
## What does this do?

Here's the current behaviour, when the content doesn't have any hard constraints that would push the modal to it's max-width:
<img width="897" alt="Screenshot 2022-09-06 at 13 17 48" src="https://user-images.githubusercontent.com/14129033/188633682-8045385c-c292-412c-b37a-7e1d3c65713e.png">

I believe, the default behaviour should be that the content is always at the max-width by default
