### PR TITLE
GRW2716 - success state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.18.5] - UNRELEASED
+### Added
+- InternalField takes showStatus and status props
+- Internal field renders complete status
+
 ## [2.18.4] - 2023-03-28
 ### Changed
 - Set the z-index on the snackbar container

--- a/src/fields/Fieldset/Fieldset.stories.tsx
+++ b/src/fields/Fieldset/Fieldset.stories.tsx
@@ -39,3 +39,11 @@ WithSmallLabel.args = {
   ...defaultArgs,
   renderAsTitle: false,
 }
+
+export const WithStatus = Template.bind({})
+
+WithStatus.args = {
+  ...defaultArgs,
+  showStatus: true,
+  status: 'complete',
+}

--- a/src/fields/commonFieldTypes.ts
+++ b/src/fields/commonFieldTypes.ts
@@ -11,6 +11,8 @@ export interface CommonFieldProps extends MarginProps {
   required?: boolean
   error?: boolean
   errorMsg?: string
+  showStatus?: boolean
+  status?: 'complete' | null
 }
 
 export interface InternalCommonFieldProps extends CommonFieldProps {

--- a/src/fields/components/InternalField.tsx
+++ b/src/fields/components/InternalField.tsx
@@ -1,9 +1,10 @@
 import React, { ReactNode } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import { Text } from '../../Text'
 import { Box } from '../../Box'
 import { InternalCommonFieldProps } from '../commonFieldTypes'
+import { Icon } from '../../Icon'
 
 interface InternalFieldProps extends InternalCommonFieldProps {
   children: ReactNode
@@ -25,9 +26,12 @@ export const InternalField = ({
   error,
   errorMsg,
   required,
+  status,
+  showStatus,
   ...marginProps
 }: InternalFieldProps) => {
   const labelTag = fieldType === 'field' ? 'label' : 'legend'
+
   return (
     <Container
       as={fieldType === 'field' ? 'div' : 'fieldset'}
@@ -74,9 +78,34 @@ export const InternalField = ({
           {errorMsg}
         </Text>
       )}
+
+      {/* When status is null, a container is rendered to avoid layout shift */}
+      {!(error && errorMsg) && showStatus && status !== undefined && (
+        <StatusWrapper displayStatus={!!status} mt={'8px'}>
+          <Icon render="included" size={16} color="success" />
+          <Text typo="caption" color="success">
+            Complete
+          </Text>
+        </StatusWrapper>
+      )}
     </Container>
   )
 }
+
+const StatusWrapper = styled(Box)<{ displayStatus: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 0;
+  overflow: hidden;
+
+  ${({ displayStatus }) =>
+    displayStatus &&
+    css`
+      transition: width 0.6s ease-in;
+      width: 100%;
+    `}
+`
 
 const Container = styled(Box)`
   display: flex;


### PR DESCRIPTION
## Screenshot / video

![image](https://user-images.githubusercontent.com/126488797/230077369-2f83524b-9e6d-4a0f-b685-a338c3761b0f.png)

## What does this do?

Allows components using InternalField to render complete status
