### PR TITLE
fix: adding hideOverflow, rowActions bgColor, columnPadding, props to the Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [3.1.8] - 2023-09-21
 ### Changed
 - adds hideOverflow prop to Table, allowing for tooltips to be used
+- adds columnPadding prop
+- moves rowActions prop to its own objects, with bgColor and minWidth
 
 ## [3.1.7] - 2023-09-20
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.1.8] - 2023-09-21
+### Changed
+- adds hideOverflow prop to Table, allowing for tooltips to be used
+
 ## [3.1.7] - 2023-09-20
 ### Changed
 - adds headerHeight, maxWidth, noDataContent, truncateContent, noWrapContent props to Table
@@ -695,6 +699,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[3.1.8]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.7...v3.1.8
 [3.1.7]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.6...v3.1.7
 [3.1.6]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.5...v3.1.6
 [3.1.5]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.4...v3.1.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "3.1.8",
+  "version": "3.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mrshmllw/smores-react",
-      "version": "3.1.8",
+      "version": "3.1.7",
       "license": "MIT",
       "dependencies": {
         "body-scroll-lock": "^4.0.0-beta.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mrshmllw/smores-react",
-      "version": "3.1.7",
+      "version": "3.1.8",
       "license": "MIT",
       "dependencies": {
         "body-scroll-lock": "^4.0.0-beta.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "main": "./dist/index.js",
   "description": "Collection of React components used by Marshmallow Technology",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "3.1.8",
+  "version": "3.1.7",
   "main": "./dist/index.js",
   "description": "Collection of React components used by Marshmallow Technology",
   "keywords": [

--- a/src/Table/Table.stories.tsx
+++ b/src/Table/Table.stories.tsx
@@ -208,7 +208,7 @@ RowActions.args = {
     },
     showOnExpand: () => true,
   },
-  rowActions: { actions: rowActions },
+  rowActions: { actions: rowActions, bgColor: 'strawberry' },
 }
 
 export const EverythingTable = TemplateWithWrapper.bind({})

--- a/src/Table/Table.stories.tsx
+++ b/src/Table/Table.stories.tsx
@@ -177,7 +177,7 @@ SubTable.args = {
           headerColor="mascarpone"
           rowColor="matcha"
           fixedHeader={false}
-          rowActions={rowActions}
+          rowActions={{ actions: rowActions }}
         />
       )
     },
@@ -202,13 +202,13 @@ RowActions.args = {
           headerColor="mascarpone"
           rowColor="matcha"
           fixedHeader={false}
-          rowActions={rowActions}
+          rowActions={{ actions: rowActions }}
         />
       )
     },
     showOnExpand: () => true,
   },
-  rowActions: rowActions,
+  rowActions: { actions: rowActions },
 }
 
 export const EverythingTable = TemplateWithWrapper.bind({})
@@ -226,7 +226,7 @@ EverythingTable.args = {
           headerColor="mascarpone"
           rowColor="matcha"
           fixedHeader={false}
-          rowActions={rowActions}
+          rowActions={{ actions: rowActions }}
         />
       )
     },
@@ -244,7 +244,7 @@ EverythingTable.args = {
             columns={columns}
             rowColor="cream"
             rowBorderColor="chia"
-            rowActions={rowActions}
+            rowActions={{ actions: rowActions }}
           />
         )
       })
@@ -253,6 +253,9 @@ EverythingTable.args = {
   },
   rowColor: 'custard',
   headerColor: 'mascarpone',
