### PR TITLE
Rebrand Typography and update tag

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -33,8 +33,8 @@ const GlobalStyle = createGlobalStyle`
   }
 
   @font-face {
-    font-family: 'ClearfaceITC';
-    src: url('https://uploads-ssl.webflow.com/5baa461315ee32413d16236d/60acf786bae02f4552bcb0d1_ITC%20-%20ClearfaceITCPro-Heavy.woff2') format('woff2');
+    font-family: 'MarshmallowYouth';
+    src: url('https://assets.marshmallow.com/fonts/MarshmallowYouth-Bold.woff2') format('woff2');
     font-weight: 700;
     font-style: normal;
   }

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -91,12 +91,12 @@ interface IAccordion {
 
 const Wrapper = styled(Box)<Omit<IAccordion, 'isOpen'>>(
   ({ borderTop, fullBorder, filledBackground }) => css`
-    border-bottom: 1px solid ${theme.colors.marzipan};
-    ${borderTop && `border-top: 1px solid ${theme.colors.marzipan};`}
+    border-bottom: 1px solid ${theme.colors.oatmeal};
+    ${borderTop && `border-top: 1px solid ${theme.colors.oatmeal};`}
 
     ${fullBorder &&
     css`
-      border: 1px solid ${theme.colors.marzipan};
+      border: 1px solid ${theme.colors.oatmeal};
       border-radius: 16px;
     `}
 

--- a/src/Accordion/__tests__/__snapshots__/Accordion.js.snap
+++ b/src/Accordion/__tests__/__snapshots__/Accordion.js.snap
@@ -41,7 +41,7 @@ exports[`renders 1`] = `
 }
 
 .c0 {
-  border-bottom: 1px solid #A1957C;
+  border-bottom: 1px solid #DAD2C4;
 }
 
 .c3 {

--- a/src/Banner/Banner.stories.tsx
+++ b/src/Banner/Banner.stories.tsx
@@ -82,6 +82,22 @@ const ChildComponent: FC = () => {
           Critical banner
         </Button>
       </Row>
+      <Row label="Success (do not auto close)">
+        <Button
+          primary
+          onClick={() => {
+            addBanner({
+              type: 'success',
+              topOffset: '64px',
+              leadingIcon: 'circle-tick',
+              message: 'Marshmallow Miles discount applied (no timeout)',
+              noTimeout: true,
+            })
+          }}
+        >
+          Success banner (no timeout)
+        </Button>
+      </Row>
     </Box>
   )
 }

--- a/src/Banner/BannerItem.tsx
+++ b/src/Banner/BannerItem.tsx
@@ -55,8 +55,10 @@ export const BannerItem: FC<Props> = ({
   canManuallyClose,
   showCloseIcon,
   deleteBanner,
+  noTimeout,
 }) => {
   const autoCloseBaner = () => {
+    if (noTimeout) return
     if (type !== 'critical') return deleteBanner(id)
     else {
       return

--- a/src/Banner/types.ts
+++ b/src/Banner/types.ts
@@ -10,6 +10,7 @@ export interface Banner {
   leadingIcon?: string
   canManuallyClose?: boolean
   showCloseIcon?: boolean
+  noTimeout?: boolean
 }
 
 export type CreateBanner = Omit<Banner, 'id'>

--- a/src/BrandCard/BrandCard.stories.tsx
+++ b/src/BrandCard/BrandCard.stories.tsx
@@ -57,7 +57,7 @@ BrandCardWithImageBelow.args = {
   alignVisual: 'left',
   visualBottom: true,
   bgColor: 'peanut',
-  tag: <Tag label="default tag" bgColor="fairyFloss" color="liquorice" />,
+  tag: <Tag label="new" bgColor="fairyFloss" color="liquorice" />,
   buttonAction: <Button fallback={true}>Tell me more</Button>,
   visual: placeHolderSvg,
 }

--- a/src/Card/Card.stories.tsx
+++ b/src/Card/Card.stories.tsx
@@ -105,7 +105,7 @@ CardWithImageWithTag.args = {
   leadingIcon: 'copy',
   maxWidth: '300px',
   visualHeight: '180px',
-  tag: <Tag label="default tag" bgColor="marzipan" color="cream" />,
+  tag: <Tag label="default" bgColor="feijoa" color="cream" />,
   buttonAction: (
     <Button primary={true} forcedWidth="100%">
       Default

--- a/src/Loader/Loader.stories.tsx
+++ b/src/Loader/Loader.stories.tsx
@@ -14,9 +14,9 @@ Default.args = {
   height: 32,
 }
 
-export const BigAndBlue = Template.bind({})
+export const BigLoader = Template.bind({})
 
-BigAndBlue.args = {
+BigLoader.args = {
   height: 54,
   color: 'liquorice',
 }

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -69,7 +69,7 @@ export const Modal: FC<ModalProps> = ({
           {cross && (
             <IconStrict
               render="cross"
-              backgroundColor="mascarpone"
+              backgroundColor="oatmeal"
               handleClick={handleClick}
               size={36}
             />

--- a/src/Tag/Collection.tsx
+++ b/src/Tag/Collection.tsx
@@ -14,19 +14,19 @@ const tagList: {
 }[] = [
   {
     title: 'default',
-    color: 'mascarpone',
-    bgColor: 'marzipan',
+    color: 'cream',
+    bgColor: 'feijoa',
     label: 'default',
   },
   {
     title: 'fallback',
     color: 'liquorice',
     bgColor: 'coconut',
-    label: 'default',
+    label: 'default (fallback)',
   },
   {
     title: 'inactive',
-    color: 'mascarpone',
+    color: 'cream',
     bgColor: 'sesame',
     label: 'disabled',
   },
@@ -38,7 +38,7 @@ const tagList: {
   },
   {
     title: 'success',
-    color: 'mascarpone',
+    color: 'cream',
     bgColor: 'apple',
     label: 'included',
   },
@@ -52,11 +52,11 @@ const tagList: {
     title: 'agentWarning',
     color: 'liquorice',
     bgColor: 'tangerine',
-    label: 'warning',
+    label: 'agent warning',
   },
   {
     title: 'error',
-    color: 'mascarpone',
+    color: 'cream',
     bgColor: 'strawberry',
     label: 'error',
   },

--- a/src/Tag/Tag.stories.tsx
+++ b/src/Tag/Tag.stories.tsx
@@ -13,8 +13,8 @@ export const Default = Template.bind({})
 
 Default.args = {
   label: 'This is a tag',
-  bgColor: 'apple',
-  borderColor: 'apple',
+  bgColor: 'feijoa',
+  borderColor: 'feijoa',
   color: 'cream',
 }
 
@@ -22,14 +22,6 @@ Default.argTypes = {
   theme: { table: { disable: true } },
   as: { table: { disable: true } },
   forwardedAs: { table: { disable: true } },
-}
-
-export const BgGradient = Template.bind({})
-
-BgGradient.args = {
-  label: 'This is a gradient background tag',
-  bgGradient: true,
-  color: 'cream',
 }
 
 export const Collection = CollectionPage.bind({})

--- a/src/Text/fontMapping.ts
+++ b/src/Text/fontMapping.ts
@@ -4,7 +4,7 @@ import { Typo } from './Text'
 export const fontStyleMapping: Record<Typo, string> = {
   'hero-alternate': `
     font-size: 40px;
