### PR TITLE
Update Link storybook trailing icon prop

### DIFF
--- a/src/Link/Link.stories.tsx
+++ b/src/Link/Link.stories.tsx
@@ -29,7 +29,7 @@ export const LeadingIcon = Link.bind({})
 LeadingIcon.args = {
   ...linkArgs,
   iconToRender: 'new-window',
-  trailingIcon: false,
+  isTrailingIcon: false,
 }
 
 const ParagraphDemo = (props: LinkProps) => (


### PR DESCRIPTION
## What does this do?

- Updates the storybook prop to use `isTrailingIcon`
