### PR TITLE
fix: tooltip overflow clipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [3.1.9] - 2023-09-28
 ### Changed
+- fixes clipping of Tooltip if parent has overflow: hidden;
+- moves Tooltip underline prop to Text component to prevent height issues
+
+## [3.1.9] - 2023-09-28
+### Changed
 - adds clickableRow prop to Table
 - updates Table caveats & prop info
 
@@ -706,6 +711,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[3.1.10]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.9...v3.1.10
 [3.1.9]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.8...v3.1.9
 [3.1.8]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.7...v3.1.8
 [3.1.7]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.6...v3.1.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.1.9] - 2023-09-28
+## [3.1.10] - 2023-09-28
 ### Changed
 - fixes clipping of Tooltip if parent has overflow: hidden;
 - moves Tooltip underline prop to Text component to prevent height issues

--- a/src/Tooltip/Tooltip.stories.tsx
+++ b/src/Tooltip/Tooltip.stories.tsx
@@ -19,10 +19,13 @@ const Template = (props: TooltipProps) => (
 )
 
 const OverflowHiddenTemplate = (props: TooltipProps) => (
-  <OverflowHiddenBox flex justifyContent="center">
+  <OverflowHiddenBox>
     <Tooltip {...props}>
       <Box>Harry Hill</Box>
     </Tooltip>
+    <ClippedText mt="12px">
+      I am some super long text, that should be clipped
+    </ClippedText>
   </OverflowHiddenBox>
 )
 
@@ -30,7 +33,12 @@ const OverflowHiddenBox = styled(Box)`
   height: 200px;
   width: 200px;
   margin-top: 200px;
+  overflow: hidden;
   background: ${theme.colors.blueberry};
+`
+
+const ClippedText = styled(Text)`
+  white-space: nowrap;
 `
 
 export const Default = Template.bind({})

--- a/src/Tooltip/Tooltip.stories.tsx
+++ b/src/Tooltip/Tooltip.stories.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
+import styled from 'styled-components'
 import { Box } from '../Box'
 import { Text } from '../Text'
+import { theme } from '../theme'
 import { Tooltip, TooltipProps } from './Tooltip'
 
 export default {
@@ -15,6 +17,21 @@ const Template = (props: TooltipProps) => (
     </Tooltip>
   </Box>
 )
+
+const OverflowHiddenTemplate = (props: TooltipProps) => (
+  <OverflowHiddenBox flex justifyContent="center">
+    <Tooltip {...props}>
+      <Box>Harry Hill</Box>
+    </Tooltip>
+  </OverflowHiddenBox>
+)
+
+const OverflowHiddenBox = styled(Box)`
+  height: 200px;
+  width: 200px;
+  margin-top: 200px;
+  background: ${theme.colors.blueberry};
+`
 
 export const Default = Template.bind({})
 
@@ -75,4 +92,15 @@ ReactNodeExample.args = {
   underline: true,
   arrowPosition: 'left',
   shadow: false,
+}
+
+export const OverflowExample = OverflowHiddenTemplate.bind({})
+
+OverflowExample.args = {
+  title: 'React node example',
+  position: 'top',
+  content: tooltipContent,
+  size: 'large',
+  arrowPosition: 'left',
+  underline: true,
 }

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -123,58 +123,65 @@ export const Tooltip: FC<TooltipProps> = ({
   })
 
   return (
-    <Container underline={underline}>
-      <Text
+    <Container>
+      <UnderLinedText
+        underline={underline}
         cursor="pointer"
         onMouseEnter={() => setShowTip(true)}
         onMouseLeave={() => setShowTip(false)}
       >
         {children}
-      </Text>
-      <Tip
-        className="tooltip"
-        showTip={showTip}
-        position={tooltipPosition}
-        arrowPosition={arrowPosition}
-        ref={tipContainer}
-        maxWidth={maxWidth}
-        fallbackStyle={fallbackStyle}
-      >
-        {title && (
-          <Text
-            tag="h5"
-            typo="desc-medium"
-            color={fallbackStyle ? 'cream' : 'liquorice'}
-          >
-            {title}
-          </Text>
-        )}
-        {(typeof content === 'string' && (
-          <Text typo="desc-light" color={fallbackStyle ? 'cream' : 'liquorice'}>
-            {content}
-          </Text>
-        )) ||
-          content}
-      </Tip>
+      </UnderLinedText>
+      <TipWrapper>
+        <Tip
+          className="tooltip"
+          showTip={showTip}
+          position={tooltipPosition}
+          arrowPosition={arrowPosition}
+          ref={tipContainer}
+          maxWidth={maxWidth}
+          fallbackStyle={fallbackStyle}
+        >
+          {title && (
+            <Text
+              tag="h5"
+              typo="desc-medium"
+              color={fallbackStyle ? 'cream' : 'liquorice'}
+            >
+              {title}
+            </Text>
+          )}
+          {(typeof content === 'string' && (
+            <Text
+              typo="desc-light"
+              color={fallbackStyle ? 'cream' : 'liquorice'}
+            >
+              {content}
+            </Text>
+          )) ||
+            content}
+        </Tip>
+      </TipWrapper>
     </Container>
   )
 }
 
-export const Container = styled.div<{ underline: boolean }>`
-  position: relative;
+export const Container = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
 
+  > span:hover + .tooltip {
+    opacity: 1;
+  }
+`
+
+const UnderLinedText = styled(Text)<{ underline: boolean }>`
   ${({ underline }) =>
     underline &&
     css`
       border-bottom: 1px dashed ${theme.colors.marshmallowPink};
     `}
-
-  > span:hover + .tooltip {
-    opacity: 1;
-  }
 `
 
 const arrowPaddingSize = 18
@@ -282,6 +289,12 @@ const right = css<{ arrowPosition: ArrowPosition }>`
     ${({ arrowPosition }) => handleVerticalArrowPosition(arrowPosition)}
     left: -11px;
   }
+`
+
+const TipWrapper = styled.div`
+  outline: 1px solid green;
+  position: fixed;
+  pointer-events: none;
 `
 
 export const Tip = styled.div<{

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -292,7 +292,6 @@ const right = css<{ arrowPosition: ArrowPosition }>`
 `
 
 const TipWrapper = styled.div`
-  outline: 1px solid green;
   position: fixed;
   pointer-events: none;
 `


### PR DESCRIPTION
## Screenshot / video

<img width="447" alt="Screenshot 2023-10-10 at 17 27 34" src="https://github.com/marshmallow-insurance/smores-react/assets/57456071/b480b41d-e4da-44ab-8e6f-9359a9c1e1c6">



## What does this do?

- fixes clipping issues if parent has overflow hidden
- - (removes position: relative on the parent)
- fixes alignment issue on underline if parent had height set
