### PR TITLE
skip lib check

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,8 @@
     "strictNullChecks": true,
     "noUnusedLocals": true,
     "allowSyntheticDefaultImports": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "skipLibCheck": true
   },
   "include": ["src/**/*", "src/global.d.ts", "vitest.config.ts"],
   "exclude": ["node_modules", "dist", "scripts"]


### PR DESCRIPTION
## What does this do?

- skip type checking of node modules
- Looks like facebook use less strict settings for their typescript compiler, ours fails on `@lexical/react` when run locally
- [issue discussion](https://github.com/facebook/lexical/issues/2528)