### PR TITLE
chore: changes to datepicker and snackbar for CMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.19.3] - 2023-07-04
+### Changed
+- Added End date to Datepicker
+- Added ability to show years on Datepicker
+- Added ability to open the date picker on the selected date or current month
+- Updated snackbar to always be on top with z-index
 ## [2.19.2] - 2023-06-06
 ### Changed
 - Added showDayLabels prop to Datepicker component

--- a/src/Datepicker/Datepicker.tsx
+++ b/src/Datepicker/Datepicker.tsx
@@ -10,6 +10,7 @@ import {
   isWithinInterval,
   getDaysInMonth,
   isWeekend,
+  isSameMonth,
 } from 'date-fns'
 
 import { Box } from '../Box'
@@ -38,6 +39,9 @@ export type DatepickerProps = {
   showDayLabels?: boolean
   disableWeekend?: boolean
   fromDate?: Date
+  endingDate?: Date
+  showYear?: boolean
+  showSelectedDate?: boolean
   range?: number
   onDateSelect: (date: string) => void
   onChange?: (value: Date) => void
@@ -49,6 +53,9 @@ export const Datepicker: FC<DatepickerProps> = ({
   disableWeekend = true,
   range = 14,
   fromDate = new Date(),
+  endingDate,
+  showYear = false,
+  showSelectedDate = false,
   onDateSelect,
   onChange,
   value,
@@ -57,14 +64,22 @@ export const Datepicker: FC<DatepickerProps> = ({
   // We want to make sure that the date is in the UK timezone,
   // this might need to be revisit when opening up to new countries
   const startDate = convertToUkDate(fromDate)
-  const endDate = addDays(startDate, range)
+  const endDate = endingDate ? endingDate : addDays(startDate, range)
   const availableMonths = getAvailableMonths(startDate, endDate)
+
+  const selectedDate = value ?? new Date()
 
   const [activeDay, setActiveDay] = useControllableState({
     initialState: undefined,
     stateProp: value,
   })
-  const [activeMonthIndex, setActiveMonth] = useState(0)
+  const [activeMonthIndex, setActiveMonth] = useState(
+    showSelectedDate
+      ? availableMonths.findIndex((month) =>
+          isSameMonth(month.date, selectedDate),
+        )
+      : 0,
+  )
 
   const handleSelectEvent = (date: Date) => {
     setActiveDay(date)
@@ -111,7 +126,8 @@ export const Datepicker: FC<DatepickerProps> = ({
         </Circle>
 
         <Heading tag="h4" typo="body-regular">
-          {availableMonths[activeMonthIndex].label}
+          {availableMonths[activeMonthIndex].label}{' '}
+          {showYear && `- ${getYear(availableMonths[activeMonthIndex].date)}`}
         </Heading>
 
         <Circle

--- a/src/Snackbar/SnackbarContainer.tsx
+++ b/src/Snackbar/SnackbarContainer.tsx
@@ -71,5 +71,5 @@ const SnackbarWrapper = styled.div`
   margin: 0 auto;
   width: 90%;
   max-width: 875px;
-  z-index: 99;
+  z-index: 1000;
 `


### PR DESCRIPTION
## Screenshot / video
![Screenshot 2023-07-04 at 11 01 02](https://github.com/marshmallow-insurance/smores-react/assets/5758372/ac021635-91b7-4369-8fad-8baeb50c4663)


## What does this do?

Changes to `Datepicker` and `SnackbarContainer` for CMS.

- Added ability to show the year on `Datepicker`
- Added ability to supply an end date to `Datepicker`
- Added ability to open the `Datepicker` on the current month or the selected value month
- Updated `SnackbarContainer` to always be ontop with z-index