### PR TITLE
fix: add zIndex & portalContainer props to tooltip

### DIFF
--- a/src/Tooltip/Tooltip.stories.tsx
+++ b/src/Tooltip/Tooltip.stories.tsx
@@ -1,6 +1,8 @@
-import React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 import { Box } from '../Box'
+import { Button } from '../Button'
+import { Modal } from '../Modal'
 import { Text } from '../Text'
 import { theme } from '../theme'
 import { Tooltip, TooltipProps } from './Tooltip'
@@ -17,35 +19,6 @@ const Template = (props: TooltipProps) => (
     </Tooltip>
   </Box>
 )
-
-const OverflowHiddenTemplate = (props: TooltipProps) => (
-  <OverflowHiddenBox my="64px">
-    <Tooltip {...props}>
-      <Box>Harry Hill</Box>
-    </Tooltip>
-
-    <ClippedText mt="12px">
-      I am some super long text, that should be clipped
-    </ClippedText>
-
-    <Box my="64px">
-      <Tooltip {...props}>
-        <Box>Harry Hill</Box>
-      </Tooltip>
-    </Box>
-  </OverflowHiddenBox>
-)
-
-const OverflowHiddenBox = styled(Box)`
-  height: 100px;
-  width: 200px;
-  overflow: scroll;
-  background: ${theme.colors.blueberry};
-`
-
-const ClippedText = styled(Text)`
-  white-space: nowrap;
-`
 
 export const Default = Template.bind({})
 
@@ -102,10 +75,69 @@ ReactNodeExample.args = {
   shadow: false,
 }
 
