### PR TITLE
fix: release @lexica/react package.json change and RichTextEditor outline prop

### DIFF
--- a/src/RichTextEditor/RichTextEditor.tsx
+++ b/src/RichTextEditor/RichTextEditor.tsx
@@ -27,10 +27,11 @@ export interface RichTextEditorProps extends MarginProps {
   defaultValue?: string
   maxHeight?: string
   height?: string
+  outline?: boolean
   onChange: (e: string) => void
 }
 
-export const RichTextEditor: FC<RichTextEditorProps> = ({ defaultValue, height, maxHeight = "300px", onChange, ...props }) => {
+export const RichTextEditor: FC<RichTextEditorProps> = ({ defaultValue, height, outline, maxHeight = "300px", onChange, ...props }) => {
 
   const defaultEditorState = (editor: LexicalEditor) => {
     const parser = new DOMParser();
@@ -69,7 +70,7 @@ export const RichTextEditor: FC<RichTextEditorProps> = ({ defaultValue, height, 
   }
 
   return (
-    <Container {...props}>
+    <Container $outline={outline} {...props}>
       <Editor $maxHeight={maxHeight} $height={height}>
         <LexicalComposer initialConfig={initialConfig}>
           <ToolbarPlugin />
@@ -110,8 +111,9 @@ const Editor = styled(Box)<{$maxHeight: string, $height?: string}>`
   }
 `
 
-const Container = styled(Box)`
+const Container = styled(Box)<{$outline: boolean}>`
   background-color: ${theme.colors.coconut};
   border-radius: 16px;
   padding: 12px;
+  ${({$outline}) => $outline && `border: 2px solid ${theme.colors.oatmeal}`}
 `

--- a/src/RichTextEditor/storybook/Collection.tsx
+++ b/src/RichTextEditor/storybook/Collection.tsx
@@ -14,6 +14,7 @@ export const CollectionPage: FC = () => {
         </Title>
         <Row label="Email">
           <RichTextEditor
+            outline
             onChange={(e) => console.log(e)}
             defaultValue={
               `<div dir=\"ltr\"><div>Testing some features of the rich text viewer. This is an example of an email sent from gmail.<br></div><div><ul><li style=\"margin-left:15px\">bullet</li><li style=\"margin-left:15px\">points<br></li></ul><div><ol><li style=\"margin-left:15px\">numbered</li><li style=\"margin-left:15px\">list</li></ol><div><font size=\"4\">Different</font> <b><i>text</i></b> <u style=\"background-color:rgb(0,255,255)\">formatting</u></div></div></div><div><br></div><span class=\"gmail_signature_prefix\">-- </span><br><div dir=\"ltr\" class=\"gmail_signature\" data-smartmail=\"gmail_signature\"><div dir=\"ltr\"><span style=\"color:rgb(136,136,136);font-family:Roboto,RobotoDraft,Helvetica,Arial,sans-serif\"><font size=\"4\"><b>Liam Piesley</b></font></span><div style=\"color:rgb(136,136,136);font-family:Roboto,RobotoDraft,Helvetica,Arial,sans-serif;font-size:12.8px\"><div>Software Engineer</div><div>Marshmallow</div><div><a href=\"http://www.marshmallow.com/\" rel=\"noreferrer\" style=\"color:rgb(17,85,204)\" target=\"_blank\">www.marshmallow.com</a></div><div><br></div><div><img src=\"https://i.imgur.com/psgAauI.png\" width=\"200\" height=\"39\"><br></div></div></div></div></div>\r\n`

--- a/src/RichTextEditor/storybook/RichText.stories.tsx
+++ b/src/RichTextEditor/storybook/RichText.stories.tsx
@@ -16,7 +16,8 @@ Default.args = {
   defaultValue: '<h1>Header</h1><h2>Subheading</h2><p>A paragraph of text with a <a href="https://liamp.uk">link</a></p>',
   onChange: () => {},
   height: "300px",
-  maxHeight: "300px"
+  maxHeight: "300px",
+  outline: true
 }
 
 export const Collection = CollectionPage.bind({})


### PR DESCRIPTION
## Screenshot / video

<img width="1078" alt="image" src="https://github.com/marshmallow-insurance/smores-react/assets/17195367/d2306c95-d387-4e61-88d6-08c393eab3c2">

## What does this do?

- bump version and release change to package.json
- add outline prop to rich text editor