### PR TITLE
Fix small textbtn padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.2.1] - 2023-11-10
+### Changed
+- fixes the padding for when text button is combined with a small button (removes padding)
+
 ## [3.2.0] - 2023-11-10
 ### Changed
 - adds the ability for InternalField to take assistive text with links
@@ -730,6 +734,7 @@
 ### Changed
 - Updated gap and styles on Row component
 
+[3.2.1]: https://github.com/marshmallow-insurance/smores-react/compare/v3.2.0...v3.2.1
 [3.2.0]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.13...v3.2.0
 [3.1.13]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.12...v3.1.13
 [3.1.12]: https://github.com/marshmallow-insurance/smores-react/compare/v3.1.11...v3.1.12

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mrshmllw/smores-react",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "body-scroll-lock": "^4.0.0-beta.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrshmllw/smores-react",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "main": "./dist/index.js",
   "description": "Collection of React components used by Marshmallow Technology",
   "keywords": [

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -185,6 +185,20 @@ const Container = styled(Box)<IButton>(
         background-color: ${theme.colors.mascarpone};
       }
     `}
+  ${smallButton &&
+    css`
+      padding: 0 10px;
+      min-width: 54px;
+      font-size: 14px;
+
+      .childrenContainer {
+        padding: 9px 0;
+      }
+
+      span {
+        margin: 0 5px 0 0;
+      }
+    `}
   ${textBtn &&
     css`
       background-color: transparent;
@@ -198,20 +212,6 @@ const Container = styled(Box)<IButton>(
       &:active {
         background-color: transparent;
         color: ${theme.colors.sesame};
-      }
-    `}
-  ${smallButton &&
-    css`
-      padding: 0 10px;
-      min-width: 54px;
-      font-size: 14px;
-
-      .childrenContainer {
-        padding: 9px 0;
-      }
-
-      span {
-        margin: 0 5px 0 0;
       }
     `}
   `,


### PR DESCRIPTION
## Screenshot / video
Issue - when `smallButton` and `textBtn` are combined, the padding remains.
<img width="685" alt="Screenshot 2023-11-20 at 14 53 01" src="https://github.com/marshmallow-insurance/smores-react/assets/126488797/88ab342e-5740-4ef1-ac88-e8e392073fff">

Fixed - no padding when `smallButton` with `textBtn`
<img width="683" alt="Screenshot 2023-11-20 at 14 45 49" src="https://github.com/marshmallow-insurance/smores-react/assets/126488797/7239e923-2e94-4f30-a897-c928251ad2be">

The `textBtn` prop does not have any padding, however when combined with `smallButton`, the padding property was overrriden.
