### PR TITLE
Allow modal content to be scrolled on mobile devices when body is locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.18.2] - 2023-03-15
+### Changed
+- Fixed modal scrolling on mobile
 ## [2.18.1] - 2023-03-10
 ### Added
 - Adding icons phone-outline, edit-contact, edit-outline, filter
@@ -581,6 +584,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[2.18.2]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1810...v2.18.2
 [2.18.1]: https://github.com/marshmallow-insurance/smores-react/compare/v2.18.0...v2.18.1
 [2.18.0]: https://github.com/marshmallow-insurance/smores-react/compare/v2.17.8...v2.18.0
 [2.17.8]: https://github.com/marshmallow-insurance/smores-react/compare/v2.17.7...v2.17.8

--- a/src/Modal/useBodyScrollLock.ts
+++ b/src/Modal/useBodyScrollLock.ts
@@ -20,7 +20,10 @@ export default function useBodyScrollLock({
     if (node === null) return
 
     if (showModal) {
-      disableBodyScroll(node, { reserveScrollBarGap: true })
+      disableBodyScroll(node, {
+        reserveScrollBarGap: true,
+        allowTouchMove: () => true,
+      })
     } else {
       enableBodyScroll(node)
     }


### PR DESCRIPTION
## What does this do?

On mobile devices, body scroll lock works differently than on desktop and it was preventing to scroll inside the modal.
You could scroll using two fingers but it's very unintuitive, updated the options of the bodyScroll plugin to allow touchMove
