### PR TITLE
fix(snackbar): setting the z-index so it's always ontop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.18.4] - 2023-03-28
+### Changed
+- Set the z-index on the snackbar container
+
 ## [2.18.3] - 2023-03-23
 ### Changed
 - Fixed fill colour in minimise and maximise icons
@@ -5,6 +9,7 @@
 ## [2.18.2] - 2023-03-15
 ### Changed
 - Fixed modal scrolling on mobile
+
 ## [2.18.1] - 2023-03-10
 ### Added
 - Adding icons phone-outline, edit-contact, edit-outline, filter
@@ -12,6 +17,7 @@
 ## [2.18.0] - 2023-03-07
 ### Added
 - New Snackbar component
+
 ## [2.17.8] - 2023-03-07
 ### Changed
 - Removed modal animation

--- a/src/Snackbar/SnackbarContainer.tsx
+++ b/src/Snackbar/SnackbarContainer.tsx
@@ -71,4 +71,5 @@ const SnackbarWrapper = styled.div`
   margin: 0 auto;
   width: 90%;
   max-width: 875px;
+  z-index: 99;
 `


### PR DESCRIPTION
## What does this do?

Updating the `SnackbarContainer` to always be ontop with `z-index` 