### PR TITLE
Update auto approve workflow to use GITHUB_OUTPUT env file

### DIFF
--- a/.github/workflows/autoApproveDependabotPullRequests.yml
+++ b/.github/workflows/autoApproveDependabotPullRequests.yml
@@ -21,7 +21,7 @@ jobs:
               version-update:semver-minor) should_run=true ;;
               *) should_run=false ;;
           esac
-          echo ::set-output name=should_run::$should_run
+          echo should_run=$should_run >> $GITHUB_OUTPUT
       - name: Approve Pull Request
         if: steps.should-run.outputs.should_run == 'true'
         uses: hmarr/auto-approve-action@5d04a5ca6da9aeb8ca9f31a5239b96fc3e003029


### PR DESCRIPTION
The [set-output command is deprecated for removal](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/). This PR updates the auto approve workflow to use the GITHUB_OUTPUT env file instead.
This has been tested on the [uk-auto-quote-search](https://github.com/marshmallow-insurance/uk-auto-quote-search/blob/main/.github/workflows/autoApproveDependabotPullRequests.yml) repository.
<sub>PR generated using [multi-gitter](https://github.com/lindell/multi-gitter) from [this config file](https://github.com/marshmallow-insurance/Platform-multi-git-changes/blob/main/github-output-env-file/github-output-env-file.yaml)</sub>
