### PR TITLE
fix(field): only display error if we also have a message

### DIFF
--- a/src/fields/components/InternalField.tsx
+++ b/src/fields/components/InternalField.tsx
@@ -69,7 +69,7 @@ export const InternalField = ({
 
       <Box>{children}</Box>
 
-      {error && (
+      {error && errorMsg && (
         <Text tag="span" typo="caption" color="error" mt="8px">
           {errorMsg}
         </Text>


### PR DESCRIPTION
## What does this do?

Remove the `Text` component that adds margin to the bottom when there's no `errorMsg` provided.
