### PR TITLE
Move FOSSA action to after deploy

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -19,10 +19,6 @@ jobs:
         run: |
           npm ci
           npm run build-storybook
-      - name: Fossa dependency analysis 🐛
-        uses: fossas/fossa-action@main
-        with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4
         with:
@@ -30,3 +26,7 @@ jobs:
           branch: gh-pages
           folder: storybook-static
           clean: true
+      - name: Fossa dependency analysis 🐛
+        uses: fossas/fossa-action@main
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
## What does this do?

- We're having some issues with the FOSSA api key and the build steps are set up this way in TeamCity

https://eatmarshmallows.slack.com/archives/C04CQU4U84T/p1707413197220079