### PR TITLE
Modals rebrand

### DIFF
--- a/src/IconStrict/IconStrict.stories.tsx
+++ b/src/IconStrict/IconStrict.stories.tsx
@@ -31,3 +31,11 @@ WithoutBackground.args = {
   size: 48,
   render: 'info',
 }
+
+export const WithClickHandler = Template.bind({})
+WithClickHandler.args = {
+  size: 48,
+  render: 'info',
+  handleClick: () => alert('clicked'),
+  backgroundColor: 'mascarpone',
+}

--- a/src/IconStrict/IconStrict.tsx
+++ b/src/IconStrict/IconStrict.tsx
@@ -16,6 +16,8 @@ export type IconStrictProps = {
   iconColor?: Color
   /** set background colour */
   backgroundColor?: Color
+  /** function to handle click */
+  handleClick?: () => void
   /** rotation degrees */
   rotate?: number
 } & MarginProps
@@ -46,6 +48,7 @@ export const IconStrict: FC<IconStrictProps> = ({
   iconColor,
   backgroundColor,
   rotate,
+  handleClick,
   ...marginProps
 }) => (
   <IconContainer
@@ -53,6 +56,7 @@ export const IconStrict: FC<IconStrictProps> = ({
     size={size}
     {...marginProps}
     backgroundColor={backgroundColor}
+    onClick={handleClick}
   >
     <Icon
       render={render}
@@ -68,10 +72,11 @@ export const IconStrict: FC<IconStrictProps> = ({
 interface IIconStrict {
   size: 16 | 24 | 36 | 48
   backgroundColor?: Color
+  onClick?: () => void
 }
 
 const IconContainer = styled.div<IIconStrict>(
-  ({ size, backgroundColor }) => css`
+  ({ size, backgroundColor, onClick }) => css`
     padding: ${backgroundColor ? `${iconSizes[size].padding}px` : 0};
     width: 100%;
     max-width: ${size}px;
@@ -80,5 +85,6 @@ const IconContainer = styled.div<IIconStrict>(
     background-color: ${backgroundColor
       ? theme.colors[backgroundColor]
       : 'none'};
+    cursor: ${onClick ? 'pointer' : 'default'};
   `,
 )

--- a/src/IconStrict/__tests__/__snapshots__/IconStrict.js.snap
+++ b/src/IconStrict/__tests__/__snapshots__/IconStrict.js.snap
@@ -31,6 +31,7 @@ exports[`renders 1`] = `
   height: 48px;
   border-radius: 100%;
   background-color: none;
+  cursor: default;
 }
 
 <div

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -4,9 +4,9 @@ import { theme } from '../theme'
 import { createPortal } from 'react-dom'
 
 import { Box } from '../Box'
-import { Icon } from '../Icon'
 import { Text } from '../Text'
 import useBodyScrollLock from './useBodyScrollLock'
+import { IconStrict } from '../IconStrict'
 
 interface IModalWrapper {
   // showModal state
@@ -34,7 +34,6 @@ export type ModalProps = {
 
 export const Modal: FC<ModalProps> = ({
   title = '',
-  icon = '',
   children,
   showModal = false,
   handleClick,
@@ -63,17 +62,17 @@ export const Modal: FC<ModalProps> = ({
           mb="8px"
         >
           <TitleElements flex direction="column">
-            {icon !== '' && (
-              <Icon render={icon} size={42} color="liquorice" mb="16px" />
-            )}
             <Text tag="h2" typo="heading-small" align="left">
               {title}
             </Text>
           </TitleElements>
           {cross && (
-            <IconContainer onClick={handleClick}>
-              <Icon render="cross" color="liquorice" size={32} />
-            </IconContainer>
+            <IconStrict
+              render="cross"
+              backgroundColor="mascarpone"
+              handleClick={handleClick}
+              size={36}
+            />
           )}
         </Box>
         <Box flex direction="column">
@@ -112,10 +111,9 @@ const Overlay = styled.div`
 
 const Container = styled.div<IModalContainer>(
   ({ drawer, width }) => css`
-    background: ${theme.colors.cream};
-    border: 1px solid ${theme.colors.chia};
+    background: ${theme.colors.coconut};
     box-sizing: border-box;
-    border-radius: 8px;
+    border-radius: 16px;
     padding: 24px;
     width: 100%;
     max-width: ${width};
@@ -139,21 +137,6 @@ const Container = styled.div<IModalContainer>(
     `}
   `,
 )
-
-const IconContainer = styled.div`
-  cursor: pointer;
-  background: ${theme.colors.coconut};
-  border-radius: 32px;
-  margin-right: 8px;
-
-  &:hover {
-    background: ${theme.colors.coconut};
-  }
-
-  svg {
-    padding: 3px;
-  }
-`
 
 const TitleElements = styled(Box)`
   align-self: center;


### PR DESCRIPTION
## Screenshot / video

![image](https://github.com/marshmallow-insurance/smores-react/assets/34772985/4b76fd33-02f8-480e-96e6-ee46c7a529a4)

![image](https://github.com/marshmallow-insurance/smores-react/assets/34772985/16e38a74-e2f0-4292-842f-876f0e5465a0)

## What does this do?

- Adds an optional `handleClick` to the `IconStrict` component
- Replaces the close icon with an `IconStrict` cross
- Updates the modal background colour and border radius

Figma [here](https://www.figma.com/file/FqSaizGOyOzXFZNmZ4X0LGMn/%F0%9F%8D%AC-S'mores?type=design&node-id=12298-86498&mode=design&t=np57oGZ05tr5netD-0)
FE RFC [here](https://www.notion.so/getmarshmallow/Modals-1b6fe38e50e743378861c1d037dc1e30)
