### PR TITLE
Rebrand Link component and update storybook

### DIFF
--- a/src/CheckBox/__tests__/__snapshots__/CheckBox.js.snap
+++ b/src/CheckBox/__tests__/__snapshots__/CheckBox.js.snap
@@ -2,11 +2,11 @@
 
 exports[`renders 1`] = `
 <label
-  class="sc-gsFSXq eTvnet"
+  class="sc-iGgWBj dPltQv"
   id="MM_SMORES_0"
 >
   <span
-    class="sc-aXZVg sc-dcJsrY byxNQM cUWdtw"
+    class="sc-aXZVg sc-fqkvVR byxNQM exYCmj"
     color="liquorice"
     cursor="inherit"
     title=""
@@ -15,7 +15,7 @@ exports[`renders 1`] = `
     type="checkbox"
   />
   <span
-    class="sc-iGgWBj isvEjr"
+    class="sc-dcJsrY gILBME"
   />
 </label>
 `;

--- a/src/Link/Link.stories.tsx
+++ b/src/Link/Link.stories.tsx
@@ -19,6 +19,19 @@ const linkArgs = {
 export const Playground = Link.bind({})
 Playground.args = linkArgs
 
+export const Highlighted = Link.bind({})
+Highlighted.args = {
+  ...linkArgs,
+  highlight: true,
+}
+
+export const LeadingIcon = Link.bind({})
+LeadingIcon.args = {
+  ...linkArgs,
+  iconToRender: 'new-window',
+  trailingIcon: false,
+}
+
 const ParagraphDemo = (props: LinkProps) => (
   <Text tag="p" color="apple">
     Lorem Ipsum is simply dummy text of the printing and typesetting industry,

--- a/src/Link/Link.tsx
+++ b/src/Link/Link.tsx
@@ -18,7 +18,7 @@ export type LinkProps = {
   typo?: LinkTypo
   highlight?: boolean
   iconToRender?: string
-  trailingIcon?: boolean
+  isTrailingIcon?: boolean
 }
 
 export const Link: FC<LinkProps> = ({
@@ -31,7 +31,7 @@ export const Link: FC<LinkProps> = ({
   typo = 'regular',
   highlight = false,
   iconToRender = openInNewTab ? 'new-window' : '',
-  trailingIcon = true,
+  isTrailingIcon = true,
 }) => {
   return (
     <LinkWrapper
@@ -46,7 +46,7 @@ export const Link: FC<LinkProps> = ({
         target: '_blank',
       })}
     >
-      {iconToRender && !trailingIcon && (
+      {iconToRender && !isTrailingIcon && (
         <Icon
           mt={{ custom: '3px' }}
           mr={{ custom: '4px' }}
@@ -56,7 +56,7 @@ export const Link: FC<LinkProps> = ({
         />
       )}
       {children}
-      {iconToRender && trailingIcon && (
+      {iconToRender && isTrailingIcon && (
         <Icon
           mt={{ custom: '3px' }}
           ml={{ custom: '4px' }}

--- a/src/Link/Link.tsx
+++ b/src/Link/Link.tsx
@@ -16,6 +16,9 @@ export type LinkProps = {
   children?: ReactNode
   download?: boolean
   typo?: LinkTypo
+  highlight?: boolean
+  iconToRender?: string
+  trailingIcon?: boolean
 }
 
 export const Link: FC<LinkProps> = ({
@@ -26,6 +29,9 @@ export const Link: FC<LinkProps> = ({
   download,
   children,
   typo = 'regular',
+  highlight = false,
+  iconToRender = openInNewTab ? 'new-window' : '',
+  trailingIcon = true,
 }) => {
   return (
     <LinkWrapper
@@ -34,25 +40,37 @@ export const Link: FC<LinkProps> = ({
       onClick={onClick}
       download={download}
       typo={typo}
+      highlight={highlight}
       {...(openInNewTab && {
         rel: 'noopener noreferrer',
         target: '_blank',
       })}
     >
-      {children}
-      {openInNewTab && (
-        <StyledIcon
-          render="new-window"
+      {iconToRender && !trailingIcon && (
+        <Icon
+          mt={{ custom: '3px' }}
+          mr={{ custom: '4px' }}
+          render={iconToRender}
           size={typo === 'regular' ? 14 : 12}
-          color="marshmallowPink"
+          color={highlight ? 'lollipop' : 'liquorice'}
+        />
+      )}
+      {children}
+      {iconToRender && trailingIcon && (
+        <Icon
+          mt={{ custom: '3px' }}
+          ml={{ custom: '4px' }}
+          render={iconToRender}
+          size={typo === 'regular' ? 14 : 12}
+          color={highlight ? 'lollipop' : 'liquorice'}
         />
       )}
     </LinkWrapper>
   )
 }
 
-const LinkWrapper = styled.a<{ typo: LinkTypo }>(
-  ({ typo }) =>
+const LinkWrapper = styled.a<{ typo: LinkTypo; highlight: boolean }>(
+  ({ typo, highlight }) =>
     css`
       ${focusOutline()}
       display: inline-flex;
@@ -72,16 +90,16 @@ const LinkWrapper = styled.a<{ typo: LinkTypo }>(
 
       font-weight: ${theme.font.weight.medium};
       text-decoration: underline;
-      color: ${theme.colors.marshmallowPink};
+      color: ${highlight ? theme.colors.lollipop : theme.colors.liquorice};
 
       background: none;
       cursor: pointer;
 
       &:hover {
-        color: ${darken(0.1, theme.colors.marshmallowPink)};
+        color: ${theme.colors.sesame};
 
         path {
-          fill: ${darken(0.1, theme.colors.marshmallowPink)};
+          fill: ${theme.colors.sesame};
         }
       }
 
@@ -115,9 +133,4 @@ export const linkStyleOverride = ({ color }: { color: string }) => css`
       }
     }
   }
-`
-
-const StyledIcon = styled(Icon)`
-  margin-left: 4px;
-  margin-top: 3px;
 `


### PR DESCRIPTION
## Screenshot / video

![image](https://github.com/marshmallow-insurance/smores-react/assets/34772985/10ba9171-3120-418c-821a-ddd03d7b3afa)

## What does this do?

- Updates colours in line with rebrand
- Adds new `highlight` style
- Removes logic that renders new window icon if `openInNewTab` is `true`, and instead accept an optional `iconToRender` prop which accepts an icon string
- Default `iconToRender` to *new-window* if `openInNewTab` is `true` (this can be overridden by `iconToRender` string)
- Also add optional `isTrailingIcon` boolean property (true by default) and use this to render the icon after the link text if `true`, or before if `false`.
- Updates storybook

Figma [here](https://www.figma.com/file/FqSaizGOyOzXFZNmZ4X0LGMn/branch/QtMe0nsVPpPkgqtdqd2Op2/%F0%9F%8D%AC-S'mores?type=design&node-id=6862-26178&mode=design&t=vf4f4OrW36S5IfOL-0)
FE RFC [here](https://www.notion.so/getmarshmallow/Links-9605a5b45b154c96a9a78d495c0f2bca)