### PR TITLE
Fix(rebrand): Fixes button type from default submit on datepicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.0.6] - 2023-08-17
+### Changed
+- Allow accordion background colours
+- Specify button type for Datepicker day buttons
+
 ## [3.0.5] - 2023-08-15
 ### Changed
 - Update heading-alternate font family
@@ -652,6 +657,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[3.0.6]: https://github.com/marshmallow-insurance/smores-react/compare/v3.0.5...v3.0.6
 [3.0.5]: https://github.com/marshmallow-insurance/smores-react/compare/v3.0.4...v3.0.5
 [3.0.4]: https://github.com/marshmallow-insurance/smores-react/compare/v3.0.3...v3.0.4
 [3.0.3]: https://github.com/marshmallow-insurance/smores-react/compare/v3.0.2...v3.0.3

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -12,9 +12,9 @@ export type AccordionProps = {
   subTitle?: string
   filledBackground?: boolean
   borderTop?: boolean
-  borderColor?: 'oatmeal' | 'custard' | 'cream'
+  borderColor?: 'oatmeal' | 'custard' | 'cream' | 'coconut'
   fullBorder?: boolean
-  backgroundColor?: 'oatmeal' | 'custard' | 'cream'
+  backgroundColor?: 'oatmeal' | 'custard' | 'cream' | 'coconut'
   onToggle?: (isOpen: boolean) => void
   children: ReactNode
   defaultIsOpen?: boolean
@@ -93,8 +93,8 @@ interface IAccordion {
   borderTop?: boolean
   fullBorder?: boolean
   filledBackground?: boolean
-  borderColor?: 'oatmeal' | 'custard' | 'cream'
-  backgroundColor?: 'oatmeal' | 'custard' | 'cream'
+  borderColor?: 'oatmeal' | 'custard' | 'cream' | 'coconut'
+  backgroundColor?: 'oatmeal' | 'custard' | 'cream' | 'coconut'
 }
 
 const Wrapper = styled(Box)<Omit<IAccordion, 'isOpen'>>(

--- a/src/Datepicker/DatesList.tsx
+++ b/src/Datepicker/DatesList.tsx
@@ -44,6 +44,7 @@ export const DatesList: FC<Props> = ({
       {items.map((item: Day, i) => (
         <ListButton
           key={i}
+          type="button"
           disabled={item.disabled}
           className={`ListButton ${item.active ? 'active' : ''}`}
           onClick={() => handleDateSelect(item.date)}


### PR DESCRIPTION
The button type was 'submit' by default and was causing the page submit on direct signup.
