### PR TITLE
Remove unwanted spacing above the label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.7.1] - 2022-09-06
+### Changed
+- Fix `Modal` width
+- Fix field's label spacing
+
 ## [2.7.0] - 2022-09-06
 ### Added
 - New `RadioGroup` component

--- a/src/NumberInput/__tests__/__snapshots__/NumberInput.js.snap
+++ b/src/NumberInput/__tests__/__snapshots__/NumberInput.js.snap
@@ -168,18 +168,14 @@ exports[`renders - currency 1`] = `
   class="c0"
   id="currencyInput"
 >
-  <div
-    class="c1"
+  <label
+    class="c1 c2"
+    color="subtext"
+    cursor="inherit"
+    title=""
   >
-    <label
-      class="c2"
-      color="subtext"
-      cursor="inherit"
-      title=""
-    >
-      Currency
-    </label>
-  </div>
+    Currency
+  </label>
   <div
     class=""
   >
@@ -341,18 +337,14 @@ exports[`renders - disabled 1`] = `
   class="c0"
   id="currencyInput"
 >
-  <div
-    class="c1"
+  <label
+    class="c1 c2"
+    color="subtext"
+    cursor="inherit"
+    title=""
   >
-    <label
-      class="c2"
-      color="subtext"
-      cursor="inherit"
-      title=""
-    >
-      Currency
-    </label>
-  </div>
+    Currency
+  </label>
   <div
     class=""
   >
@@ -554,18 +546,14 @@ exports[`renders - error 1`] = `
   class="c0"
   id="currencyInput"
 >
-  <div
-    class="c1"
+  <label
+    class="c1 c2"
+    color="subtext"
+    cursor="inherit"
+    title=""
   >
-    <label
-      class="c2"
-      color="subtext"
-      cursor="inherit"
-      title=""
-    >
-      Currency
-    </label>
-  </div>
+    Currency
+  </label>
   <div
     class=""
   >
@@ -744,26 +732,22 @@ exports[`renders - number 1`] = `
   class="c0"
   id="numberInput"
 >
-  <div
-    class="c1"
+  <label
+    class="c1 c2"
+    color="subtext"
+    cursor="inherit"
+    title=""
   >
-    <label
-      class="c2"
-      color="subtext"
+    Number
+    <span
+      class="c3"
+      color="error"
       cursor="inherit"
       title=""
     >
-      Number
-      <span
-        class="c3"
-        color="error"
-        cursor="inherit"
-        title=""
-      >
-        *
-      </span>
-    </label>
-  </div>
+      *
+    </span>
+  </label>
   <div
     class=""
   >
@@ -885,18 +869,14 @@ exports[`renders - tel 1`] = `
   class="c0"
   id="tel"
 >
-  <div
-    class="c1"
+  <label
+    class="c1 c2"
+    color="subtext"
+    cursor="inherit"
+    title=""
   >
-    <label
-      class="c2"
-      color="subtext"
-      cursor="inherit"
-      title=""
-    >
-      Telephone number
-    </label>
-  </div>
+    Telephone number
+  </label>
   <div
     class=""
   >
@@ -1026,18 +1006,14 @@ exports[`renders - with suffix 1`] = `
   class="c0"
   id="currencyInput"
 >
-  <div
-    class="c1"
+  <label
+    class="c1 c2"
+    color="subtext"
+    cursor="inherit"
+    title=""
   >
-    <label
-      class="c2"
-      color="subtext"
-      cursor="inherit"
-      title=""
-    >
-      Currency
-    </label>
-  </div>
+    Currency
+  </label>
   <div
     class=""
   >
