### PR TITLE
Rebrand Buttons component

### DIFF
--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -21,7 +21,7 @@ export const Playground = Template.bind({})
 Playground.args = {
   primary: true,
   secondary: false,
-  tertiary: false,
+  fallback: false,
   disabled: false,
   loading: false,
   icon: '',

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -1,11 +1,9 @@
 import React, { FC, ReactNode, ButtonHTMLAttributes, forwardRef } from 'react'
 import styled, { css } from 'styled-components'
-import { darken } from 'polished'
 
-import { Color, theme } from '../theme'
+import { theme } from '../theme'
 import { focusOutline } from '../utils/focusOutline'
 import { useDeprecatedWarning } from '../utils/deprecated'
-import { LegacyButton } from './LegacyButton'
 import { Box } from '../Box'
 import { Loader } from '../Loader'
 import { Icon as IconComponent } from '../Icon'
@@ -15,16 +13,13 @@ type Props = {
   children: ReactNode
   id?: string
   className?: string
-  color?: Color
-  block?: boolean
-  inverted?: boolean
   disabled?: boolean
-  outlined?: boolean
   handleClick?: (e: React.FormEvent<HTMLButtonElement>) => void
   loading?: boolean
   primary?: boolean
   secondary?: boolean
   tertiary?: boolean
+  fallback?: boolean
   icon?: string
   forcedWidth?: string
   form?: string
@@ -42,16 +37,13 @@ export const Button: FC<ButtonProps> = forwardRef<
     children,
     id,
     className = '',
-    color = 'liquorice',
-    block = false,
-    inverted = false,
     disabled = false,
-    outlined = false,
     handleClick,
     loading = false,
     primary = false,
     secondary = false,
     tertiary = false,
+    fallback = false,
     icon = '',
     forcedWidth = '',
     form,
@@ -59,46 +51,26 @@ export const Button: FC<ButtonProps> = forwardRef<
     ...otherProps
   } = props
 
-  const isLegacyButton = !primary && !secondary && !tertiary
-
   useDeprecatedWarning({
-    enabled: isLegacyButton,
-    title: 'Legacy Button',
+    enabled: tertiary,
+    title: 'Tertiary prop usage',
     message:
-      "You're using the legacy Button component. Please use the new Button by providing one of the following props: 'primary', 'secondary', 'tertiary'.",
+      "You're using the tertiary prop which is now deprecated. Please use the new 'fallback' prop instead, or 'primary' or 'secondary' as appropriate.",
     componentProps: props,
   })
-
-  if (isLegacyButton) {
-    return (
-      <LegacyButton
-        id={id}
-        className={className}
-        color={color}
-        block={block}
-        inverted={inverted}
-        disabled={disabled}
-        outlined={outlined}
-        handleClick={(e) => {
-          handleClick && handleClick(e)
-        }}
-      >
-        {children}
-      </LegacyButton>
-    )
-  }
 
   return (
     <Container
       as="button"
       id={id}
       className={className}
-      disabled={disabled || loading}
+      disabled={disabled}
       onClick={handleClick}
       $loading={loading}
       primary={primary}
       secondary={secondary}
       tertiary={tertiary}
+      fallback={fallback}
       icon={icon}
       forcedWidth={forcedWidth}
       {...(form ? { form } : {})}
@@ -108,17 +80,11 @@ export const Button: FC<ButtonProps> = forwardRef<
     >
       {loading && (
         <LoaderContainer>
-          <Loader color={primary ? 'cream' : 'liquorice'} height="16" />
+          <Loader color={'liquorice'} height="16" />
         </LoaderContainer>
       )}
       <ContentContainer icon={icon} $loading={loading}>
-        {icon && (
-          <IconContainer
-            render={icon}
-            size={24}
-            color={primary ? 'cream' : 'liquorice'}
-          />
-        )}
+        {icon && <IconContainer render={icon} size={24} color={'liquorice'} />}
         <ChildrenContainer>{children}</ChildrenContainer>
       </ContentContainer>
     </Container>
@@ -130,23 +96,36 @@ Button.displayName = 'Button'
 type IButton = Required<
   Pick<
     ButtonProps,
-    'disabled' | 'primary' | 'secondary' | 'tertiary' | 'icon' | 'forcedWidth'
+    | 'disabled'
+    | 'primary'
+    | 'secondary'
+    | 'tertiary'
+    | 'icon'
+    | 'forcedWidth'
+    | 'fallback'
   >
 > & {
   $loading: NonNullable<ButtonProps['loading']>
 }
 
 const Container = styled(Box)<IButton>(
-  ({ disabled, $loading, primary, secondary, tertiary, forcedWidth }) => css`
+  ({
+    disabled,
+    $loading,
+    primary,
+    secondary,
+    tertiary,
+    forcedWidth,
+    fallback,
+  }) => css`
     ${focusOutline()}
     position: relative;
     background-color: ${theme.colors.marshmallowPink};
-    border: 2px solid;
     box-shadow: none;
     color: ${theme.colors.liquorice};
     padding: 0 20px;
     outline: none;
-    border-radius: 8px;
+    border-radius: 10000px;
     font-weight: ${theme.font.weight.medium};
     cursor: ${disabled || $loading ? 'not-allowed' : 'pointer'};
     line-height: 100%;
@@ -156,49 +135,35 @@ const Container = styled(Box)<IButton>(
 
     ${primary &&
     css`
-      color: ${theme.colors.cream};
-      border-color: ${theme.colors.marshmallowPink};
+      color: ${theme.colors.liquorice};
 
       &:hover {
-        background-color: ${!(disabled || $loading) &&
-        darken(0.1, theme.colors.marshmallowPink)};
-        border-color: ${!(disabled || $loading) &&
-        darken(0.1, theme.colors.marshmallowPink)};
+        background-color: ${!(disabled || $loading) && theme.colors.bubblegum};
       }
       &:active {
-        background-color: ${darken(0.1, theme.colors.marshmallowPink)};
-        border-color: ${darken(0.1, theme.colors.marshmallowPink)};
+        background-color: ${theme.colors.lollipop};
       }
     `}
     ${secondary &&
     css`
+      background-color: ${theme.colors.oatmeal};
+
+      &:hover {
+        background-color: ${!(disabled || $loading) && theme.colors.mascarpone};
+      }
+      &:active {
+        background-color: ${theme.colors.custard};
+      }
+    `}
+  ${(tertiary || fallback) &&
+    css`
       background-color: ${theme.colors.cream};
-      border-color: ${theme.colors.liquorice};
 
       &:hover {
         background-color: ${!(disabled || $loading) && theme.colors.coconut};
-        border: ${!(disabled || $loading) &&
-        `2px solid ${theme.colors.liquorice}`};
       }
       &:active {
-        background-color: ${theme.colors.coconut};
-        border: 2px solid ${theme.colors.liquorice};
-      }
-    `}
-  ${tertiary &&
-    css`
-      background-color: ${theme.colors.coconut};
-      border-color: ${theme.colors.coconut};
-
-      &:hover {
-        background-color: ${!(disabled || $loading) &&
-        darken(0.1, theme.colors.coconut)};
-        border-color: ${!(disabled || $loading) &&
-        darken(0.1, theme.colors.coconut)};
-      }
-      &:active {
-        background-color: ${darken(0.1, theme.colors.coconut)};
-        border-color: ${darken(0.1, theme.colors.coconut)};
+        background-color: ${theme.colors.mascarpone};
       }
     `}
   `,

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -2,7 +2,6 @@ import React, { FC, ReactNode, ButtonHTMLAttributes, forwardRef } from 'react'
 import styled, { css } from 'styled-components'
 
 import { theme } from '../theme'
-import { focusOutline } from '../utils/focusOutline'
 import { useDeprecatedWarning } from '../utils/deprecated'
 import { Box } from '../Box'
 import { Loader } from '../Loader'
@@ -20,7 +19,9 @@ type Props = {
   secondary?: boolean
   tertiary?: boolean
   fallback?: boolean
+  textBtn?: boolean
   icon?: string
+  trailingIcon?: boolean
   forcedWidth?: string
   form?: string
 }
@@ -44,7 +45,9 @@ export const Button: FC<ButtonProps> = forwardRef<
     secondary = false,
     tertiary = false,
     fallback = false,
+    textBtn = false,
     icon = '',
+    trailingIcon = false,
     forcedWidth = '',
     form,
     type,
@@ -71,7 +74,9 @@ export const Button: FC<ButtonProps> = forwardRef<
       secondary={secondary}
       tertiary={tertiary}
       fallback={fallback}
+      textBtn={textBtn}
       icon={icon}
+      trailingIcon={trailingIcon}
       forcedWidth={forcedWidth}
       {...(form ? { form } : {})}
       type={type}
@@ -84,8 +89,23 @@ export const Button: FC<ButtonProps> = forwardRef<
         </LoaderContainer>
       )}
       <ContentContainer icon={icon} $loading={loading}>
-        {icon && <IconContainer render={icon} size={24} color={'liquorice'} />}
+        {!trailingIcon && icon && (
+          <IconContainer
+            trailingIcon={trailingIcon}
+            render={icon}
+            size={24}
+            color={'liquorice'}
+          />
+        )}
         <ChildrenContainer>{children}</ChildrenContainer>
+        {trailingIcon && icon && textBtn && (
+          <IconContainer
+            trailingIcon={trailingIcon}
+            render={icon}
+            size={24}
+            color={'liquorice'}
+          />
+        )}
       </ContentContainer>
     </Container>
   )
@@ -103,6 +123,8 @@ type IButton = Required<
     | 'icon'
     | 'forcedWidth'
     | 'fallback'
+    | 'textBtn'
+    | 'trailingIcon'
   >
 > & {
   $loading: NonNullable<ButtonProps['loading']>
@@ -117,8 +139,8 @@ const Container = styled(Box)<IButton>(
     tertiary,
     forcedWidth,
     fallback,
+    textBtn,
   }) => css`
-    ${focusOutline()}
     position: relative;
     background-color: ${theme.colors.marshmallowPink};
     box-shadow: none;
@@ -166,6 +188,21 @@ const Container = styled(Box)<IButton>(
         background-color: ${theme.colors.mascarpone};
       }
     `}
+  ${textBtn &&
+    css`
+      background-color: transparent;
+      padding: 0;
+      border-radius: 0;
+      text-decoration: underline;
+
+      &:hover {
+        background-color: ${!(disabled || $loading) && theme.colors.fairyFloss};
+      }
+      &:active {
+        background-color: transparent;
+        color: ${theme.colors.sesame};
+      }
+    `}
   `,
 )
 
@@ -189,9 +226,11 @@ const ContentContainer = styled.div<
   opacity: ${({ $loading }) => ($loading ? '0' : '1')};
 `
 
-const IconContainer = styled(IconComponent)`
-  margin-right: 10px;
-`
+const IconContainer = styled(IconComponent)<Pick<ButtonProps, 'trailingIcon'>>(
+  ({ trailingIcon }) => css`
+    margin: ${trailingIcon ? '0 0 0 10px' : '0 10px 0 0'};
+  `,
+)
 
 const ChildrenContainer = styled.div`
   padding: 16px 0;

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -2,7 +2,6 @@ import React, { FC, ReactNode, ButtonHTMLAttributes, forwardRef } from 'react'
 import styled, { css } from 'styled-components'
 
 import { theme } from '../theme'
-import { useDeprecatedWarning } from '../utils/deprecated'
 import { Box } from '../Box'
 import { Loader } from '../Loader'
 import { Icon as IconComponent } from '../Icon'
@@ -17,7 +16,6 @@ type Props = {
   loading?: boolean
   primary?: boolean
   secondary?: boolean
-  tertiary?: boolean
   fallback?: boolean
   textBtn?: boolean
   icon?: string
@@ -43,7 +41,6 @@ export const Button: FC<ButtonProps> = forwardRef<
     loading = false,
     primary = false,
     secondary = false,
-    tertiary = false,
     fallback = false,
     textBtn = false,
     icon = '',
@@ -53,14 +50,6 @@ export const Button: FC<ButtonProps> = forwardRef<
     type,
     ...otherProps
   } = props
-
-  useDeprecatedWarning({
-    enabled: tertiary,
-    title: 'Tertiary prop usage',
-    message:
-      "You're using the tertiary prop which is now deprecated. Please use the new 'fallback' prop instead, or 'primary' or 'secondary' as appropriate.",
-    componentProps: props,
-  })
 
   return (
     <Container
@@ -72,7 +61,6 @@ export const Button: FC<ButtonProps> = forwardRef<
       $loading={loading}
       primary={primary}
       secondary={secondary}
-      tertiary={tertiary}
       fallback={fallback}
       textBtn={textBtn}
       icon={icon}
@@ -119,7 +107,6 @@ type IButton = Required<
     | 'disabled'
     | 'primary'
     | 'secondary'
-    | 'tertiary'
     | 'icon'
     | 'forcedWidth'
     | 'fallback'
@@ -136,7 +123,6 @@ const Container = styled(Box)<IButton>(
     $loading,
     primary,
     secondary,
-    tertiary,
     forcedWidth,
     fallback,
     textBtn,
@@ -177,7 +163,7 @@ const Container = styled(Box)<IButton>(
         background-color: ${theme.colors.custard};
       }
     `}
-  ${(tertiary || fallback) &&
+  ${fallback &&
     css`
       background-color: ${theme.colors.cream};
 

--- a/src/Button/Collection.tsx
+++ b/src/Button/Collection.tsx
@@ -8,7 +8,8 @@ import { Button, ButtonProps } from './Button'
 const buttonList: Array<ButtonProps> = [
   { primary: true, children: 'Save' },
   { secondary: true, children: 'Edit' },
-  { tertiary: true, children: 'Cancel' },
+  { fallback: true, children: 'Cancel' },
+  { textBtn: true, children: 'View' },
 ]
 
 export const CollectionPage: FC = () => {

--- a/src/Button/__tests__/Button.js
+++ b/src/Button/__tests__/Button.js
@@ -1,10 +1,10 @@
-import React from 'react';
-import {render} from '@testing-library/react';
-import 'jest-styled-components';
+import React from 'react'
+import { render } from '@testing-library/react'
+import 'jest-styled-components'
 
-import {Button} from '../Button';
+import { Button } from '../Button'
 
 test('renders', () => {
-  const {container} = render(<Button color="green" />);
-  expect(container.firstChild).toMatchSnapshot();
-});
+  const { container } = render(<Button color="green" />)
+  expect(container.firstChild).toMatchSnapshot()
+})

--- a/src/Button/__tests__/__snapshots__/Button.js.snap
+++ b/src/Button/__tests__/__snapshots__/Button.js.snap
@@ -2,34 +2,61 @@
 
 exports[`renders 1`] = `
 .c0 {
+  outline: 0;
   position: relative;
-  display: inline-block;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 8px;
-  font-size: 16px;
-  padding: 18px 16px 14px;
+  background-color: #FF88C8;
+  box-shadow: none;
+  color: #292924;
+  padding: 0 20px;
   outline: none;
-  cursor: pointer;
-  width: auto;
-  color: #FFFFFF;
+  border-radius: 10000px;
   font-weight: 500;
+  cursor: pointer;
+  line-height: 100%;
+  font-size: 16px;
+  opacity: 1;
+  width: auto;
 }
 
-.c0:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
+.c0:focus-visible {
+  outline: 2px solid #292924;
+  outline-offset: 2px;
 }
 
-@media (min-width:768px) {
-  .c0 {
-    padding: 16px 16px 15px;
-    font-size: 16px;
-  }
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  opacity: 1;
+}
+
+.c2 {
+  padding: 16px 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 <button
   class="c0"
   color="green"
-/>
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    />
+  </div>
+</button>
 `;

--- a/src/Button/__tests__/__snapshots__/Button.js.snap
+++ b/src/Button/__tests__/__snapshots__/Button.js.snap
@@ -2,7 +2,6 @@
 
 exports[`renders 1`] = `
 .c0 {
-  outline: 0;
   position: relative;
   background-color: #FF88C8;
   box-shadow: none;
@@ -16,11 +15,6 @@ exports[`renders 1`] = `
   font-size: 16px;
   opacity: 1;
   width: auto;
-}
-
-.c0:focus-visible {
-  outline: 2px solid #292924;
-  outline-offset: 2px;
 }
 
 .c1 {


### PR DESCRIPTION
## Screenshot / video

![image](https://github.com/marshmallow-insurance/smores-react/assets/34772985/8660af0c-21be-4650-aafc-007bebef4704)

## What does this do?

Updates the Buttons component and stories in line with the rebrand

- Update Button colours
- Deprecate `tertiary` style and replace with `fallback`
- Add `textBtn` style with optional `trailingIcon`

FE RFC [here](https://www.notion.so/getmarshmallow/Buttons-0f02e12343c049f2938819262b690fe9)
Design [here](https://www.figma.com/file/FqSaizGOyOzXFZNmZ4X0LGMn/branch/QtMe0nsVPpPkgqtdqd2Op2/%F0%9F%8D%AC-S'mores?type=design&node-id=13006-107162&mode=design&t=f0OWcvekbOrxyb72-0)
