### PR TITLE
Add `value` prop to `SearchInput`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.7.3] - 2022-09-12
+### Changed
+- Add `value` prop to `SearchInput`
+
 ## [2.7.2] - 2022-09-08
 ### Changed
 - Add deprecated message for `Confirmation` and `RadioButton`
@@ -447,6 +451,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[2.7.3]: https://github.com/marshmallow-insurance/smores-react/compare/v2.7.2...v2.7.3
 [2.7.2]: https://github.com/marshmallow-insurance/smores-react/compare/v2.7.1...v2.7.2
 [2.7.1]: https://github.com/marshmallow-insurance/smores-react/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/marshmallow-insurance/smores-react/compare/v2.6.2...v2.7.0

--- a/src/SearchInput/SearchInput.tsx
+++ b/src/SearchInput/SearchInput.tsx
@@ -6,6 +6,7 @@ import { theme } from '../theme'
 import { Icon } from '../Icon'
 import { Field, CommonFieldProps } from '../fields/Field'
 import { useUniqueId } from '../utils/id'
+import { useControllableState } from '../utils/useControlledState'
 import { SearchOptions } from './SearchOptions'
 
 export type SearchInputItem = {
@@ -22,6 +23,7 @@ export interface SearchInputProps extends CommonFieldProps {
   showIcon?: boolean
   onBlur?: (e: FocusEvent<HTMLInputElement>) => void
   outlined?: boolean
+  value?: string
 }
 
 export const SearchInput: FC<SearchInputProps> = ({
@@ -36,11 +38,18 @@ export const SearchInput: FC<SearchInputProps> = ({
   showIcon = false,
   renderAsTitle = false,
   onBlur,
+  value,
   ...otherProps
 }) => {
   const id = useUniqueId(idProp)
   const [showOptions, setShowOptions] = useState(false)
-  const [selectedValue, setSelectedValue] = useState<string | null>(null)
+  const [selectedValue, setSelectedValue] = useControllableState<string | null>(
+    {
+      initialState: null,
+      stateProp: value,
+    },
+  )
+
   const [searchQuery, setSearchQuery] = useState<string | null>(null)
 
   const filteredList = useMemo(() => {

--- a/src/utils/useControlledState.ts
+++ b/src/utils/useControlledState.ts
@@ -1,0 +1,28 @@
+import type { SetStateAction } from 'react'
+import { useCallback, useState } from 'react'
+
+export const useControllableState = <StateType>({
+  initialState,
+  stateProp,
+}: {
+  initialState: StateType
+  stateProp: StateType | undefined
+}) => {
+  const [state, setState] = useState(initialState)
+
+  const returnedState = stateProp !== undefined ? stateProp : state
+  const returnedSetState = useCallback<
+    (state: SetStateAction<StateType>) => void
+  >(
+    (nextState) => {
+      if (stateProp !== undefined) {
+        return
+      }
+
+      setState(nextState)
+    },
+    [state, stateProp],
+  )
+
+  return [returnedState, returnedSetState] as const
+}


### PR DESCRIPTION
## What does this do?

- **Add `value` prop to `SearchInput`**
- **Implemented a `useControllableState`**: This logic can be re-used for our other form component at some point
When `stateProp` is `undefined`, we have an uncontrolled behaviour meaning that the state is handled inside the component
When `stateProp` is anything else, we have a controlled behaviour so the source of truth is now external and come from `value`