### PR TITLE
fix(snackbar): use span tag for button content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.19.1] - 2023-04-27
+### Changed
+- Fixed snackbar button content to use a `span` tag
 ## [2.19.0] - 2023-04-24
 ### Added
 - Upgraded Storybook to v7
@@ -606,6 +609,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[2.19.1]: https://github.com/marshmallow-insurance/smores-react/compare/v2.19.0...v2.19.1
 [2.19.0]: https://github.com/marshmallow-insurance/smores-react/compare/v2.18.6...v2.19.0
 [2.18.6]: https://github.com/marshmallow-insurance/smores-react/compare/v2.18.5...v2.18.6
 [2.18.5]: https://github.com/marshmallow-insurance/smores-react/compare/v2.18.4...v2.18.5

--- a/src/Snackbar/SnackbarItem.tsx
+++ b/src/Snackbar/SnackbarItem.tsx
@@ -40,7 +40,7 @@ export const SnackbarItem: FC<Props> = ({
           {showCloseIcon ? (
             <Icon render="cross" size={16} color="white" />
           ) : (
-            <UnderlinedText typo="desc-medium" color="white">
+            <UnderlinedText tag="span" typo="desc-medium" color="white">
               Dismiss
             </UnderlinedText>
           )}


### PR DESCRIPTION
## What does this do?

Fix the snackbar `button` content to use a `span` for the text instead of the default `p`
