### PR TITLE
chore(version): bump from v2.18.3 to v2.18.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -594,7 +594,9 @@
 ### Changed
 - Updated gap and styles on Row component
 
-[2.18.2]: https://github.com/marshmallow-insurance/smores-react/compare/v2.1810...v2.18.2
+[2.18.4]: https://github.com/marshmallow-insurance/smores-react/compare/v2.18.3...v2.18.4
+[2.18.3]: https://github.com/marshmallow-insurance/smores-react/compare/v2.18.2...v2.18.3
+[2.18.2]: https://github.com/marshmallow-insurance/smores-react/compare/v2.18.1...v2.18.2
 [2.18.1]: https://github.com/marshmallow-insurance/smores-react/compare/v2.18.0...v2.18.1
 [2.18.0]: https://github.com/marshmallow-insurance/smores-react/compare/v2.17.8...v2.18.0
 [2.17.8]: https://github.com/marshmallow-insurance/smores-react/compare/v2.17.7...v2.17.8

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "2.18.3",
+  "version": "2.18.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mrshmllw/smores-react",
-      "version": "2.18.3",
+      "version": "2.18.4",
       "license": "MIT",
       "dependencies": {
         "body-scroll-lock": "^4.0.0-beta.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "2.18.3",
+  "version": "2.18.4",
   "main": "./dist/index.js",
   "description": "Collection of React components used by Marshmallow Technology",
   "keywords": [


### PR DESCRIPTION
## What does this do?

![image](https://user-images.githubusercontent.com/5758372/228226405-94cddab1-0d05-4f79-85bf-de46208a2ce0.png)

Bumplestiltskin (I'm struggling for ideas on messages for bump PRs)