### PR TITLE
Optionally set active page as prop for pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.14.0] - 2023-01-30
+### Changed
+- Added optional currentPage prop for pagination
+
 ## [2.13.0] - 2023-01-25
 ### Changed
 - Add `gap`, `columnGap` and `rowGap` prop to `Box`
@@ -531,6 +535,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[2.14.0]: https://github.com/marshmallow-insurance/smores-react/compare/v2.13.0...v2.14.0
 [2.13.0]: https://github.com/marshmallow-insurance/smores-react/compare/v2.12.6...v2.13.0
 [2.12.6]: https://github.com/marshmallow-insurance/smores-react/compare/v2.12.5...v2.12.6
 [2.12.5]: https://github.com/marshmallow-insurance/smores-react/compare/v2.12.4...v2.12.5

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -18,12 +18,15 @@ export type PaginationProps = {
   partition: number
   /** Handle page change */
   handlePageChange: (page: number) => void
+  /** Set active page from component */
+  page?: number
 } & MarginProps
 
 export const Pagination: FC<PaginationProps> = ({
   total,
   partition,
   handlePageChange,
+  page,
   ...marginProps
 }) => {
   const [lastPage, setLastPage] = useState(0)
@@ -36,8 +39,12 @@ export const Pagination: FC<PaginationProps> = ({
   useEffect(() => {
     // This is a rather hacky fix, in theory it should be listening to total, but because the total comes from the same endpoint as the data, it forces a reset to 1 every time
     // Using lastPage seems to bypass that
-    setActivePage(1)
-  }, [lastPage])
+    if (page) {
+      setActivePage(page)
+    } else {
+      setActivePage(1)
+    }
+  }, [lastPage, page])
 
   useEffect(() => {
     const numberOfPages = Math.ceil(total / partition)

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -18,15 +18,15 @@ export type PaginationProps = {
   partition: number
   /** Handle page change */
   handlePageChange: (page: number) => void
-  /** Set page number */
-  page?: number
+  /** Sets current page number */
+  currentPage?: number
 } & MarginProps
 
 export const Pagination: FC<PaginationProps> = ({
   total,
   partition,
   handlePageChange,
-  page,
+  currentPage,
   ...marginProps
 }) => {
   const [lastPage, setLastPage] = useState(0)
@@ -39,12 +39,12 @@ export const Pagination: FC<PaginationProps> = ({
   useEffect(() => {
     // This is a rather hacky fix, in theory it should be listening to total, but because the total comes from the same endpoint as the data, it forces a reset to 1 every time
     // Using lastPage seems to bypass that
-    if (page) {
-      setActivePage(page)
+    if (currentPage) {
+      setActivePage(currentPage)
     } else {
       setActivePage(1)
     }
-  }, [lastPage, page])
+  }, [lastPage, currentPage])
 
   useEffect(() => {
     const numberOfPages = Math.ceil(total / partition)

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -18,7 +18,7 @@ export type PaginationProps = {
   partition: number
   /** Handle page change */
   handlePageChange: (page: number) => void
-  /** Set active page from component */
+  /** Set page number */
   page?: number
 } & MarginProps
 


### PR DESCRIPTION
## Screenshot / video


https://user-images.githubusercontent.com/57456071/215477913-abd08fcb-bb84-4104-8681-6ba4f8f4b67b.mov



## What does this do?

- Allows page number to be optionally passed from where the component is being used, allowing for active page to be maintained on hard refresh
- Previously we only store activePage in state & hard refresh always results in active page to be set to 1
