### PR TITLE
fix (rebrand): Small rebrand fixes 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.0.5] - 2023-08-15
+### Changed
+- Update heading-alternate font family
+- Update default Divider colour to oatmeal
 ## [3.0.4] - 2023-10-03
 ### Changed
 - sets Tag component to have fixed height
@@ -648,6 +652,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[3.0.5]: https://github.com/marshmallow-insurance/smores-react/compare/v3.0.4...v3.0.5
 [3.0.4]: https://github.com/marshmallow-insurance/smores-react/compare/v3.0.3...v3.0.4
 [3.0.3]: https://github.com/marshmallow-insurance/smores-react/compare/v3.0.2...v3.0.3
 [3.0.2]: https://github.com/marshmallow-insurance/smores-react/compare/v3.0.1...v3.0.2

--- a/src/Divider/Divider.tsx
+++ b/src/Divider/Divider.tsx
@@ -13,7 +13,7 @@ export type DividerProps = {
 export const Divider: FC<DividerProps> = memo(function Divider({
   maxWidth = 'none',
   height = '1px',
-  color = 'chia',
+  color = 'oatmeal',
   ...marginProps
 }) {
   return (

--- a/src/Text/fontMapping.ts
+++ b/src/Text/fontMapping.ts
@@ -25,6 +25,7 @@ export const fontStyleMapping: Record<Typo, string> = {
   `,
   'heading-alternate': `
     font-size: 40px;
+    font-family: 'MarshmallowYouth';
     font-weight: ${theme.font.weight.bold};
     line-height: 40px;
   `,


### PR DESCRIPTION
## What does this do?

- Updates the `heading-alternate` font family to `MarshmallowYouth`
- Updates the default `Divider` colour to `oatmeal`
