### PR TITLE
fix: undoing type: "module" in package.json causing test errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.1.3] - 2023-09-14
+### Changed
+- undoing type: module in package.json
+
 ## [3.1.2] - 2023-09-14
 ### Changed
 - re-exporting removed props

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@mrshmllw/smores-react",
   "version": "3.1.2",
   "main": "./dist/index.js",
-  "type": "module",
   "description": "Collection of React components used by Marshmallow Technology",
   "keywords": [
     "react",


### PR DESCRIPTION
## Screenshot / video

N/A

## What does this do?

- this was causing `Serialized Error: { code: 'ERR_UNSUPPORTED_DIR_IMPORT'` in files on the latest versions