-  rowActions: rowActions,
+  rowActions: {
+    actions: rowActions,
+    bgColor: 'custard',
+  },
   rowPadding: '4px',
 }

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -50,8 +50,8 @@ export const Table = <T extends object>({
   stripedColor,
   rowBorderColor = 'oatmeal',
   rowActions,
-  rowActionsMinWidth,
   rowPadding,
+  columnPadding,
   noDataContent,
 }: TableProps<T>) => {
   const showActionsCell = expandable || rowActions
@@ -66,13 +66,17 @@ export const Table = <T extends object>({
           subTable={subTable}
           headerColor={headerColor}
           rowActions={rowActions}
+          columnPadding={columnPadding}
           expandable={expandable}
-          rowActionsMinWidth={rowActionsMinWidth}
         />
       </thead>
       <tbody>
         {data.length === 0 && (
-          <StyledCell colSpan={expandSubProp} rowPadding={rowPadding}>
+          <StyledCell
+            colSpan={expandSubProp}
+            rowPadding={rowPadding}
+            columnPadding={columnPadding}
+          >
             {noDataContent ? (
               noDataContent
             ) : (
@@ -94,6 +98,7 @@ export const Table = <T extends object>({
               rowColor={rowColor}
               rowBorderColor={rowBorderColor}
               rowPadding={rowPadding}
+              columnPadding={columnPadding}
               expandable={expandable}
             />
           ))}

--- a/src/Table/components/RowActions.tsx
+++ b/src/Table/components/RowActions.tsx
@@ -16,10 +16,13 @@ export const RowActions = <T extends object>({
   toggleExpansion,
 }: RowActionsProps<T>) => {
   return (
-    <StyledCell stickyCell={Boolean(rowActions) || Boolean(expandable)}>
+    <StyledCell
+      stickyCell={Boolean(rowActions) || Boolean(expandable)}
+      rowActionsBgColor={rowActions?.bgColor}
+    >
       <Box flex alignItems="center" justifyContent="flex-end">
         {rowActions &&
-          rowActions?.map((action, actionIndex) => {
+          rowActions.actions?.map((action, actionIndex) => {
             if (!action.showCondition || action.showCondition(rowData)) {
               return (
                 <Wrapper flex key={actionIndex}>

--- a/src/Table/components/TableHeader.tsx
+++ b/src/Table/components/TableHeader.tsx
@@ -8,8 +8,8 @@ export const TableHeader = <T extends object>({
   headerColor,
   rowActions,
   headerHeight,
+  columnPadding,
   expandable,
-  rowActionsMinWidth,
 }: TableHeaderProps<T>) => {
   return (
     <StyledRow>
@@ -21,6 +21,7 @@ export const TableHeader = <T extends object>({
           minWidth={column.minWidth}
           maxWidth={column.maxWidth}
           headerColor={headerColor}
+          columnPadding={columnPadding}
         >
           {column.name}
         </StyledHeaderCell>
@@ -29,8 +30,9 @@ export const TableHeader = <T extends object>({
         <StyledHeaderCell
           fixedHeader={fixedHeader}
           stickyCell={true}
-          minWidth={rowActionsMinWidth}
+          minWidth={rowActions?.minWidth}
           headerColor={headerColor}
+          columnPadding={columnPadding}
         >
           Actions
         </StyledHeaderCell>

--- a/src/Table/components/TableRow.tsx
+++ b/src/Table/components/TableRow.tsx
@@ -15,6 +15,7 @@ export const TableRow = <T extends object>({
   rowColor,
   rowBorderColor,
   rowPadding,
+  columnPadding,
   showActions,
   expandable,
 }: TableRowProps<T>) => {
@@ -55,6 +56,7 @@ export const TableRow = <T extends object>({
             <StyledCell
               key={columnIndex}
               rowPadding={rowPadding}
+              columnPadding={columnPadding}
               minWidth={column.minWidth}
               maxWidth={column.maxWidth}
               noWrapContent={column.noWrapContent}
@@ -90,6 +92,7 @@ export const TableRow = <T extends object>({
             isReactElement(subRowsData) &&
             React.cloneElement(subRowsData as ReactElement, {
               rowPadding: rowPadding,
+              columnPadding: columnPadding,
             })}
 
           {subRows &&
@@ -107,6 +110,7 @@ export const TableRow = <T extends object>({
             <StyledCell colSpan={expandSubProp}>
               {React.cloneElement(subTableData, {
                 rowPadding: rowPadding,
+                columnPadding: columnPadding,
               })}
             </StyledCell>
           )}
@@ -125,6 +129,7 @@ export const TableRow = <T extends object>({
         isReactElement(subRowsData) &&
         React.cloneElement(subRowsData as ReactElement, {
           rowPadding: rowPadding,
+          columnPadding: columnPadding,
         })}
 
       {subRows &&
@@ -134,6 +139,7 @@ export const TableRow = <T extends object>({
         (subRowsData as ReactElement[]).map((row) =>
           React.cloneElement(row, {
             rowPadding: rowPadding,
+            columnPadding: columnPadding,
           }),
         )}
 
@@ -141,6 +147,7 @@ export const TableRow = <T extends object>({
         <StyledCell colSpan={expandSubProp}>
           {React.cloneElement(subTableData, {
             rowPadding: rowPadding,
+            columnPadding: columnPadding,
           })}
         </StyledCell>
       )}

--- a/src/Table/components/TableRow.tsx
+++ b/src/Table/components/TableRow.tsx
@@ -59,6 +59,7 @@ export const TableRow = <T extends object>({
               maxWidth={column.maxWidth}
               noWrapContent={column.noWrapContent}
               truncateContent={column.truncateContent}
+              hideOverflow={column.hideOverflow}
             >
               {cellContent}
             </StyledCell>

--- a/src/Table/components/commonComponents.tsx
+++ b/src/Table/components/commonComponents.tsx
@@ -52,11 +52,16 @@ export const StyledHeaderCell = styled.th<TableStylesProps>`
 
 export const StyledCell = styled.td<TableStylesProps>`
   vertical-align: middle;
-  overflow: hidden;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 8px;
   padding-bottom: 8px;
+
+  ${({ hideOverflow }) =>
+    hideOverflow &&
+    css`
+      overflow: hidden;
+    `};
 
   ${({ noWrapContent }) =>
     noWrapContent &&
@@ -67,6 +72,7 @@ export const StyledCell = styled.td<TableStylesProps>`
   ${({ truncateContent }) =>
     truncateContent &&
     css`
+      overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
     `};

--- a/src/Table/components/commonComponents.tsx
+++ b/src/Table/components/commonComponents.tsx
@@ -48,6 +48,13 @@ export const StyledHeaderCell = styled.th<TableStylesProps>`
     css`
       min-width: ${minWidth};
     `}
+    
+  ${({ columnPadding }) =>
+    columnPadding &&
+    css`
+      padding-left: ${columnPadding};
+      padding-right: ${columnPadding};
+    `};
 `
 
 export const StyledCell = styled.td<TableStylesProps>`
@@ -91,10 +98,23 @@ export const StyledCell = styled.td<TableStylesProps>`
       padding-bottom: ${rowPadding};
     `};
 
+  ${({ columnPadding }) =>
+    columnPadding &&
+    css`
+      padding-left: ${columnPadding};
+      padding-right: ${columnPadding};
+    `};
+
   ${({ maxWidth }) =>
     maxWidth &&
     css`
       max-width: ${maxWidth};
+    `}
+
+  ${({ rowActionsBgColor }) =>
+    rowActionsBgColor &&
+    css`
+      background: ${theme.colors[rowActionsBgColor]};
     `}
 `
 

--- a/src/Table/types.ts
+++ b/src/Table/types.ts
@@ -16,6 +16,7 @@ export type TableStylesProps = {
   noWrapContent?: boolean
   truncateContent?: boolean
   rowPadding?: string
+  hideOverflow?: boolean
 }
 
 export type Primitive = string | number | boolean | bigint
@@ -54,6 +55,7 @@ export interface TableColumn<T> {
   maxWidth?: string
   noWrapContent?: boolean
   truncateContent?: boolean
+  hideOverflow?: boolean
   cell?: RowCellRenderer<T>
 }
 

--- a/src/Table/types.ts
+++ b/src/Table/types.ts
@@ -11,11 +11,13 @@ export type TableStylesProps = {
   headerColor?: Color
   rowColor?: Color
   rowBorderColor?: Color
+  rowActionsBgColor?: Color
   minWidth?: string
   maxWidth?: string
   noWrapContent?: boolean
   truncateContent?: boolean
   rowPadding?: string
+  columnPadding?: string
   hideOverflow?: boolean
 }
 
@@ -40,6 +42,12 @@ export type RowAction<T> = {
     | 'smallButton'
   >
   showCondition?: (rowData: T) => boolean
+}
+
+export type RowActions<T> = {
+  actions: RowAction<T>[]
+  minWidth?: string
+  bgColor?: Color
 }
 
 type RowCellRenderer<T> = (
@@ -76,9 +84,9 @@ interface CommonTableProps<T> {
     rows: (rowData: T) => ReactElement | ReactElement[]
     showOnExpand?: (rowData: T) => boolean
   }
-  rowActions?: RowAction<T>[]
-  rowActionsMinWidth?: string
+  rowActions?: RowActions<T>
   rowPadding?: string
+  columnPadding?: string
 }
 
 export interface TableProps<T> extends CommonTableProps<T> {


### PR DESCRIPTION
## Screenshot / video

Before:
<img width="1453" alt="Screenshot 2023-09-21 at 09 05 35" src="https://github.com/marshmallow-insurance/smores-react/assets/57456071/60bb14ba-1b82-4fa9-a466-bea53b8fa1c2">

After:
<img width="1113" alt="Screenshot 2023-09-21 at 09 08 34" src="https://github.com/marshmallow-insurance/smores-react/assets/57456071/141b10bd-a553-4934-a261-7ea3fa8cce73">

<img width="1131" alt="Screenshot 2023-09-21 at 16 15 42" src="https://github.com/marshmallow-insurance/smores-react/assets/57456071/3837196f-f199-4ea3-bfba-accb454b6cb2">


## What does this do?

- adds option to add `overflow: hidden` prop easily in the columns object, allowing for tooltips to show correctly.
