### PR TITLE
Feat: makes placeholder option disabled

### DIFF
--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -128,12 +128,12 @@ export const Dropdown = forwardRef(function Dropdown(
         >
           {hasOptGroups ? (
             <optgroup label={defaultOptionLabel()}>
-              <option value="" hidden={!showDefaultOption}>
+              <option value="" hidden={!showDefaultOption} disabled>
                 {defaultOptionLabel()}
               </option>
             </optgroup>
           ) : (
-            <option value="" hidden={!showDefaultOption}>
+            <option value="" hidden={!showDefaultOption} disabled>
               {defaultOptionLabel()}
             </option>
           )}


### PR DESCRIPTION
## Screenshot / video
https://www.loom.com/share/cd346d9f47e744f7ac535e32a947114c

## What does this do?
- The default option shown in the options list, should be disabled.

Following on [Slack](https://eatmarshmallows.slack.com/archives/C04QG0DUJJD/p1708082328198189?thread_ts=1708081655.209539&cid=C04QG0DUJJD)
