### PR TITLE
Adds cursor pointer for radio item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.9.1] - 2022-10-12
+### Added
+- Cursor pointer for RadioItem
+
 ## [2.9.0] - 2022-10-11
 ### Changed
 - Update SearchInput logic to select correct item when value is the same
@@ -476,6 +480,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[2.9.1]: https://github.com/marshmallow-insurance/smores-react/compare/v2.9.0...v2.9.1
 [2.9.0]: https://github.com/marshmallow-insurance/smores-react/compare/v2.8.4...v2.9.0
 [2.8.4]: https://github.com/marshmallow-insurance/smores-react/compare/v2.8.3...v2.8.4
 [2.8.3]: https://github.com/marshmallow-insurance/smores-react/compare/v2.8.2...v2.8.3

--- a/src/RadioGroup/RadioItem.tsx
+++ b/src/RadioGroup/RadioItem.tsx
@@ -77,6 +77,7 @@ const Visual = styled.div<{ visualUrl: string }>`
 const Wrapper = styled.label<Pick<RadioItemProps, 'displayType' | 'checked'>>`
   display: flex;
   flex-direction: column;
+  cursor: pointer;
 
   ${({ displayType, checked }) =>
     css`


### PR DESCRIPTION
## Video
https://user-images.githubusercontent.com/99182828/195374983-34439baa-d351-4855-a8ec-bbc8bf9fbcac.mov

## What does this do?
- Adds `cursor: pointer` for `RadioItem` (as requested from Dmitry)
