### PR TITLE
Add fossa analysis step to CI

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,8 @@
+version: 3
+
+project:
+  id: smores-react
+  name: smores-react
+  url: https://github.com/marshmallow-insurance/smores-react
+  team: frontend
+  policy: Frontend Security Policy

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -20,16 +20,9 @@ jobs:
           npm ci
           npm run build-storybook
       - name: Fossa dependency analysis 🐛
+        uses: fossas/fossa-action@main
         with:
-          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
-        run: |
-          curl "https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh" -o "install-fossa-cli-latest.sh"
-          chmod +x ./install-fossa-cli-latest.sh 
-          ./install-fossa-cli-latest.sh
-          sudo apt-get install -y yq
-          
-          curl -X 'POST' 'https://app.fossa.com/api/teams' -H "Authorization: Bearer $FOSSA_API_KEY" -H 'accept: application/json' -H 'Content-Type: application/json' -d '{ "name": "'"$TEAM_NAME"'" }'
-          fossa analyze --team $(yq .service.owner opslevel.yml) --project smores-react --project-url https://github.com/marshmallow-insurance/smores-react --policy "Frontend Security Policy"
+          api-key: ${{ secrets.FOSSA_API_KEY }}
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -19,6 +19,17 @@ jobs:
         run: |
           npm ci
           npm run build-storybook
+      - name: Fossa dependency analysis 🐛
+        with:
+          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+        run: |
+          curl "https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh" -o "install-fossa-cli-latest.sh"
+          chmod +x ./install-fossa-cli-latest.sh 
+          ./install-fossa-cli-latest.sh
+          sudo apt-get install -y yq
+          
+          curl -X 'POST' 'https://app.fossa.com/api/teams' -H "Authorization: Bearer $FOSSA_API_KEY" -H 'accept: application/json' -H 'Content-Type: application/json' -d '{ "name": "'"$TEAM_NAME"'" }'
+          fossa analyze --team $(yq .service.owner opslevel.yml) --project smores-react --project-url https://github.com/marshmallow-insurance/smores-react --policy "Frontend Security Policy"
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:


### PR DESCRIPTION
[As requested here](https://eatmarshmallows.slack.com/archives/C8J3F9PN1/p1667389007431219?thread_ts=1667385398.687619&cid=C8J3F9PN1), this should run the fossa tool on every merge to main. We need to install the fossa CLI, and yq, then we use the FOSSA_API_KEY organization secret to run the analysis and upload it.