### PR TITLE
feat(dropdown): allow placeholder to be used as empty value

### DIFF
--- a/src/Dropdown/Collection.tsx
+++ b/src/Dropdown/Collection.tsx
@@ -104,6 +104,39 @@ export const CollectionPage: FC = () => {
                   fallbackStyle
                 />
               </Row>
+              <Row label="Placeholder">
+                <Dropdown
+                  id={id}
+                  label={label}
+                  placeholder={placeholder}
+                  list={list}
+                  error={false}
+                  errorMsg={errorMsg}
+                  onSelect={onSelect}
+                />
+              </Row>
+              <Row label="No placeholder">
+                <Dropdown
+                  id={id}
+                  label={label}
+                  list={list}
+                  error={false}
+                  errorMsg={errorMsg}
+                  onSelect={onSelect}
+                />
+              </Row>
+              <Row label="Placeholder as value">
+                <Dropdown
+                  id={id}
+                  label={label}
+                  list={list}
+                  placeholder={placeholder}
+                  showPlaceholderAsValue
+                  error={false}
+                  errorMsg={errorMsg}
+                  onSelect={onSelect}
+                />
+              </Row>
               <Row label="Leading Icon">
                 <Dropdown
                   id={id}

--- a/src/Dropdown/Collection.tsx
+++ b/src/Dropdown/Collection.tsx
@@ -125,18 +125,32 @@ export const CollectionPage: FC = () => {
                   onSelect={onSelect}
                 />
               </Row>
-              <Row label="Placeholder as value">
+              <Row label="show default option">
                 <Dropdown
                   id={id}
                   label={label}
                   list={list}
                   placeholder={placeholder}
-                  showPlaceholderAsValue
+                  showDefaultOption
                   error={false}
                   errorMsg={errorMsg}
                   onSelect={onSelect}
                 />
               </Row>
+              <Row label="show default option with custom option label">
+                <Dropdown
+                  id={id}
+                  label={label}
+                  list={list}
+                  placeholder={placeholder}
+                  showDefaultOption
+                  customDefaultOption="Select a day"
+                  error={false}
+                  errorMsg={errorMsg}
+                  onSelect={onSelect}
+                />
+              </Row>
+
               <Row label="Leading Icon">
                 <Dropdown
                   id={id}

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -24,6 +24,7 @@ export type DropdownItem = {
 
 export interface Props extends CommonFieldProps {
   placeholder?: string
+  showPlaceholderAsValue?: boolean
   name?: string
   value?: string | null
   defaultValue?: string
@@ -51,6 +52,7 @@ export const Dropdown = forwardRef(function Dropdown(
   {
     id: idProp,
     placeholder,
+    showPlaceholderAsValue = false,
     name,
     value: valueProp,
     defaultValue,
@@ -117,12 +119,22 @@ export const Dropdown = forwardRef(function Dropdown(
         >
           {hasOptGroups ? (
             <optgroup label={placeholder}>
-              <option value="" hidden>
+              <option
+                value=""
+                {...(placeholder && showPlaceholderAsValue
+                  ? {}
+                  : { hidden: true })}
+              >
                 {placeholder}
               </option>
             </optgroup>
           ) : (
-            <option value="" hidden>
+            <option
+              value=""
+              {...(placeholder && showPlaceholderAsValue
+                ? {}
+                : { hidden: true })}
+            >
               {placeholder}
             </option>
           )}

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -121,20 +121,13 @@ export const Dropdown = forwardRef(function Dropdown(
             <optgroup label={placeholder}>
               <option
                 value=""
-                {...(placeholder && showPlaceholderAsValue
-                  ? {}
-                  : { hidden: true })}
+                hidden={!(placeholder && showPlaceholderAsValue)}
               >
                 {placeholder}
               </option>
             </optgroup>
           ) : (
-            <option
-              value=""
-              {...(placeholder && showPlaceholderAsValue
-                ? {}
-                : { hidden: true })}
-            >
+            <option value="" hidden={!(placeholder && showPlaceholderAsValue)}>
               {placeholder}
             </option>
           )}

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -24,7 +24,8 @@ export type DropdownItem = {
 
 export interface Props extends CommonFieldProps {
   placeholder?: string
-  showPlaceholderAsValue?: boolean
+  showDefaultOption?: boolean
+  customDefaultOption?: string
   name?: string
   value?: string | null
   defaultValue?: string
@@ -52,7 +53,8 @@ export const Dropdown = forwardRef(function Dropdown(
   {
     id: idProp,
     placeholder,
-    showPlaceholderAsValue = false,
+    showDefaultOption = false,
+    customDefaultOption,
     name,
     value: valueProp,
     defaultValue,
@@ -89,6 +91,13 @@ export const Dropdown = forwardRef(function Dropdown(
     return Array.from(itemsPerGroupLabel.values())
   }, [list])
 
+  const defaultOptionLabel = () => {
+    if (!showDefaultOption) {
+      return placeholder
+    }
+    return customDefaultOption ?? 'Select an option'
+  }
+
   return (
     <Field {...fieldProps} htmlFor={id} error={error}>
       <Box flex alignItems="center">
@@ -118,17 +127,14 @@ export const Dropdown = forwardRef(function Dropdown(
           value={value ? value : ''}
         >
           {hasOptGroups ? (
-            <optgroup label={placeholder}>
-              <option
-                value=""
-                hidden={!(placeholder && showPlaceholderAsValue)}
-              >
-                {placeholder}
+            <optgroup label={defaultOptionLabel()}>
+              <option value="" hidden={!showDefaultOption}>
+                {defaultOptionLabel()}
               </option>
             </optgroup>
           ) : (
-            <option value="" hidden={!(placeholder && showPlaceholderAsValue)}>
-              {placeholder}
+            <option value="" hidden={!showDefaultOption}>
+              {defaultOptionLabel()}
             </option>
           )}
 


### PR DESCRIPTION
## Screenshot / video
<img width="1025" alt="Screenshot 2024-01-18 at 15 33 24" src="https://github.com/marshmallow-insurance/smores-react/assets/5758372/0923f338-48b8-4108-85eb-6a816d6bcac5">
<img width="1073" alt="Screenshot 2024-01-18 at 15 33 29" src="https://github.com/marshmallow-insurance/smores-react/assets/5758372/deca9a6a-6ff1-4b78-8976-e74b5c825996">
![Screenshot 2024-01-19 at 10 58 26](https://github.com/marshmallow-insurance/smores-react/assets/5758372/a1d4e487-b454-4054-a985-12eec2dff1c4)
![Screenshot 2024-01-19 at 10 57 19](https://github.com/marshmallow-insurance/smores-react/assets/5758372/601154ba-0ef4-487c-a196-56ec48be78be)

## What does this do?

- Adds an optional prop, `showDefaultOption` , to the `Dropdown` component to render a default selected option of "Select an option"
- Adds another optional prop, `customDefaultOption` that allows the user to override the "Select an option" value 
- Adds placeholder and show default option values to the dropdown `Collection.tsx`

## Ticket
- [Github Ticket](https://github.com/marshmallow-insurance/growth/issues/638)
- [Slack thread from Design](https://eatmarshmallows.slack.com/archives/C02U91D49C6/p1705658871408059)