### PR TITLE
feat: adding more props to Table component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.1.7] - 2023-09-20
+### Changed
+- adds headerHeight, maxWidth, noDataContent, truncateContent, noWrapContent props to Table
+
 ## [3.1.6] - 2023-09-20
 ### Changed
 - adds Table component
@@ -691,6 +695,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[3.1.7]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.6...v3.1.7
 [3.1.6]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.5...v3.1.6
 [3.1.5]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.4...v3.1.5
 [3.1.4]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.3...v3.1.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mrshmllw/smores-react",
-      "version": "3.1.6",
+      "version": "3.1.7",
       "license": "MIT",
       "dependencies": {
         "body-scroll-lock": "^4.0.0-beta.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "3.1.7",
+  "version": "3.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mrshmllw/smores-react",
-      "version": "3.1.7",
+      "version": "3.1.6",
       "license": "MIT",
       "dependencies": {
         "body-scroll-lock": "^4.0.0-beta.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "main": "./dist/index.js",
   "description": "Collection of React components used by Marshmallow Technology",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "3.1.7",
+  "version": "3.1.6",
   "main": "./dist/index.js",
   "description": "Collection of React components used by Marshmallow Technology",
   "keywords": [

--- a/src/ActionDropdown/ActionDropdown.tsx
+++ b/src/ActionDropdown/ActionDropdown.tsx
@@ -2,9 +2,9 @@ import React, { FC, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Box } from '../Box'
-import { Text } from '../Text'
 import { Icon } from '../Icon'
-import { List, ActionListItem } from './List'
+import { Text } from '../Text'
+import { ActionListItem, List } from './List'
 
 import { Color, theme } from '../theme'
 import { MarginProps } from '../utils/space'
@@ -121,7 +121,7 @@ const OuterContainer = styled.div<IOpen>(
     max-height: ${open ? '235px' : '48px'};
     background-color: ${theme.colors.custard};
     overflow-y: ${open ? 'auto' : 'hidden'};
-    z-index: 2;
+    z-index: 4;
     transition: all 0.2s ease-in-out;
   `,
 )

--- a/src/ActionDropdown/__tests__/__snapshots__/ActionDropdown.js.snap
+++ b/src/ActionDropdown/__tests__/__snapshots__/ActionDropdown.js.snap
@@ -106,7 +106,7 @@ exports[`renders 1`] = `
   max-height: 48px;
   background-color: #F1E9DC;
   overflow-y: hidden;
-  z-index: 2;
+  z-index: 4;
   -webkit-transition: all 0.2s ease-in-out;
   transition: all 0.2s ease-in-out;
 }

--- a/src/Table/Table.stories.tsx
+++ b/src/Table/Table.stories.tsx
@@ -29,7 +29,7 @@ export const Default = Template.bind({})
 
 Default.args = {
   rowPadding: '12px',
-  columns: columns,
+  columns: columns.slice(0, 6),
   data,
   fixedHeader: true,
 }
@@ -42,6 +42,14 @@ BasicTable.args = {
   data,
 }
 
+export const TrucateContent = Template.bind({})
+
+TrucateContent.args = {
+  rowPadding: '12px',
+  columns: columns,
+  data,
+}
+
 export const OverflowTable = TemplateWithWrapper.bind({})
 
 OverflowTable.args = {
@@ -50,10 +58,44 @@ OverflowTable.args = {
   data,
 }
 
+export const NoDataTable = TemplateWithWrapper.bind({})
+
+NoDataTable.args = {
+  rowPadding: '12px',
+  columns: columns.slice(0, 4),
+  data: [],
+}
+
+const BorderBox = styled(Box)`
+  border: 1px dashed ${theme.colors.oatmeal};
+`
+export const CustomNoDataTable = TemplateWithWrapper.bind({})
+
+CustomNoDataTable.args = {
+  rowPadding: '0px',
+  columns: columns.slice(0, 5),
+  data: [],
+  noDataContent: (
+    <BorderBox flex justifyContent="center" my="24px" p="48px">
+      No data
+    </BorderBox>
+  ),
+}
+
 export const StaticHeader = TemplateWithWrapper.bind({})
 
 StaticHeader.args = {
   rowPadding: '12px',
+  columns: columns,
+  data,
+  fixedHeader: false,
+}
+
+export const ReallyLargeHeader = TemplateWithWrapper.bind({})
+
+ReallyLargeHeader.args = {
+  rowPadding: '12px',
+  headerHeight: '120px',
   columns: columns,
   data,
   fixedHeader: false,
@@ -98,7 +140,7 @@ SubRowsShowOnExpand.args = {
   rowPadding: '12px',
   columns: columns.slice(0, 4),
   data,
-  expandable: () => true,
+  expandable: (row: DataRow) => !!row.subRowData,
   subRows: {
     rows: (row: DataRow) => {
       if (!row.subRowData) return

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
+import { Text } from '../Text'
 import { TableHeader } from './components/TableHeader'
 import { TableRow } from './components/TableRow'
-import { StyledTable } from './components/commonComponents'
+import { StyledCell, StyledTable } from './components/commonComponents'
 import { TableProps } from './types'
 
 /**
@@ -33,6 +34,7 @@ import { TableProps } from './types'
  * @property {RowAction<T>[]} [rowActions] - Array of actions that can be performed on each row.
  * @property {string} [rowActionsMinWidth] - The minimum width for the row actions column.
  * @property {string} [rowPadding] - The padding for each row, essentially the height
+ * @property {string} [noDataContent] - The text to show when there is no available data to map through
  */
 export const Table = <T extends object>({
   columns,
@@ -41,6 +43,7 @@ export const Table = <T extends object>({
   expandable,
   subTable,
   subRows,
+  headerHeight,
   headerColor = 'mascarpone',
   rowColor = 'custard',
   stripedColor,
@@ -48,13 +51,17 @@ export const Table = <T extends object>({
   rowActions,
   rowActionsMinWidth,
   rowPadding,
+  noDataContent,
 }: TableProps<T>) => {
+  const showActionsCell = expandable || rowActions
+  const expandSubProp = showActionsCell ? columns.length + 1 : columns.length
   return (
     <StyledTable>
       <thead>
         <TableHeader
           columns={columns}
           fixedHeader={fixedHeader}
+          headerHeight={headerHeight}
           subTable={subTable}
           headerColor={headerColor}
           rowActions={rowActions}
@@ -63,22 +70,32 @@ export const Table = <T extends object>({
         />
       </thead>
       <tbody>
-        {data.map((row, rowIndex) => (
-          <TableRow
-            key={rowIndex}
-            rowData={row}
-            rowIndex={rowIndex}
-            columns={columns}
-            rowActions={rowActions}
-            stripedColor={stripedColor}
-            subTable={subTable}
-            subRows={subRows}
-            rowColor={rowColor}
-            rowBorderColor={rowBorderColor}
-            rowPadding={rowPadding}
-            expandable={expandable}
-          />
-        ))}
+        {data.length === 0 && (
+          <StyledCell colSpan={expandSubProp} rowPadding={rowPadding}>
+            {noDataContent ? (
+              noDataContent
+            ) : (
+              <Text align="center">No available data</Text>
+            )}
+          </StyledCell>
+        )}
+        {data.length !== 0 &&
+          data.map((row, rowIndex) => (
+            <TableRow
+              key={rowIndex}
+              rowData={row}
+              rowIndex={rowIndex}
+              columns={columns}
+              rowActions={rowActions}
+              stripedColor={stripedColor}
+              subTable={subTable}
+              subRows={subRows}
+              rowColor={rowColor}
+              rowBorderColor={rowBorderColor}
+              rowPadding={rowPadding}
+              expandable={expandable}
+            />
+          ))}
       </tbody>
     </StyledTable>
   )

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -22,6 +22,7 @@ import { TableProps } from './types'
  * @property {T[]} data - Array of data to be displayed in the table.
  * @property {TableColumn<T>[]} columns - Array of columns to display in the table.
  * @property {boolean} [fixedHeader=false] - If true, the table header will be fixed/sticky.
+ * @property {string} [headerHeight] - Sets the height of the header.
  * @property {function(T): boolean} [expandable] - A function to determine if a row is expandable.
  * @property {Color} [stripedColor] - If present, the table rows will have alternating colors.
  * @property {Color} [headerColor='mascarpone'] - The color for the table header.
@@ -33,8 +34,8 @@ import { TableProps } from './types'
  * @property {boolean} [subRows.showOnExpand=false] - If true, the sub rows will only be shown when the row is expanded.
  * @property {RowAction<T>[]} [rowActions] - Array of actions that can be performed on each row.
  * @property {string} [rowActionsMinWidth] - The minimum width for the row actions column.
- * @property {string} [rowPadding] - The padding for each row, essentially the height
- * @property {string} [noDataContent] - The text to show when there is no available data to map through
+ * @property {string} [rowPadding] - The padding for each row, essentially the height.
+ * @property {string} [noDataContent] - The text to show when there is no available data to map through.
  */
 export const Table = <T extends object>({
   columns,

--- a/src/Table/components/RowActions.tsx
+++ b/src/Table/components/RowActions.tsx
@@ -23,13 +23,13 @@ export const RowActions = <T extends object>({
             if (!action.showCondition || action.showCondition(rowData)) {
               return (
                 <Wrapper flex key={actionIndex}>
-                  {isReactElement(action.label) &&
-                    React.cloneElement(action.label, {
+                  {isReactElement(action.element) &&
+                    React.cloneElement(action.element, {
                       onClick: () => action.onClick(rowData),
                       tabIndex: 0,
                       className: 'reactElementRowAction',
                     })}
-                  {action.genericButton && !isReactElement(action.label) && (
+                  {action.genericButton && !isReactElement(action.element) && (
                     <Button
                       {...action.genericButton}
                       handleClick={() => action.onClick(rowData)}

--- a/src/Table/components/TableHeader.tsx
+++ b/src/Table/components/TableHeader.tsx
@@ -7,6 +7,7 @@ export const TableHeader = <T extends object>({
   fixedHeader,
   headerColor,
   rowActions,
+  headerHeight,
   expandable,
   rowActionsMinWidth,
 }: TableHeaderProps<T>) => {
@@ -16,7 +17,9 @@ export const TableHeader = <T extends object>({
         <StyledHeaderCell
           key={columnIndex}
           fixedHeader={fixedHeader}
+          headerHeight={headerHeight}
           minWidth={column.minWidth}
+          maxWidth={column.maxWidth}
           headerColor={headerColor}
         >
           {column.name}

--- a/src/Table/components/TableRow.tsx
+++ b/src/Table/components/TableRow.tsx
@@ -52,7 +52,14 @@ export const TableRow = <T extends object>({
           }
 
           return (
-            <StyledCell key={columnIndex} rowPadding={rowPadding}>
+            <StyledCell
+              key={columnIndex}
+              rowPadding={rowPadding}
+              minWidth={column.minWidth}
+              maxWidth={column.maxWidth}
+              noWrapContent={column.noWrapContent}
+              truncateContent={column.truncateContent}
+            >
               {cellContent}
             </StyledCell>
           )

--- a/src/Table/components/commonComponents.tsx
+++ b/src/Table/components/commonComponents.tsx
@@ -19,8 +19,9 @@ export const StyledHeaderCell = styled.th<TableStylesProps>`
   z-index: 2;
   text-align: left;
   vertical-align: bottom;
-  padding: 8px;
   ${fontStyleMapping['label']};
+  padding-top: 8px;
+  padding-bottom: 8px;
 
   ${({ headerColor }) =>
     headerColor &&
@@ -48,7 +49,6 @@ export const StyledHeaderCell = styled.th<TableStylesProps>`
 `
 
 export const StyledCell = styled.td<TableStylesProps>`
-  padding: 8px;
   vertical-align: middle;
   overflow: hidden;
 
@@ -75,7 +75,8 @@ export const StyledCell = styled.td<TableStylesProps>`
   ${({ rowPadding }) =>
     rowPadding &&
     css`
-      padding: ${rowPadding};
+      padding-top: ${rowPadding};
+      padding-bottom: ${rowPadding};
     `};
 
   ${({ maxWidth }) =>

--- a/src/Table/components/commonComponents.tsx
+++ b/src/Table/components/commonComponents.tsx
@@ -5,6 +5,7 @@ import { TableStylesProps } from '../types'
 
 export const StyledTable = styled.table<TableStylesProps>`
   width: 100%;
+  height: 100%;
   border-collapse: collapse;
   overflow: auto;
   background: ${theme.colors.coconut};
@@ -27,6 +28,18 @@ export const StyledHeaderCell = styled.th<TableStylesProps>`
       background: ${theme.colors[headerColor]};
     `}
 
+  ${({ headerHeight }) =>
+    headerHeight &&
+    css`
+      height: ${headerHeight};
+    `}
+
+  ${({ maxWidth }) =>
+    maxWidth &&
+    css`
+      max-width: ${maxWidth};
+    `}
+
   ${({ minWidth }) =>
     minWidth &&
     css`
@@ -37,7 +50,20 @@ export const StyledHeaderCell = styled.th<TableStylesProps>`
 export const StyledCell = styled.td<TableStylesProps>`
   padding: 8px;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow: hidden;
+
+  ${({ noWrapContent }) =>
+    noWrapContent &&
+    css`
+      white-space: nowrap;
+    `};
+
+  ${({ truncateContent }) =>
+    truncateContent &&
+    css`
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    `};
 
   ${({ stickyCell }) =>
     stickyCell &&
@@ -51,6 +77,12 @@ export const StyledCell = styled.td<TableStylesProps>`
     css`
       padding: ${rowPadding};
     `};
+
+  ${({ maxWidth }) =>
+    maxWidth &&
+    css`
+      max-width: ${maxWidth};
+    `}
 `
 
 export const StyledRow = styled.tr<TableStylesProps>`

--- a/src/Table/components/commonComponents.tsx
+++ b/src/Table/components/commonComponents.tsx
@@ -51,6 +51,8 @@ export const StyledHeaderCell = styled.th<TableStylesProps>`
 export const StyledCell = styled.td<TableStylesProps>`
   vertical-align: middle;
   overflow: hidden;
+  padding-top: 8px;
+  padding-bottom: 8px;
 
   ${({ noWrapContent }) =>
     noWrapContent &&

--- a/src/Table/components/commonComponents.tsx
+++ b/src/Table/components/commonComponents.tsx
@@ -20,6 +20,8 @@ export const StyledHeaderCell = styled.th<TableStylesProps>`
   text-align: left;
   vertical-align: bottom;
   ${fontStyleMapping['label']};
+  padding-left: 8px;
+  padding-right: 8px;
   padding-top: 8px;
   padding-bottom: 8px;
 
@@ -51,6 +53,8 @@ export const StyledHeaderCell = styled.th<TableStylesProps>`
 export const StyledCell = styled.td<TableStylesProps>`
   vertical-align: middle;
   overflow: hidden;
+  padding-left: 8px;
+  padding-right: 8px;
   padding-top: 8px;
   padding-bottom: 8px;
 

--- a/src/Table/storyUtils.tsx
+++ b/src/Table/storyUtils.tsx
@@ -188,6 +188,8 @@ export const columns = [
     cell: (row: DataRow) => (
       <Button textBtn={row.evolves}>{row.evolves.toString()}</Button>
     ),
+    minWidth: '100px',
+    maxWidth: '100px',
   },
   {
     name: 'e.g1',
@@ -206,8 +208,9 @@ export const columns = [
   },
   {
     name: 'e.g4',
-    cell: () => 'example data4',
-    minWidth: '150px',
+    cell: () => 'really super long text that should be cut off',
+    maxWidth: '200px',
+    truncateContent: true,
   },
   {
     name: 'e.g5',

--- a/src/Table/types.ts
+++ b/src/Table/types.ts
@@ -1,24 +1,27 @@
-import { ReactElement } from 'react'
+import { ReactElement, ReactNode } from 'react'
 import { ButtonProps } from '../Button/Button'
 import { IconStrictProps } from '../IconStrict'
 import { Color } from '../theme'
 
 export type TableStylesProps = {
   fixedHeader?: boolean
+  headerHeight?: string
   stripedColor?: Color
   stickyCell?: boolean
   headerColor?: Color
   rowColor?: Color
   rowBorderColor?: Color
   minWidth?: string
+  maxWidth?: string
+  noWrapContent?: boolean
+  truncateContent?: boolean
   rowPadding?: string
 }
 
 export type Primitive = string | number | boolean | bigint
 
 export type RowAction<T> = {
-  //NOTE: what can i rename this too?
-  label?: ReactElement
+  element?: ReactElement
   onClick: (rowData: T) => void
   iconButton?: Pick<
     IconStrictProps,
@@ -48,11 +51,15 @@ type RowCellRenderer<T> = (
 export interface TableColumn<T> {
   name?: string | number | React.ReactNode
   minWidth?: string
+  maxWidth?: string
+  noWrapContent?: boolean
+  truncateContent?: boolean
   cell?: RowCellRenderer<T>
 }
 
 interface CommonTableProps<T> {
   columns: TableColumn<T>[]
+  headerHeight?: string
   fixedHeader?: boolean
   stripedColor?: Color
   expandable?: (rowData: T) => boolean
@@ -74,6 +81,7 @@ interface CommonTableProps<T> {
 
 export interface TableProps<T> extends CommonTableProps<T> {
   data: T[]
+  noDataContent?: ReactNode
 }
 
 export interface TableRowProps<T> extends CommonTableProps<T> {


### PR DESCRIPTION
## Screenshot / video

<img width="1064" alt="Screenshot 2023-09-20 at 14 50 01" src="https://github.com/marshmallow-insurance/smores-react/assets/57456071/b8ca299c-f059-47c3-9fc4-24e2e042b932">
<img width="1067" alt="Screenshot 2023-09-20 at 14 50 12" src="https://github.com/marshmallow-insurance/smores-react/assets/57456071/9ec5aa77-5346-453f-8359-9727705aa135">


## What does this do?

- adds headerHeight, maxWidth, noDataContent, truncateContent, noWrapContent props to Table
