### PR TITLE
chore: adjust workflow to use marshmallow-ci PAT

### DIFF
--- a/.github/workflows/bump_and_publish.yml
+++ b/.github/workflows/bump_and_publish.yml
@@ -23,5 +23,5 @@ jobs:
       - name: Generate CHANGELOG.md & Bump & Release to NPM 🦫
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MARSHMALLOW_CI_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Screenshot / video

N/A

## What does this do?

- adjusts the GH_TOKEN secret to be the `MARSHMALLOW_CI_PAT` which means @marshmallow-ci will author commits by the `semantic-releases-bot` - allowing us to bypass the branch protection
