### PR TITLE
fix(workflow): rever to MARSHMALLOW_CI_PAT

### DIFF
--- a/.github/workflows/bump_and_publish.yml
+++ b/.github/workflows/bump_and_publish.yml
@@ -25,6 +25,6 @@ jobs:
           npm ci
       - name: Generate CHANGELOG.md & Bump & Release to NPM 🦫
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MARSHMALLOW_CI_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## What does this do?

Revert to using `MARSHMALLOW_CI_PAT`