### PR TITLE
fix: add semantic-release GH-release plugin

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -40,6 +40,12 @@
         }
       }
     ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": ["dist"]
+      }
+    ],
     "@semantic-release/changelog",
     {
       "path": "@semantic-release/npm",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@babel/preset-typescript": "^7.18.6",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
+        "@semantic-release/github": "^9.2.4",
         "@semantic-release/npm": "^11.0.1",
         "@snyk/protect": "^1.881.0",
         "@storybook/addon-essentials": "^7.0.6",
@@ -4719,9 +4720,9 @@
       }
     },
     "node_modules/@semantic-release/github": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.2.3.tgz",
-      "integrity": "sha512-FAjXb1F84CVI6IG8fWi+XS9ErYD+s3MHkP03zBa3+GyUrV4kqwYu/WPppIciHxujGFR51SAWPkOY5rnH6ZlrxA==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.2.4.tgz",
+      "integrity": "sha512-VMzqiuSLhHc0/1Q8M/FmWnOaclh5aXL2pQWceldWBYSWLNzQu8GOR4bkGl57ciUtvm+MCMi4FaStZxSDJGEfUg==",
       "dev": true,
       "dependencies": {
         "@octokit/core": "^5.0.0",
@@ -4737,7 +4738,7 @@
         "https-proxy-agent": "^7.0.0",
         "issue-parser": "^6.0.0",
         "lodash-es": "^4.17.21",
-        "mime": "^3.0.0",
+        "mime": "^4.0.0",
         "p-filter": "^3.0.0",
         "url-join": "^5.0.0"
       },
@@ -4871,15 +4872,18 @@
       }
     },
     "node_modules/@semantic-release/github/node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.0.tgz",
+      "integrity": "sha512-pzhgdeqU5pJ9t5WK9m4RT4GgGWqYJylxUf62Yb9datXRwdcw5MjiD1BYI5evF8AgTXN9gtKX3CFLvCUL5fAhEA==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
       "bin": {
-        "mime": "cli.js"
+        "mime": "bin/cli.js"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/@semantic-release/github/node_modules/path-type": {
@@ -31217,9 +31221,9 @@
       }
     },
     "@semantic-release/github": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.2.3.tgz",
-      "integrity": "sha512-FAjXb1F84CVI6IG8fWi+XS9ErYD+s3MHkP03zBa3+GyUrV4kqwYu/WPppIciHxujGFR51SAWPkOY5rnH6ZlrxA==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.2.4.tgz",
+      "integrity": "sha512-VMzqiuSLhHc0/1Q8M/FmWnOaclh5aXL2pQWceldWBYSWLNzQu8GOR4bkGl57ciUtvm+MCMi4FaStZxSDJGEfUg==",
       "dev": true,
       "requires": {
         "@octokit/core": "^5.0.0",
@@ -31235,7 +31239,7 @@
         "https-proxy-agent": "^7.0.0",
         "issue-parser": "^6.0.0",
         "lodash-es": "^4.17.21",
-        "mime": "^3.0.0",
+        "mime": "^4.0.0",
         "p-filter": "^3.0.0",
         "url-join": "^5.0.0"
       },
@@ -31321,9 +31325,9 @@
           "dev": true
         },
         "mime": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-          "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.0.tgz",
+          "integrity": "sha512-pzhgdeqU5pJ9t5WK9m4RT4GgGWqYJylxUf62Yb9datXRwdcw5MjiD1BYI5evF8AgTXN9gtKX3CFLvCUL5fAhEA==",
           "dev": true
         },
         "path-type": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@babel/preset-typescript": "^7.18.6",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
+    "@semantic-release/github": "^9.2.4",
     "@semantic-release/npm": "^11.0.1",
     "@snyk/protect": "^1.881.0",
     "@storybook/addon-essentials": "^7.0.6",


### PR DESCRIPTION
## Screenshot / video

N/A

## What does this do?

- adds the plugin for github releases to be automated when we run the `Bump & Publish` workflow