### PR TITLE
fix(actions): add git author details to env variables

### DIFF
--- a/.github/workflows/bump_and_publish.yml
+++ b/.github/workflows/bump_and_publish.yml
@@ -26,5 +26,9 @@ jobs:
       - name: Generate CHANGELOG.md & Bump & Release to NPM 🦫
         env:
           GITHUB_TOKEN: ${{ secrets.MARSHMALLOW_CI_PAT }}
+          GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMITTER_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## What does this do?

Updating the `bump_and_publish.yml` to pass the GitHub secret tokens to the `env` variables to be used when running the action.