### PR TITLE
fix: fix NumberInput for currencies

### DIFF
--- a/src/NumberInput/Container.tsx
+++ b/src/NumberInput/Container.tsx
@@ -19,7 +19,6 @@ export const Container = () => {
         min={-100}
         max={180}
         step={10}
-        strict
         roundCurrency
         required
       />

--- a/src/NumberInput/NumberInput.tsx
+++ b/src/NumberInput/NumberInput.tsx
@@ -27,7 +27,6 @@ export interface Props extends CommonFieldProps {
   onBlur?: (e: FocusEvent<HTMLInputElement>) => void
   min?: number
   max?: number
-  strict?: boolean
   roundCurrency?: boolean
   step?: number
 }
@@ -60,7 +59,6 @@ export const NumberInput = forwardRef(function NumberInput(
     roundCurrency,
     min = -999999,
     max = 999999,
-    strict,
     step = 0,
     disabled = false,
     error = false,
@@ -91,28 +89,21 @@ export const NumberInput = forwardRef(function NumberInput(
     return Math.round(event * 100) / 100
   }
 
-  const handleStrictValue = (event: number): number => {
-    if (isInRange(event)) {
+  const formatCurrency = (event: string) => {
+    const decimalIndex = event.indexOf('.')
+    if (decimalIndex >= 0 && event.length > decimalIndex + 1) {
+      const fractionalString = event.substring(decimalIndex + 1).substring(0, 2)
+      return `${event.substring(0, decimalIndex)}.${fractionalString}`
+    } else {
       return event
     }
+  }
 
-    // Get the difference between the max (or min) and the current value
-    const dMax = max - event
-    const dMin = min - event
-
-    // if the difference is zero return the min value
-    if (!dMax) {
-      return min
-    }
-
-    // if the difference is zero return the max value
-    if (!dMin) {
-      return max
-    }
-
-    // Convert all negative numbers to positive numbers (-90 becomes 90) then,
-    // if the converted max diff is less than the min diff, return the max (eg. 100), otherwise return the min (eg. 0)
-    return Math.abs(dMax) < Math.abs(dMin) ? max : min
+  const applyMinMax = (value: string) => {
+    const number = Number(value)
+    if(min && number < min) return min
+    if(max && number > max) return max
+    return value
   }
 
   const handleChange = (event: string) => {
@@ -122,17 +113,10 @@ export const NumberInput = forwardRef(function NumberInput(
     if (event === EMPTY_INPUT) {
       onChange(event)
     } else {
-      const formattedEvent = Number(event)
+      const value = roundCurrency ? formatCurrency(event) : event
+      const normalisedValue = applyMinMax(value)
 
-      const amount = roundCurrency
-        ? roundNumber(formattedEvent)
-        : formattedEvent
-
-      if (strict) {
-        onChange(handleStrictValue(amount))
-      } else {
-        onChange(amount)
-      }
+      onChange(normalisedValue)
     }
   }
   // Increment or decrement the value when clicking the Spinner controls

--- a/src/NumberInput/NumberInput.tsx
+++ b/src/NumberInput/NumberInput.tsx
@@ -153,6 +153,7 @@ export const NumberInput = forwardRef(function NumberInput(
         <Input
           ref={ref}
           error={error}
+          inputMode="numeric"
           disabled={disabled}
           type={type}
           id={id}

--- a/src/NumberInput/__tests__/NumberInput.js
+++ b/src/NumberInput/__tests__/NumberInput.js
@@ -49,7 +49,6 @@ test('renders - currency', () => {
       onChange={str => {}}
       placeholder="100.00"
       prefix="$"
-      strict={true}
       min={0}
       max={100}
       step={10}


### PR DESCRIPTION
## What does this do?

- Fixes how numbers are rounded for currencies, previously if you tried to enter 100.01, when typing 100.0 javascript would stringify this to 100
- `strict` doesn't seem to be used anywhere so I've removed it, though keeping normalising with min & max