### PR TITLE
Add new IconStrict component and story

### DIFF
--- a/src/IconStrict/IconStrict.stories.tsx
+++ b/src/IconStrict/IconStrict.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { IconStrict, IconStrictProps } from './IconStrict'
+
+export default {
+  title: 'IconStrict',
+  component: IconStrict,
+}
+
+const Template = (props: IconStrictProps) => <IconStrict {...props} />
+
+export const Default = Template.bind({})
+
+Default.args = {
+  size: 48,
+  render: 'info',
+  backgroundColor: 'mascarpone',
+}
+
+export const AlternateColours = Template.bind({})
+
+AlternateColours.args = {
+  size: 48,
+  render: 'info',
+  iconColor: 'cream',
+  backgroundColor: 'marshmallowPink',
+}
+
+export const WithoutBackground = Template.bind({})
+
+WithoutBackground.args = {
+  size: 48,
+  render: 'info',
+}

--- a/src/IconStrict/IconStrict.tsx
+++ b/src/IconStrict/IconStrict.tsx
@@ -1,0 +1,84 @@
+import React, { FC } from 'react'
+import styled, { css } from 'styled-components'
+
+import { Icon } from '../Icon'
+import { MarginProps } from '../utils/space'
+import { Color, theme } from '../theme'
+
+export type IconStrictProps = {
+  /** className attribute to apply classes from props */
+  className?: string
+  /** set size of the Icon (including background) */
+  size?: 16 | 24 | 36 | 48
+  /** specify what Icon to render  */
+  render: string
+  /** set icon colour */
+  iconColor?: Color
+  /** set background colour */
+  backgroundColor?: Color
+  /** rotation degrees */
+  rotate?: number
+} & MarginProps
+
+const iconSizes = {
+  48: {
+    smallSize: 28,
+    padding: 10,
+  },
+  36: {
+    smallSize: 20,
+    padding: 8,
+  },
+  24: {
+    smallSize: 12,
+    padding: 6,
+  },
+  16: {
+    smallSize: 10,
+    padding: 3,
+  },
+}
+
+export const IconStrict: FC<IconStrictProps> = ({
+  className = '',
+  size = 16,
+  render,
+  iconColor,
+  backgroundColor,
+  rotate,
+  ...marginProps
+}) => (
+  <IconContainer
+    className={className}
+    size={size}
+    {...marginProps}
+    backgroundColor={backgroundColor}
+  >
+    <Icon
+      render={render}
+      className={className}
+      size={backgroundColor ? iconSizes[size].smallSize : size}
+      color={iconColor}
+      rotate={rotate}
+      {...marginProps}
+    />
+  </IconContainer>
+)
+
+interface IIconStrict {
+  size: 16 | 24 | 36 | 48
+  backgroundColor?: Color
+}
+
+const IconContainer = styled.div<IIconStrict>(
+  ({ size, backgroundColor }) => css`
+    padding: ${backgroundColor ? `${iconSizes[size].padding}px` : 0};
+    width: 100%;
+    max-width: ${size}px;
+    height: ${size}px;
+    border-radius: 100%;
+    background-color: ${backgroundColor
+      ? theme.colors[backgroundColor]
+      : 'none'};
+  `,
+)

--- a/src/IconStrict/README.md
+++ b/src/IconStrict/README.md
@@ -1,0 +1,23 @@
+# < IconStrict />
+
+## Props:
+
+```ts
+className?: string;
+render:   string; /* icon set */
+size?:    number; /* icon dimentions */
+iconColor?:   string; /* from theme */
+backgroundColor?: string; /* from theme */
+rotate?:  number; /* degrees */
+```
+
+## Usage
+This component is designed to provide strict sizes for the Icon component, and to render an optional background colour. If a background colour is provided, the Icon will be shrunk and the background will maintain the specified size.
+
+```js
+import {IconStrict} from '@mrshmllw/smores-react';
+
+const App = () => (
+  <IconStrict render='edit' backgroundColor="marshmallowPink" size={24} />
+);
+```

--- a/src/IconStrict/__tests__/IconStrict.js
+++ b/src/IconStrict/__tests__/IconStrict.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import 'jest-styled-components'
+
+import { IconStrict } from '../IconStrict'
+
+test('renders', () => {
+  const { container } = render(<IconStrict render="at" size="48" />)
+  expect(container.firstChild).toMatchSnapshot()
+})

--- a/src/IconStrict/__tests__/__snapshots__/IconStrict.js.snap
+++ b/src/IconStrict/__tests__/__snapshots__/IconStrict.js.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+}
+
+.c0 {
+  padding: 0;
+  width: 100%;
+  max-width: 48px;
+  height: 48px;
+  border-radius: 100%;
+  background-color: none;
+}
+
+<div
+  class="c0"
+  size="48"
+>
+  <span
+    class="c1"
+    color="liquorice"
+    rotate="0"
+    size="48"
+  >
+    <svg
+      fill="none"
+      height="100%"
+      viewBox="0 0 24 24"
+      width="100%"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 2C6.486 2 2 6.486 2 12s4.486 10 10 10a1 1 0 100-2c-4.411 0-8-3.589-8-8s3.589-8 8-8 8 3.589 8 8c0 1.103-.897 2-2 2s-2-.897-2-2c0-2.206-1.794-4-4-4s-4 1.794-4 4 1.794 4 4 4c1.2 0 2.266-.542 3-1.382.734.84 1.8 1.382 3 1.382 2.206 0 4-1.794 4-4 0-5.514-4.486-10-10-10zm0 12c-1.103 0-2-.897-2-2s.897-2 2-2 2 .897 2 2-.897 2-2 2z"
+        fill="#292924"
+      />
+    </svg>
+  </span>
+</div>
+`;

--- a/src/IconStrict/index.ts
+++ b/src/IconStrict/index.ts
@@ -1,0 +1,1 @@
+export * from './IconStrict'

--- a/src/colors.stories.tsx
+++ b/src/colors.stories.tsx
@@ -53,7 +53,7 @@ const thirdPartyBrand = [
 const ColorCard = ({ colorName }: { colorName: Color }) => {
   const hexValue = theme.colors[colorName]
   return (
-    <ColorCardWrapper width="180px">
+    <ColorCardWrapper width="224px">
       <ColorBox colorName={colorName} width="100%" pt={{ custom: '50%' }} />
       <Divider />
       <Box px="16px" py={{ custom: 4 }}>


### PR DESCRIPTION
## Screenshot / video

**With background:**
![image](https://github.com/marshmallow-insurance/smores-react/assets/34772985/5eff3bdd-08a3-4c00-8f50-246b65b8910b)

## What does this do?

Adds a new `IconStrict` component with strict sizes and an optional background colour. If a background colour is provided, the Icon is shrunk according to specified sizes.

Design document [here](https://www.notion.so/getmarshmallow/Iconography-f2b75f0162904dd89532a3af04871930)
FE RFC [here](https://www.notion.so/getmarshmallow/Iconography-ceb2bc82883b4f46a430e8ddd4b21da5)

- [x] Write tests
