### PR TITLE
fix(workflow): github token for bump and publish

### DIFF
--- a/.github/workflows/bump_and_publish.yml
+++ b/.github/workflows/bump_and_publish.yml
@@ -26,9 +26,5 @@ jobs:
       - name: Generate CHANGELOG.md & Bump & Release to NPM 🦫
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
-          GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
-          GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMITTER_NAME }}
-          GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/.github/workflows/bump_and_publish.yml
+++ b/.github/workflows/bump_and_publish.yml
@@ -25,7 +25,7 @@ jobs:
           npm ci
       - name: Generate CHANGELOG.md & Bump & Release to NPM 🦫
         env:
-          GITHUB_TOKEN: ${{ secrets.MARSHMALLOW_CI_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMITTER_NAME }}


### PR DESCRIPTION
## What does this do?

use GITHUB_TOKEN for the workflow github token.