### PR TITLE
Update CheckBox border radius and tick

### DIFF
--- a/src/CheckBox/CheckBox.tsx
+++ b/src/CheckBox/CheckBox.tsx
@@ -58,19 +58,34 @@ const Checkmark = styled.span<{ error?: boolean }>`
   box-sizing: border-box;
   border-radius: 1px;
 
+  &:before {
+    content: '';
+    position: absolute;
+    display: none;
+    top: 9px;
+    left: 5px;
+    width: 3px;
+    height: 8px;
+    border-radius: 4px;
+    background-color: ${theme.colors.cream};
+    -webkit-transform: rotate(316deg);
+    -ms-transform: rotate(316deg);
+    transform: rotate(316deg);
+  }
+
   &:after {
     content: '';
     position: absolute;
     display: none;
     top: 3px;
-    left: 7px;
-    width: 5px;
-    height: 12px;
-    border: solid white;
-    border-width: 0 2px 2px 0;
-    -webkit-transform: rotate(45deg);
-    -ms-transform: rotate(45deg);
-    transform: rotate(45deg);
+    left: 11px;
+    width: 3px;
+    height: 15px;
+    border-radius: 4px;
+    background-color: ${theme.colors.cream};
+    -webkit-transform: rotate(43deg);
+    -ms-transform: rotate(43deg);
+    transform: rotate(43deg);
   }
 `
 
@@ -92,6 +107,10 @@ const BoxContainer = styled.label`
       border: solid 1px ${theme.colors.liquorice};
     }
 
+    &:checked ~ ${Checkmark}:before {
+      display: block;
+    }
+
     &:checked ~ ${Checkmark}:after {
       display: block;
     }
@@ -108,6 +127,10 @@ const BoxContainer = styled.label`
 
   @media (min-width: 768px) {
     padding-left: 32px;
+  }
+
+  span {
+    border-radius: 4px;
   }
 `
 

--- a/src/CheckBox/__tests__/__snapshots__/CheckBox.js.snap
+++ b/src/CheckBox/__tests__/__snapshots__/CheckBox.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders 1`] = `
 <label
-  class="sc-iGgWBj dPltQv"
+  class="sc-iGgWBj iexDye"
   id="MM_SMORES_0"
 >
   <span
@@ -15,7 +15,7 @@ exports[`renders 1`] = `
     type="checkbox"
   />
   <span
-    class="sc-dcJsrY gILBME"
+    class="sc-dcJsrY hGMcyn"
   />
 </label>
 `;


### PR DESCRIPTION
## Screenshot / video

![image](https://github.com/marshmallow-insurance/smores-react/assets/34772985/8a4b75d2-6461-40b4-95a7-b20d4106c746)

## What does this do?

- Increases border-radius of CheckBox
- Uses a `before` pseudo element as well as `after` to render the rounded tick
