### PR TITLE
fix: typeErr from rollup of default import of styled-comp

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,9 @@ export default defineConfig({
     },
     rollupOptions: {
       output: {
+        format: 'cjs',
+        sourcemap: true,
+        interop: 'auto',
         inlineDynamicImports: false,
         preserveModules: true,
       },


### PR DESCRIPTION
## Screenshot / video

N/A

## What does this do?

- the rollup caused this non-breaking error, but would cause some tests to fail: `TypeError: styled.div is not a function`
- can be seen happening to others here: https://arc.net/l/quote/ohybkqce
- the bug fix is here: https://arc.net/l/quote/uhzhtdqg