+const OverflowHiddenTemplate = (props: TooltipProps) => (
+  <OverflowHiddenBox my="64px">
+    <Tooltip {...props}>
+      <Box>Harry Hill</Box>
+    </Tooltip>
+
+    <ClippedText mt="12px">
+      I am some super long text, that should be clipped
+    </ClippedText>
+
+    <Box my="64px">
+      <Tooltip {...props}>
+        <Box>Harry Hill</Box>
+      </Tooltip>
+    </Box>
+  </OverflowHiddenBox>
+)
+
+const OverflowHiddenBox = styled(Box)`
+  height: 100px;
+  width: 200px;
+  overflow: scroll;
+  background: ${theme.colors.blueberry};
+`
+
+const ClippedText = styled(Text)`
+  white-space: nowrap;
+`
+
 export const OverflowExample = OverflowHiddenTemplate.bind({})
 
 OverflowExample.args = {
   title: 'React node example',
+  content: tooltipContent,
+  size: 'large',
+  underline: true,
+}
+
+const ModalTemplate = (props: TooltipProps) => {
+  const [showModal, setShowModal] = useState(false)
+
+  const handleClick = () => {
+    setShowModal(!showModal)
+  }
+
+  return (
+    <Box height="900px">
+      <Modal handleClick={handleClick} showModal={showModal}>
+        <Tooltip {...props} zIndex={1000}>
+          <Box>Harry Hill</Box>
+        </Tooltip>
+      </Modal>
+      <Button primary handleClick={handleClick}>
+        Show Modal with Mobile Drawer
+      </Button>
+    </Box>
+  )
+}
+
+export const ModalExample = ModalTemplate.bind({})
+
+ModalExample.args = {
+  title: 'Modal example',
   content: tooltipContent,
   size: 'large',
   underline: true,

--- a/src/Tooltip/Tooltip.stories.tsx
+++ b/src/Tooltip/Tooltip.stories.tsx
@@ -20,6 +20,35 @@ const Template = (props: TooltipProps) => (
   </Box>
 )
 
+const OverflowHiddenTemplate = (props: TooltipProps) => (
+  <OverflowHiddenBox my="64px">
+    <Tooltip {...props}>
+      <Box>Harry Hill</Box>
+    </Tooltip>
+
+    <ClippedText mt="12px">
+      I am some super long text, that should be clipped
+    </ClippedText>
+
+    <Box my="64px">
+      <Tooltip {...props}>
+        <Box>Harry Hill</Box>
+      </Tooltip>
+    </Box>
+  </OverflowHiddenBox>
+)
+
+const OverflowHiddenBox = styled(Box)`
+  height: 100px;
+  width: 200px;
+  overflow: scroll;
+  background: ${theme.colors.blueberry};
+`
+
+const ClippedText = styled(Text)`
+  white-space: nowrap;
+`
+
 export const Default = Template.bind({})
 
 Default.args = {
@@ -74,35 +103,6 @@ ReactNodeExample.args = {
   underline: true,
   shadow: false,
 }
-
-const OverflowHiddenTemplate = (props: TooltipProps) => (
-  <OverflowHiddenBox my="64px">
-    <Tooltip {...props}>
-      <Box>Harry Hill</Box>
-    </Tooltip>
-
-    <ClippedText mt="12px">
-      I am some super long text, that should be clipped
-    </ClippedText>
-
-    <Box my="64px">
-      <Tooltip {...props}>
-        <Box>Harry Hill</Box>
-      </Tooltip>
-    </Box>
-  </OverflowHiddenBox>
-)
-
-const OverflowHiddenBox = styled(Box)`
-  height: 100px;
-  width: 200px;
-  overflow: scroll;
-  background: ${theme.colors.blueberry};
-`
-
-const ClippedText = styled(Text)`
-  white-space: nowrap;
-`
 
 export const OverflowExample = OverflowHiddenTemplate.bind({})
 

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -26,6 +26,8 @@ export interface TooltipProps {
   title?: string
   underline?: boolean
   fallbackStyle?: boolean
+  zIndex?: number
+  portalContainer?: Element | DocumentFragment
 }
 
 export const Tooltip: FC<TooltipProps> = ({
@@ -36,6 +38,8 @@ export const Tooltip: FC<TooltipProps> = ({
   maxWidth = 500,
   underline = false,
   fallbackStyle = false,
+  zIndex = 10,
+  portalContainer = document.body,
 }) => {
   const documentRef = useRef<Document>(document)
   const tipContainer = useRef<HTMLDivElement>(null)
@@ -192,6 +196,7 @@ export const Tooltip: FC<TooltipProps> = ({
             ref={tipContainer}
             maxWidth={maxWidth}
             fallbackStyle={fallbackStyle}
+            zIndex={zIndex}
             style={{
               position: 'absolute',
               top: `${tooltipCoords.top}px`,
@@ -217,7 +222,7 @@ export const Tooltip: FC<TooltipProps> = ({
             )) ||
               content}
           </Tip>,
-          document.body,
+          portalContainer,
         )}
     </Container>
   )
@@ -317,6 +322,7 @@ export const Tip = styled.div<{
   arrowPosition: ArrowPosition
   maxWidth?: number
   fallbackStyle?: boolean
+  zIndex: number
 }>`
   position: absolute;
   margin: auto;
@@ -328,7 +334,7 @@ export const Tip = styled.div<{
   transition: opacity 0.2s ease-in-out;
   pointer-events: none;
   cursor: default;
-  z-index: 10;
+  z-index: ${({ zIndex }) => (zIndex ? zIndex : '10')};
 
   // this is the trick that will make sure the content can go up to maxWidth
   margin-right: ${({ maxWidth }) => maxWidth && -maxWidth / 2 + 'px'};


### PR DESCRIPTION
## Screenshot / video


![Screenshot 2024-02-19 at 16 25 48](https://github.com/marshmallow-insurance/smores-react/assets/57456071/fac6ecc6-49a0-4dd7-b0f5-adce73ece05e)
![Screenshot 2024-02-19 at 16 26 04](https://github.com/marshmallow-insurance/smores-react/assets/57456071/deac07d3-804f-49de-a303-17af3a5ab3d3)

## What does this do?

- allows us to pass zIndex to tooltip, altho the modal is set to 999 already - we can go over this
- passed portalContainer prop to tooltip too
