### PR TITLE
feat(version): bump to v2.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "2.15.1",
+  "version": "2.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mrshmllw/smores-react",
-      "version": "2.15.1",
+      "version": "2.16.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^2.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "2.15.1",
+  "version": "2.16.0",
   "main": "./dist/index.js",
   "description": "Collection of React components used by Marshmallow Technology",
   "keywords": [


### PR DESCRIPTION
## What does this do?

Release version 2.16.0 to allow the use of the new `Tooltip` component