### PR TITLE
fix: rename tooltip position prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.1.12] - 2023-10-13
+### Changed
+- rename Tooltip prop
+
+
 ## [3.1.11] - 2023-10-12
 ### Changed
 - actually fixes the Tooltip clipping if parent has overflow: hidden;
@@ -717,6 +722,8 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[3.1.12]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.11...v3.1.12
+[3.1.11]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.10...v3.1.11
 [3.1.10]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.9...v3.1.10
 [3.1.9]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.8...v3.1.9
 [3.1.8]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.7...v3.1.8

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "3.1.11",
+  "version": "3.1.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mrshmllw/smores-react",
-      "version": "3.1.11",
+      "version": "3.1.12",
       "license": "MIT",
       "dependencies": {
         "body-scroll-lock": "^4.0.0-beta.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "3.1.11",
+  "version": "3.1.12",
   "main": "./dist/index.js",
   "description": "Collection of React components used by Marshmallow Technology",
   "keywords": [

--- a/src/Table/storyUtils.tsx
+++ b/src/Table/storyUtils.tsx
@@ -199,7 +199,7 @@ export const columns = [
       <Box flex justifyContent="flex-start">
         <Tooltip
           content={<Text color="cream">{row.ability}</Text>}
-          defaultArrowPosition="top"
+          position="top"
           fallbackStyle
           underline
         >

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -20,7 +20,7 @@ type ArrowPosition = Position | 'center'
 export interface TooltipProps {
   children: ReactNode
   content: string | ReactNode
-  defaultArrowPosition: Position
+  position: Position
   maxWidth?: number
   title?: string
   underline?: boolean
@@ -31,7 +31,7 @@ export const Tooltip: FC<TooltipProps> = ({
   children,
   title,
   content,
-  defaultArrowPosition = 'top',
+  position = 'top',
   maxWidth = 500,
   underline = false,
   fallbackStyle = false,
@@ -39,8 +39,7 @@ export const Tooltip: FC<TooltipProps> = ({
   const documentRef = useRef<Document>(document)
   const tipContainer = useRef<HTMLDivElement>(null)
   const [showTip, setShowTip] = useState<boolean>(false)
-  const [tooltipPosition, setTooltipPosition] =
-    useState<Position>(defaultArrowPosition)
+  const [tooltipPosition, setTooltipPosition] = useState<Position>(position)
   const [childEl, setChildEl] = useState<HTMLElement | null>(null)
   const [tooltipCoords, setTooltipCoords] = useState({ top: 0, left: 0 })
 
@@ -91,8 +90,8 @@ export const Tooltip: FC<TooltipProps> = ({
   }, [])
 
   useEffect(() => {
-    setTooltipPosition(defaultArrowPosition)
-  }, [defaultArrowPosition])
+    setTooltipPosition(position)
+  }, [position])
 
   const arrowSize = 18
 
@@ -152,7 +151,7 @@ export const Tooltip: FC<TooltipProps> = ({
       setTooltipCoords(calculateTooltipPosition())
     }
   }, [
-    defaultArrowPosition,
+    position,
     window.scrollY,
     tipContainer.current,
     childEl,
@@ -188,7 +187,7 @@ export const Tooltip: FC<TooltipProps> = ({
           <Tip
             className="tooltip"
             showTip={showTip}
-            position={defaultArrowPosition}
+            position={position}
             arrowPosition={tooltipPosition}
             ref={tipContainer}
             maxWidth={maxWidth}


### PR DESCRIPTION
## Screenshot / video
N/A

## What does this do?

- accidentally renamed this for no reason