-    font-family: 'ClearfaceITC';
+    font-family: 'MarshmallowYouth';
     font-weight: ${theme.font.weight.bold};
     line-height: 44px;
 

--- a/src/fontStyle.ts
+++ b/src/fontStyle.ts
@@ -27,8 +27,8 @@ export const FontStyle = createGlobalStyle`
   }
 
   @font-face {
-    font-family: 'ClearfaceITC';
-    src: url('https://uploads-ssl.webflow.com/5baa461315ee32413d16236d/60acf786bae02f4552bcb0d1_ITC%20-%20ClearfaceITCPro-Heavy.woff2') format('woff2');
+    font-family: 'MarshmallowYouth';
+    src: url('https://assets.marshmallow.com/fonts/MarshmallowYouth-Bold.woff2') format('woff2');
     font-weight: ${theme.font.weight.bold};
     font-style: normal;
   }


### PR DESCRIPTION
## Screenshot / video

![image](https://github.com/marshmallow-insurance/smores-react/assets/34772985/496d6da6-0ddd-4195-94fc-2dcbade078f4)

![image](https://github.com/marshmallow-insurance/smores-react/assets/34772985/3d189b2c-186e-415a-88a9-71f879ad1795)

![image](https://github.com/marshmallow-insurance/smores-react/assets/34772985/b3b5919f-0ee2-4626-a12d-2b741a54c0b1)

![image](https://github.com/marshmallow-insurance/smores-react/assets/34772985/602f0022-a0c7-4d8d-8a4f-efd58070dcac)

## What does this do?

- Adds new `MarshmallowYouth` font as the hero-alternate (replacing `ClearfaceITC`)
- Adds do `noTimeout` option to `Banner` component
- Updates `Accordion` border colour
- Updates `Tag` default colour
- Other small updates requested by design 
