### PR TITLE
fix: adjusting Bump_and_Publish workflow

### DIFF
--- a/.github/workflows/bump_and_publish.yml
+++ b/.github/workflows/bump_and_publish.yml
@@ -3,9 +3,17 @@ name: Bump and Publish
 on: 
   workflow_dispatch:
 
+permissions:
+  contents: read 
+
 jobs:
   bump-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write 
+      issues: write
+      pull-requests: write
+      id-token: write
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
@@ -21,7 +29,7 @@ jobs:
         run: |
           npm ci
       - name: Generate CHANGELOG.md & Bump & Release to NPM 🦫
-        run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.MARSHMALLOW_CI_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release


### PR DESCRIPTION
## Screenshot / video

N/A

## What does this do?

- adds permissions as guided to here: https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/ci-configurations/github-actions.md
