### PR TITLE
fix: validateDomNesting warnings in SupportMessage & Tooltip

### DIFF
--- a/src/LabelledText/LabelledText.tsx
+++ b/src/LabelledText/LabelledText.tsx
@@ -2,20 +2,22 @@ import React, { FC, ReactNode } from 'react'
 import styled from 'styled-components'
 import { MarginProps } from '../utils/space'
 
-import { Text } from '../Text'
 import { Box } from '../Box'
+import { Text } from '../Text'
 
 export type LabelledTextProps = {
   children: ReactNode
   label: string
+  labelMargin: 2 | 4 | 8
 } & MarginProps
 
 export const LabelledText: FC<LabelledTextProps> = ({
   label,
   children,
+  labelMargin = 8,
   ...marginProps
 }) => (
-  <Container {...marginProps}>
+  <Container {...marginProps} labelMargin={labelMargin + 'px'}>
     <Text tag="label" color="sesame" typo="label">
       {label}
     </Text>
@@ -24,11 +26,11 @@ export const LabelledText: FC<LabelledTextProps> = ({
   </Container>
 )
 
-const Container = styled(Box)`
+const Container = styled(Box)<{ labelMargin: string }>`
   display: flex;
   flex-direction: column;
 
   label {
-    margin-bottom: 8px;
+    margin-bottom: ${({ labelMargin }) => labelMargin};
   }
 `

--- a/src/SupportMessage/SupportMessage.stories.tsx
+++ b/src/SupportMessage/SupportMessage.stories.tsx
@@ -28,7 +28,7 @@ WithCustomDescription.args = {
   type: 'info',
   title: 'A SupportMessage using the Link component',
   description: (
-    <Box>
+    <div>
       Some text rendered using a <Link href={''}>Link</Link>
     </Box>
   ),

--- a/src/SupportMessage/SupportMessage.stories.tsx
+++ b/src/SupportMessage/SupportMessage.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Box } from '../Box'
 import { Link } from '../Link'
 import { CollectionPage } from './Collection'
 import { SupportMessage, SupportMessageProps } from './SupportMessage'

--- a/src/SupportMessage/SupportMessage.stories.tsx
+++ b/src/SupportMessage/SupportMessage.stories.tsx
@@ -30,7 +30,7 @@ WithCustomDescription.args = {
   description: (
     <div>
       Some text rendered using a <Link href={''}>Link</Link>
-    </Box>
+    </div>
   ),
 }
 

--- a/src/SupportMessage/SupportMessage.stories.tsx
+++ b/src/SupportMessage/SupportMessage.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { SupportMessage, SupportMessageProps } from './SupportMessage'
+import { Box } from '../Box'
 import { Link } from '../Link'
 import { CollectionPage } from './Collection'
+import { SupportMessage, SupportMessageProps } from './SupportMessage'
 
 export default {
   title: 'SupportMessage',
@@ -28,9 +29,9 @@ WithCustomDescription.args = {
   type: 'info',
   title: 'A SupportMessage using the Link component',
   description: (
-    <>
+    <Box>
       Some text rendered using a <Link href={''}>Link</Link>
-    </>
+    </Box>
   ),
 }
 

--- a/src/SupportMessage/SupportMessage.tsx
+++ b/src/SupportMessage/SupportMessage.tsx
@@ -1,11 +1,12 @@
+import { darken } from 'polished'
 import React, { FC, MouseEventHandler, ReactElement } from 'react'
 import styled, { css } from 'styled-components'
-import { darken } from 'polished'
 
 import { Box } from '../Box'
 import { Icon } from '../Icon'
 import { Text } from '../Text'
-import { theme, Color } from '../theme'
+import { Color, theme } from '../theme'
+import { isReactElement } from '../utils/isReactElement'
 import { MarginProps } from '../utils/space'
 
 type StylesItem = {
@@ -70,26 +71,37 @@ export const SupportMessage: FC<SupportMessageProps> = ({
   type = 'info',
   title,
   ...marginProps
-}) => (
-  <Wrapper className={className} type={type} onClick={onClick} {...marginProps}>
-    <IconWrapper>
-      <Icon
-        size={20}
-        render={styles[type].icon}
-        color={styles[type].iconColor}
-      />
-    </IconWrapper>
-    <Box flex direction="column" mx="8px">
-      {title && <Title>{title}</Title>}
-      <Description tag="p">{description}</Description>
-    </Box>
-    {onClick && (
-      <Box ml={{ custom: 'auto' }}>
-        <Icon size={16} render="caret" color="marzipan" rotate={270} />
+}) => {
+  return (
+    <Wrapper
+      className={className}
+      type={type}
+      onClick={onClick}
+      {...marginProps}
+    >
+      <IconWrapper>
+        <Icon
+          size={20}
+          render={styles[type].icon}
+          color={styles[type].iconColor}
+        />
+      </IconWrapper>
+      <Box flex direction="column" mx="8px">
+        {title && <Title>{title}</Title>}
+        {isReactElement(description) ? (
+          <DescriptionBox>{description}</DescriptionBox>
+        ) : (
+          <Description tag="p">{description}</Description>
+        )}
       </Box>
-    )}
-  </Wrapper>
-)
+      {onClick && (
+        <Box ml={{ custom: 'auto' }}>
+          <Icon size={16} render="caret" color="marzipan" rotate={270} />
+        </Box>
+      )}
+    </Wrapper>
+  )
+}
 
 interface IWrapper {
   type: SupportMessageType
@@ -123,6 +135,12 @@ const Title = styled.p`
   color: ${theme.colors.liquorice};
   line-height: 20.8px;
   margin-bottom: 4px;
+`
+
+const DescriptionBox = styled(Box)`
+  color: ${theme.colors.liquorice};
+  font-size: 14px;
+  line-height: 20px;
 `
 
 const Description = styled(Text)`

--- a/src/Table/components/RowActions.tsx
+++ b/src/Table/components/RowActions.tsx
@@ -4,7 +4,7 @@ import { Box } from '../../Box'
 import { Button } from '../../Button'
 import { IconStrict } from '../../IconStrict'
 import { focusOutlineStyle } from '../../utils/focusOutline'
-import { isReactElement } from '../helpers'
+import { isReactElement } from '../../utils/isReactElement'
 import { RowActionsProps } from '../types'
 import { StyledCell } from './commonComponents'
 

--- a/src/Table/components/TableRow.tsx
+++ b/src/Table/components/TableRow.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, ReactNode, useState } from 'react'
-import { isMappedReactElement, isReactElement } from '../helpers'
+import { isReactElement } from '../../utils/isReactElement'
+import { isMappedReactElement } from '../helpers'
 import { TableRowProps } from '../types'
 import { RowActions } from './RowActions'
 import { StyledCell, StyledRow } from './commonComponents'

--- a/src/Table/helpers.ts
+++ b/src/Table/helpers.ts
@@ -1,9 +1,5 @@
 import { ReactElement, isValidElement } from 'react'
 
-export const isReactElement = (obj: unknown): obj is ReactElement => {
-  return isValidElement(obj)
-}
-
 export const isMappedReactElement = (obj: unknown): obj is ReactElement[] => {
   if (!Array.isArray(obj)) return false
   if (!obj[0]) return false

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -9,6 +9,7 @@ import React, {
 import { createPortal } from 'react-dom'
 import styled, { css } from 'styled-components'
 import { v4 as uuidv4 } from 'uuid'
+import { Box } from '../Box'
 import { Text } from '../Text'
 import { useEventListener } from '../hooks'
 import { theme } from '../theme'
@@ -176,7 +177,6 @@ export const Tooltip: FC<TooltipProps> = ({
       <UnderlinedText
         id={randomId}
         underline={underline}
-        cursor="pointer"
         onMouseEnter={() => setShowTip(true)}
         onMouseLeave={() => setShowTip(false)}
       >
@@ -233,7 +233,8 @@ export const Container = styled.div`
   }
 `
 
-const UnderlinedText = styled(Text)<{ underline: boolean }>`
+const UnderlinedText = styled(Box)<{ underline: boolean }>`
+  cursor: pointer;
   ${({ underline }) =>
     underline &&
     css`

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -174,14 +174,14 @@ export const Tooltip: FC<TooltipProps> = ({
 
   return (
     <Container>
-      <UnderlinedText
+      <UnderlinedChild
         id={randomId}
         underline={underline}
         onMouseEnter={() => setShowTip(true)}
         onMouseLeave={() => setShowTip(false)}
       >
         {children}
-      </UnderlinedText>
+      </UnderlinedChild>
       {childEl &&
         createPortal(
           <Tip
@@ -233,7 +233,7 @@ export const Container = styled.div`
   }
 `
 
-const UnderlinedText = styled(Box)<{ underline: boolean }>`
+const UnderlinedChild = styled(Box)<{ underline: boolean }>`
   cursor: pointer;
   ${({ underline }) =>
     underline &&

--- a/src/utils/isReactElement.ts
+++ b/src/utils/isReactElement.ts
@@ -1,0 +1,5 @@
+import { ReactElement, isValidElement } from 'react'
+
+export const isReactElement = (obj: unknown): obj is ReactElement => {
+  return isValidElement(obj)
+}


### PR DESCRIPTION
## Screenshot / video

N/A

## What does this do?

- fixes `validateDOMNesting(...): <div> cannot appear as a descendant of <p>` that would appear when using a ReactElement with SupportMessage description prop by adding in a ReactElement check
- fixes same error in Tooltip but instead by converting the UnderlinedText, <p /> component, to instead be a UnderlinedChild, <div /> component!
- adds labelBottom to LabelledText prop - to remove need for MarginlessLabelledText snowflake components