### PR TITLE
style: convert Toggle active state to pistachio

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Note: this workflow will fail if the package version is already on the latest, s
 
 ###### Tokens
 
-The `MARSHMALLOW_CI_PAT` has been created from the internal @marshmallow-ci GH account, it does expire next year, so will need regenerating once it does.
+The `MARSHMALLOW_CI_PAT` has been created from the internal @marshmallow-ci GH account, it expires `27/11/2024` so will need regenerating once it does.
 
 ## Running Smores in dev mode 
 To run Smores in dev mode follow the below instructions on installing and using Yalc to link up your project repo with Smores.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ When you're happy with your changes, you can release & publish your changes to N
 
 Note: this workflow will fail if the package version is already on the latest, so you dont have to worry about deploying the same changes multiple times.
 
+###### Tokens
+
+The `MARSHMALLOW_CI_PAT` has been created from the internal @marshmallow-ci GH account, it does expire next year, so will need regenerating once it does.
+
 ## Running Smores in dev mode 
 To run Smores in dev mode follow the below instructions on installing and using Yalc to link up your project repo with Smores.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Note: this workflow will fail if the package version is already on the latest, s
 
 ###### Tokens
 
-The `MARSHMALLOW_CI_PAT` has been created from the internal @marshmallow-ci GH account, it expires `27/11/2024` so will need regenerating once it does.
+The `MARSHMALLOW_CI_PAT` has been created from the internal @marshmallow-ci GH account, it is due to expire on `27th November 2024` so will need regenerating once it does.
 
 ## Running Smores in dev mode 
 To run Smores in dev mode follow the below instructions on installing and using Yalc to link up your project repo with Smores.

--- a/src/Toggle/Toggle.tsx
+++ b/src/Toggle/Toggle.tsx
@@ -1,10 +1,10 @@
 import React, { FC } from 'react'
 import styled from 'styled-components'
 
-import { focusOutline } from '../utils/focusOutline'
-import { theme } from '../theme'
-import { MarginProps } from '../utils/space'
 import { Box } from '../Box'
+import { theme } from '../theme'
+import { focusOutline } from '../utils/focusOutline'
+import { MarginProps } from '../utils/space'
 
 type Props = {
   /** unique ID */
@@ -85,7 +85,7 @@ const Checkbox = styled.input`
   ${focusOutline({ selector: `&:focus-visible + ${Slider}` })}
 
   &:checked + ${Slider} {
-    background-color: ${theme.colors.liquorice};
+    background-color: ${theme.colors.pistachio};
     border: none;
   }
 

--- a/src/Toggle/__tests__/__snapshots__/Toggle.js.snap
+++ b/src/Toggle/__tests__/__snapshots__/Toggle.js.snap
@@ -57,7 +57,7 @@ exports[`renders 1`] = `
 }
 
 .c1:checked + .c2 {
-  background-color: #292924;
+  background-color: #838E49;
   border: none;
 }
 

--- a/src/tokenTest.spec.ts
+++ b/src/tokenTest.spec.ts
@@ -1,0 +1,8 @@
+describe('Token expiry', () => {
+  it('should fail after November 27th', () => {
+    const currentDate = new Date()
+    const failAfterDate = new Date(2024, 10, 27)
+
+    expect(currentDate.getTime()).toBeLessThanOrEqual(failAfterDate.getTime())
+  })
+})


### PR DESCRIPTION
## Screenshot / video

![Screenshot 2023-11-29 at 09 53 41](https://github.com/marshmallow-insurance/smores-react/assets/57456071/c8689d32-9910-4ff8-bf7d-695a68de4f66)


## What does this do?

- changes active state of `Toggle` to green
- updates README to include info about token expiries 