### PR TITLE
Fix searchInput when multiple items has the same value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## [2.8.5] - 2022-10-10
-## Added
+## [2.9.0] - 2022-10-11
+### Changed
+- Update SearchInput logic to select correct item when value is the same
 - Data attribute ID's for DatePicker items and Radio Items
 
 ## [2.8.4] - 2022-09-28
@@ -475,7 +476,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
-[2.8.5]: https://github.com/marshmallow-insurance/smores-react/compare/v2.8.4...v2.8.5
+[2.9.0]: https://github.com/marshmallow-insurance/smores-react/compare/v2.8.4...v2.9.0
 [2.8.4]: https://github.com/marshmallow-insurance/smores-react/compare/v2.8.3...v2.8.4
 [2.8.3]: https://github.com/marshmallow-insurance/smores-react/compare/v2.8.2...v2.8.3
 [2.8.2]: https://github.com/marshmallow-insurance/smores-react/compare/v2.8.1...v2.8.2

--- a/src/SearchInput/SearchInput.tsx
+++ b/src/SearchInput/SearchInput.tsx
@@ -70,7 +70,10 @@ export const SearchInput: FC<SearchInputProps> = ({
 
     if (selectedValue !== null) {
       return (
-        searchList.find((option) => option.value === selectedValue)?.label || ''
+        searchList.find(
+          (option) =>
+            option.label === selectedValue || option.value === selectedValue,
+        )?.label || ''
       )
     }
 
@@ -95,11 +98,11 @@ export const SearchInput: FC<SearchInputProps> = ({
     updateSearchQuery(nextValue)
   }
 
-  const handleSelect = (nextValue: string): void => {
+  const handleSelect = (nextValue: SearchInputItem): void => {
     updateSearchQuery(null)
 
-    setSelectedValue(nextValue)
-    onFound(nextValue)
+    setSelectedValue(nextValue.label)
+    onFound(nextValue.value)
   }
 
   return (

--- a/src/SearchInput/SearchOptions.tsx
+++ b/src/SearchInput/SearchOptions.tsx
@@ -9,7 +9,7 @@ type Option = {
 
 type SearchOptionsProps = {
   displayedList: Array<Option>
-  onSelect: (option: string) => void
+  onSelect: (option: Option) => void
   positionRelative: boolean
   outlined: boolean
 }
@@ -28,7 +28,7 @@ export const SearchOptions: FC<SearchOptionsProps> = ({
       <ResultsList outlined={outlined}>
         {displayedList.length ? (
           displayedList.map((el, i) => (
-            <li key={i} onClick={() => onSelect(el.value)}>
+            <li key={i} onClick={() => onSelect(el)}>
               {el.label}
             </li>
           ))


### PR DESCRIPTION
## What does this do?

The SearchInput has an issue that if multiple items in the list has the same value when you select one of them it will always display the first of the list as label.

e.g. for countries `Britain`, `UK` and `United Kingdom` all has the same option value as `GB`. If you search and select `UK` the searchInput will always display `Britain` because it's the first label that he finds with `GB` value.

This PR fixes that so if you search for `UK`, `UK` will be displayed in the input. It will still select `Britain` for any persisted value that we pass to `SearchInput` because we essentially lose the label associated to the value the we pass down as a prop and will fallback to the first one he finds in the search list. Not really sure if there's a real fix for it unless we find a way to pass down both label and values to the component.
