### PR TITLE
feat(accordion): defaultIsOpen prop for accordion status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.17.0] - 2023-02-16
+### Changed
+- Added optional default position to `Accordion` component
 ## [2.16.0] - 2023-02-13
 ### Changed
 - Added Tooltip

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -14,18 +14,20 @@ export type AccordionProps = {
   fullBorder?: boolean
   onToggle?: (isOpen: boolean) => void
   children: ReactNode
+  defaultIsOpen?: boolean
 } & MarginProps
 
 export const Accordion: FC<AccordionProps> = ({
   title,
   children,
   onToggle,
+  defaultIsOpen = false,
   borderTop = false,
   subTitle,
   fullBorder = false,
   ...marginProps
 }) => {
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(defaultIsOpen)
   const px = fullBorder ? '16px' : '0'
 
   const handleToggle = () => {


### PR DESCRIPTION
## Screenshot / video
Usage in action:
<img width="1371" alt="Screenshot 2023-02-16 at 11 00 04" src="https://user-images.githubusercontent.com/5758372/219347298-ce159022-7ce9-4df3-be09-31948e5c5362.png">

Figma design for CMS
<img width="714" alt="Screenshot 2023-02-16 at 11 00 45" src="https://user-images.githubusercontent.com/5758372/219347427-677bbaed-4e35-409b-a82f-822bdeb2a043.png">

## What does this do?

Adding the ability to set the default open/close status for the `Accordion` component due to CMS needing this component to be open by default. This shouldn't affect any current usage of the `Accordion` component as the default is set to `false`