@@ -1195,18 +1171,14 @@ exports[`renders - with trailing icon 1`] = `
   class="c0"
   id="currencyInput"
 >
-  <div
-    class="c1"
+  <label
+    class="c1 c2"
+    color="subtext"
+    cursor="inherit"
+    title=""
   >
-    <label
-      class="c2"
-      color="subtext"
-      cursor="inherit"
-      title=""
-    >
-      Currency
-    </label>
-  </div>
+    Currency
+  </label>
   <div
     class=""
   >

--- a/src/SearchInput/__tests__/__snapshots__/SearchInput.js.snap
+++ b/src/SearchInput/__tests__/__snapshots__/SearchInput.js.snap
@@ -114,18 +114,14 @@ exports[`renders 1`] = `
   class="c0"
   id="days"
 >
-  <div
-    class="c1"
+  <label
+    class="c1 c2"
+    color="subtext"
+    cursor="inherit"
+    title=""
   >
-    <label
-      class="c2"
-      color="subtext"
-      cursor="inherit"
-      title=""
-    >
-      Days
-    </label>
-  </div>
+    Days
+  </label>
   <div
     class=""
   >

--- a/src/Textarea/__tests__/__snapshots__/Textarea.js.snap
+++ b/src/Textarea/__tests__/__snapshots__/Textarea.js.snap
@@ -55,18 +55,14 @@ exports[`disabled 1`] = `
   class="c0"
   id="textarea_id"
 >
-  <div
-    class="c1"
+  <label
+    class="c1 c2"
+    color="subtext"
+    cursor="inherit"
+    title=""
   >
-    <label
-      class="c2"
-      color="subtext"
-      cursor="inherit"
-      title=""
-    >
-      Textarea label
-    </label>
-  </div>
+    Textarea label
+  </label>
   <div
     class=""
   >
@@ -136,18 +132,14 @@ exports[`renders 1`] = `
   class="c0 Textarea"
   id="textarea_id"
 >
-  <div
-    class="c1"
+  <label
+    class="c1 c2"
+    color="subtext"
+    cursor="inherit"
+    title=""
   >
-    <label
-      class="c2"
-      color="subtext"
-      cursor="inherit"
-      title=""
-    >
-      Textarea label
-    </label>
-  </div>
+    Textarea label
+  </label>
   <div
     class=""
   >
@@ -229,18 +221,14 @@ exports[`renders with error 1`] = `
   class="c0"
   id="textarea_id"
 >
-  <div
-    class="c1"
+  <label
+    class="c1 c2"
+    color="subtext"
+    cursor="inherit"
+    title=""
   >
-    <label
-      class="c2"
-      color="subtext"
-      cursor="inherit"
-      title=""
-    >
-      Textarea label
-    </label>
-  </div>
+    Textarea label
+  </label>
   <div
     class=""
   >

--- a/src/fields/components/InternalField.tsx
+++ b/src/fields/components/InternalField.tsx
@@ -52,16 +52,20 @@ export const InternalField = ({
               )}
             </Box>
           ) : (
-            <Box mb={{ custom: outlined ? 4 : 0 }}>
-              <Text tag="label" typo="label" color="subtext" htmlFor={htmlFor}>
-                {label}
-                {required && (
-                  <Text tag="span" typo="body-small" color="error">
-                    *
-                  </Text>
-                )}
-              </Text>
-            </Box>
+            <Text
+              tag="label"
+              typo="label"
+              color="subtext"
+              htmlFor={htmlFor}
+              mb={{ custom: outlined ? 4 : 0 }}
+            >
+              {label}
+              {required && (
+                <Text tag="span" typo="body-small" color="error">
+                  *
+                </Text>
+              )}
+            </Text>
           )}
         </>
       )}


### PR DESCRIPTION
## What does this do?
<img width="186" alt="Screenshot 2022-09-06 at 16 27 18" src="https://user-images.githubusercontent.com/14129033/188677231-fefdfc56-bde1-4286-81d4-a8cf6cd7e9ee.png">

<img width="223" alt="Screenshot 2022-09-06 at 16 27 23" src="https://user-images.githubusercontent.com/14129033/188677216-8c849e39-dc76-4d82-97e9-ddffaa016b45.png">
 
There is some unneeded space at the top of the label because of the `Box`