### PR TITLE
Update error message to be React Element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [2.19.1] - 2023-04-27
 ### Changed
 - Fixed snackbar button content to use a `span` tag
+- Added the ability to use ReactElements as error messages in form fields
 ## [2.19.0] - 2023-04-24
 ### Added
 - Upgraded Storybook to v7

--- a/src/TextInput/TextInput.stories.tsx
+++ b/src/TextInput/TextInput.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { TextInput, TextInputProps } from './TextInput'
+import { SupportMessage } from '../SupportMessage'
 import { Container } from './Container'
 import { noop } from '../utils/noop'
 
@@ -154,6 +155,21 @@ AssistiveText.args = {
   required: true,
   assistiveText: 'Some more information...',
   renderAsTitle: true,
+}
+
+export const WithReactElementError = Template.bind({})
+
+WithReactElementError.args = {
+  id: 'textInput',
+  name: 'textInput',
+  outlined: true,
+  label: 'with Support Message as Error',
+  placeholder: 'Placeholder text',
+  onChange: noop,
+  onInputChange: noop,
+  onBlur: noop,
+  error: true,
+  errorMsg: <SupportMessage type="warning" description="error!!" />,
 }
 
 const WorkingExampleTemplate = () => <Container />

--- a/src/fields/commonFieldTypes.ts
+++ b/src/fields/commonFieldTypes.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import { ReactNode, ReactElement } from 'react'
 import { MarginProps } from '../utils/space'
 
 export interface CommonFieldProps extends MarginProps {
@@ -10,7 +10,7 @@ export interface CommonFieldProps extends MarginProps {
   assistiveText?: string
   required?: boolean
   error?: boolean
-  errorMsg?: string
+  errorMsg?: string | ReactElement
   completed?: boolean
 }
 

--- a/src/fields/components/InternalField.tsx
+++ b/src/fields/components/InternalField.tsx
@@ -72,11 +72,15 @@ export const InternalField = ({
 
       <Box>{children}</Box>
 
-      {error && errorMsg && (
-        <Text tag="span" typo="caption" color="error" mt="8px">
-          {errorMsg}
-        </Text>
-      )}
+      {error &&
+        errorMsg &&
+        (typeof errorMsg === 'string' ? (
+          <Text tag="span" typo="caption" color="error" mt="8px">
+            {errorMsg}
+          </Text>
+        ) : (
+          <Box mt="8px">{errorMsg}</Box>
+        ))}
 
       {/* When completed is false, whitespace is rendered */}
       {completed !== undefined && (


### PR DESCRIPTION
## Screenshot / video

<img width="542" alt="Screenshot 2023-04-28 at 08 27 21" src="https://user-images.githubusercontent.com/1053476/235083164-d11be079-5f61-4327-b60c-d20ce6dbe218.png">


## What does this do?

Expand error message to be a react element. Needed for some Direct flow upgrades
