### PR TITLE
feat: add clickableRow prop to Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.1.9] - 2023-09-28
+### Changed
+- adds clickableRow prop to Table
+- updates Table caveats & prop info
+
 ## [3.1.8] - 2023-09-21
 ### Changed
 - adds hideOverflow prop to Table, allowing for tooltips to be used
@@ -701,6 +706,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[3.1.9]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.8...v3.1.9
 [3.1.8]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.7...v3.1.8
 [3.1.7]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.6...v3.1.7
 [3.1.6]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.5...v3.1.6

--- a/src/IconStrict/IconStrict.tsx
+++ b/src/IconStrict/IconStrict.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, FormEvent } from 'react'
 import styled, { css } from 'styled-components'
 
 import { darken } from 'polished'
@@ -19,7 +19,7 @@ export type IconStrictProps = {
   /** set background colour */
   backgroundColor?: Color
   /** function to handle click */
-  handleClick?: () => void
+  handleClick?: (e: FormEvent<HTMLButtonElement>) => void
   /** rotation degrees */
   rotate?: number
 } & MarginProps
@@ -54,16 +54,16 @@ export const IconStrict: FC<IconStrictProps> = ({
   ...marginProps
 }) => (
   <IconContainer
+    as={handleClick ? 'button' : 'div'}
     className={className}
     size={size}
     {...marginProps}
     backgroundColor={backgroundColor}
     onClick={handleClick}
-    tabIndex={handleClick ? 0 : undefined}
-    onKeyDown={(e) => {
+    onKeyDown={(e: { key: string }) => {
       if (!handleClick) return
       if (e.key === 'Enter') {
-        handleClick()
+        handleClick
       }
     }}
   >
@@ -81,7 +81,7 @@ export const IconStrict: FC<IconStrictProps> = ({
 interface IIconStrict {
   size: 16 | 24 | 36 | 48
   backgroundColor?: Color
-  onClick?: () => void
+  onClick?: (e: FormEvent<HTMLButtonElement>) => void
 }
 
 const IconContainer = styled.div<IIconStrict>(

--- a/src/Table/Table.stories.tsx
+++ b/src/Table/Table.stories.tsx
@@ -193,6 +193,8 @@ RowActions.args = {
   data,
   stripedColor: 'cream',
   expandable: () => true,
+  clickableRow: (row: DataRow) =>
+    alert(`onClick from ${row.ability} is working`),
   subTable: {
     table: () => {
       return (
@@ -208,7 +210,7 @@ RowActions.args = {
     },
     showOnExpand: () => true,
   },
-  rowActions: { actions: rowActions, bgColor: 'strawberry' },
+  rowActions: { actions: rowActions, bgColor: 'matcha' },
 }
 
 export const EverythingTable = TemplateWithWrapper.bind({})
@@ -221,6 +223,9 @@ EverythingTable.args = {
     table: () => {
       return (
         <Table
+          clickableRow={(row: DataRow) =>
+            alert(`onClick from ${row.ability} is working`)
+          }
           columns={columnsV2}
           data={data}
           headerColor="mascarpone"

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -13,6 +13,7 @@ import { TableProps } from './types'
  * - stripedColor wont be applied to subRows or subTables.
  * - rowActions will always need an onClick, this will be automatically passed onto the ReactNode you place & will be selectable
  * - rows will scale depending on the cell content size
+ * - using clickableRow with clickable cells, ensure you use e.stopPropagation in your cells onClick
  *
  * Improvements:
  * - It would be nice if we expandable logic inside this component, e.g the presence of certain props would automatically add this
@@ -33,8 +34,9 @@ import { TableProps } from './types'
  * @property {function(T): ReactElement} subRows.rows - Function that returns a React element for the sub row.
  * @property {boolean} [subRows.showOnExpand=false] - If true, the sub rows will only be shown when the row is expanded.
  * @property {RowAction<T>[]} [rowActions] - Array of actions that can be performed on each row.
- * @property {string} [rowActionsMinWidth] - The minimum width for the row actions column.
- * @property {string} [rowPadding] - The padding for each row, essentially the height.
+ * @property {function<T>: void} [clickableRow] - Function to apply to a row, to make the entire row clickable, useful for navigation.
+ * @property {string} [rowPadding] - The Y padding for each row.
+ * @property {string} [columnPadding] - The X padding for each row.
  * @property {string} [noDataContent] - The text to show when there is no available data to map through.
  */
 export const Table = <T extends object>({
@@ -50,6 +52,7 @@ export const Table = <T extends object>({
   stripedColor,
   rowBorderColor = 'oatmeal',
   rowActions,
+  clickableRow,
   rowPadding,
   columnPadding,
   noDataContent,
@@ -100,6 +103,7 @@ export const Table = <T extends object>({
               rowPadding={rowPadding}
               columnPadding={columnPadding}
               expandable={expandable}
+              clickableRow={clickableRow}
             />
           ))}
       </tbody>

--- a/src/Table/components/RowActions.tsx
+++ b/src/Table/components/RowActions.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { FormEvent } from 'react'
 import styled from 'styled-components'
 import { Box } from '../../Box'
 import { Button } from '../../Button'
@@ -15,6 +15,14 @@ export const RowActions = <T extends object>({
   isExpanded,
   toggleExpansion,
 }: RowActionsProps<T>) => {
+  const handleAction = (
+    e: MouseEvent | FormEvent<HTMLButtonElement>,
+    action: (rowData: T) => void,
+  ) => {
+    e.stopPropagation()
+    action(rowData)
+  }
+
   return (
     <StyledCell
       stickyCell={Boolean(rowActions) || Boolean(expandable)}
@@ -28,14 +36,18 @@ export const RowActions = <T extends object>({
                 <Wrapper flex key={actionIndex}>
                   {isReactElement(action.element) &&
                     React.cloneElement(action.element, {
-                      onClick: () => action.onClick(rowData),
+                      onClick: (e: MouseEvent) => {
+                        handleAction(e, action.onClick)
+                      },
                       tabIndex: 0,
                       className: 'reactElementRowAction',
                     })}
                   {action.genericButton && !isReactElement(action.element) && (
                     <Button
                       {...action.genericButton}
-                      handleClick={() => action.onClick(rowData)}
+                      handleClick={(e) => {
+                        handleAction(e, action.onClick)
+                      }}
                     >
                       {action.genericButton.children}
                     </Button>
@@ -43,7 +55,9 @@ export const RowActions = <T extends object>({
                   {action.iconButton && (
                     <IconStrict
                       {...action.iconButton}
-                      handleClick={() => action.onClick(rowData)}
+                      handleClick={(e) => {
+                        handleAction(e, action.onClick)
+                      }}
                     />
                   )}
                 </Wrapper>
@@ -54,7 +68,10 @@ export const RowActions = <T extends object>({
         {expandable && expandable(rowData) && (
           <CaretIcon
             render="caret"
-            handleClick={() => toggleExpansion()}
+            handleClick={(e) => {
+              e.stopPropagation()
+              toggleExpansion()
+            }}
             size={36}
             isOpen={isExpanded}
             backgroundColor="cream"

--- a/src/Table/components/TableRow.tsx
+++ b/src/Table/components/TableRow.tsx
@@ -18,6 +18,7 @@ export const TableRow = <T extends object>({
   columnPadding,
   showActions,
   expandable,
+  clickableRow,
 }: TableRowProps<T>) => {
   const [expandedRows, setExpandedRows] = useState<number[]>([])
 
@@ -45,6 +46,9 @@ export const TableRow = <T extends object>({
         stripedColor={stripedColor}
         rowColor={rowColor}
         rowBorderColor={rowBorderColor}
+        clickableRow={!!clickableRow}
+        onClick={() => clickableRow && clickableRow(rowData)}
+        tabIndex={clickableRow && 0}
       >
         {columns.map((column, columnIndex) => {
           let cellContent: ReactNode

--- a/src/Table/components/commonComponents.tsx
+++ b/src/Table/components/commonComponents.tsx
@@ -1,6 +1,8 @@
+import { darken } from 'polished'
 import styled, { css } from 'styled-components'
 import { fontStyleMapping } from '../../Text/fontMapping'
 import { theme } from '../../theme'
+import { focusOutlineStyle } from '../../utils/focusOutline'
 import { TableStylesProps } from '../types'
 
 export const StyledTable = styled.table<TableStylesProps>`
@@ -138,6 +140,19 @@ export const StyledRow = styled.tr<TableStylesProps>`
     css`
       &:nth-child(even) {
         background: ${theme.colors[stripedColor]};
+      }
+    `}
+
+    ${({ clickableRow, rowColor }) =>
+    clickableRow &&
+    css`
+      cursor: pointer;
+      &:hover {
+        background: ${darken(0.1, theme.colors[rowColor ?? 'custard'])};
+      }
+      &:focus-visible {
+        ${focusOutlineStyle}
+        background: ${darken(0.1, theme.colors[rowColor ?? 'custard'])};
       }
     `}
 `

--- a/src/Table/storyUtils.tsx
+++ b/src/Table/storyUtils.tsx
@@ -234,7 +234,11 @@ export const columnsV2 = [
   },
   {
     name: 'e.g1',
-    cell: () => 'example data',
+    cell: () => (
+      <Button primary smallButton onClick={() => exampleOnClick('e.g1 button')}>
+        e.g1
+      </Button>
+    ),
   },
   {
     name: 'e.g2',

--- a/src/Table/types.ts
+++ b/src/Table/types.ts
@@ -19,6 +19,7 @@ export type TableStylesProps = {
   rowPadding?: string
   columnPadding?: string
   hideOverflow?: boolean
+  clickableRow?: boolean
 }
 
 export type Primitive = string | number | boolean | bigint
@@ -84,6 +85,7 @@ interface CommonTableProps<T> {
     rows: (rowData: T) => ReactElement | ReactElement[]
     showOnExpand?: (rowData: T) => boolean
   }
+  clickableRow?: (rowData: T) => void
   rowActions?: RowActions<T>
   rowPadding?: string
   columnPadding?: string


### PR DESCRIPTION
## Screenshot / video



https://github.com/marshmallow-insurance/smores-react/assets/57456071/9f9a6681-622c-4edc-b9d9-7b65488943b3


## What does this do?

- adds clickableRow prop to Table, useful for quick navigation, adds `e.stopPropagation` to rowAction events to to prevent both onClicks firing, this cant be done for cells
- Caveat: ensure clickable cells have a the property e.stopPropagation on their onClick event