### PR TITLE
Feat allow internalfield assistivetext to have links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.1.14] - 2023-11-10
+## [3.2.0] - 2023-11-10
 ### Changed
 - adds the ability for InternalField to take assistive text with links
 
@@ -730,7 +730,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
-[3.1.14]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.13...v3.1.14
+[3.2.0]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.13...v3.2.0
 [3.1.13]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.12...v3.1.13
 [3.1.12]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.11...v3.1.12
 [3.1.11]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.10...v3.1.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.1.14] - 2023-11-10
+### Changed
+- adds the ability for InternalField to take assistive text with links
+
 ## [3.1.13] - 2023-10-24
 ### Changed
 - fixes button state so it is disabled when loading
@@ -726,6 +730,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[3.1.14]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.13...v3.1.14
 [3.1.13]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.12...v3.1.13
 [3.1.12]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.11...v3.1.12
 [3.1.11]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.10...v3.1.11

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "3.1.13",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mrshmllw/smores-react",
-      "version": "3.1.13",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "body-scroll-lock": "^4.0.0-beta.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "3.1.13",
+  "version": "3.2.0",
   "main": "./dist/index.js",
   "description": "Collection of React components used by Marshmallow Technology",
   "keywords": [

--- a/src/fields/Field/Field.tsx
+++ b/src/fields/Field/Field.tsx
@@ -6,7 +6,6 @@ import { InternalField } from '../components/InternalField'
 export interface FieldProps extends CommonFieldProps {
   htmlFor?: string
   children: ReactNode
-  assistiveText?: string
 }
 
 export const Field = ({ children, ...fieldProps }: FieldProps) => {

--- a/src/fields/commonFieldTypes.ts
+++ b/src/fields/commonFieldTypes.ts
@@ -7,7 +7,7 @@ export interface CommonFieldProps extends MarginProps {
   children?: ReactNode
   label?: string
   renderAsTitle?: boolean
-  assistiveText?: string
+  assistiveText?: string | ReactElement
   required?: boolean
   error?: boolean
   errorMsg?: string | ReactElement

--- a/src/fields/components/InternalField.tsx
+++ b/src/fields/components/InternalField.tsx
@@ -9,7 +9,6 @@ import { Icon } from '../../Icon'
 interface InternalFieldProps extends CommonFieldProps {
   children: ReactNode
   className?: string
-  assistiveText?: string
   htmlFor?: string
   fieldType: 'field' | 'fieldset'
 }


### PR DESCRIPTION
[Demo](https://www.loom.com/share/1358a425a2f041b097d744742d74d799)

This PR allows `assistiveText` of `InternalField` to take a link:
- removes redundant type declarations in components that extend `CommonFieldProps`
- changes `assistiveText` of `CommonFieldProps` to include `ReactElement`
