### PR TITLE
fix: handle 3 digits on pagination component

### DIFF
--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -193,17 +193,16 @@ const Container = styled(Box)`
 `
 
 const PageBox = styled.button<IPageBox>`
-  background: ${({ active }) =>
-    active ? theme.colors.custard : theme.colors.cream};
-    cursor: pointer;
-    display: flex;
-    -webkit-box-pack: center;
-    justify-content: center;
-    border-radius: 24px;
-    width: fit-content;
-    padding: 0px 4px;
-    height: 24px;
-    min-width: 24px;
+  background: ${({ active }) => active ? theme.colors.custard : theme.colors.cream};
+  cursor: pointer;
+  display: flex;
+  -webkit-box-pack: center;
+  justify-content: center;
+  border-radius: 24px;
+  width: fit-content;
+  padding: 0px 4px;
+  height: 24px;
+  min-width: 24px;
 
   &:hover {
     background-color: ${theme.colors.mascarpone};

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -196,7 +196,6 @@ const PageBox = styled.button<IPageBox>`
   background: ${({ active }) => active ? theme.colors.custard : theme.colors.cream};
   cursor: pointer;
   display: flex;
-  -webkit-box-pack: center;
   justify-content: center;
   border-radius: 24px;
   width: fit-content;

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -195,12 +195,15 @@ const Container = styled(Box)`
 const PageBox = styled.button<IPageBox>`
   background: ${({ active }) =>
     active ? theme.colors.custard : theme.colors.cream};
-  cursor: pointer;
-  display: flex;
-  justify-content: center;
-  border-radius: 50%;
-  width: 24px;
-  height: 24px;
+    cursor: pointer;
+    display: flex;
+    -webkit-box-pack: center;
+    justify-content: center;
+    border-radius: 24px;
+    width: fit-content;
+    padding: 0px 4px;
+    height: 24px;
+    min-width: 24px;
 
   &:hover {
     background-color: ${theme.colors.mascarpone};

--- a/src/Pagination/__tests__/__snapshots__/Pagination.spec.tsx.snap
+++ b/src/Pagination/__tests__/__snapshots__/Pagination.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`renders 1`] = `
   direction="row"
 >
   <button
-    class="sc-iGgWBj cWFBbm"
+    class="sc-iGgWBj jjBWwA"
   >
     <p
       class="sc-aXZVg sc-fqkvVR byxNQM dmcJhI"
@@ -18,7 +18,7 @@ exports[`renders 1`] = `
     </p>
   </button>
   <button
-    class="sc-iGgWBj bKlexW"
+    class="sc-iGgWBj hRPnPA"
   >
     <p
       class="sc-aXZVg sc-fqkvVR byxNQM glAOgN"
@@ -30,7 +30,7 @@ exports[`renders 1`] = `
     </p>
   </button>
   <button
-    class="sc-iGgWBj bKlexW"
+    class="sc-iGgWBj hRPnPA"
   >
     <p
       class="sc-aXZVg sc-fqkvVR byxNQM glAOgN"
@@ -42,7 +42,7 @@ exports[`renders 1`] = `
     </p>
   </button>
   <button
-    class="sc-iGgWBj bKlexW"
+    class="sc-iGgWBj hRPnPA"
   >
     <p
       class="sc-aXZVg sc-fqkvVR byxNQM glAOgN"
@@ -54,7 +54,7 @@ exports[`renders 1`] = `
     </p>
   </button>
   <button
-    class="sc-iGgWBj bKlexW"
+    class="sc-iGgWBj hRPnPA"
   >
     <p
       class="sc-aXZVg sc-fqkvVR byxNQM glAOgN"
@@ -66,7 +66,7 @@ exports[`renders 1`] = `
     </p>
   </button>
   <button
-    class="sc-iGgWBj bKlexW"
+    class="sc-iGgWBj hRPnPA"
   >
     <p
       class="sc-aXZVg sc-fqkvVR byxNQM eIOPip"
@@ -78,7 +78,7 @@ exports[`renders 1`] = `
     </p>
   </button>
   <button
-    class="sc-iGgWBj bKlexW"
+    class="sc-iGgWBj hRPnPA"
   >
     <p
       class="sc-aXZVg sc-fqkvVR byxNQM glAOgN"

--- a/src/Pagination/__tests__/__snapshots__/Pagination.spec.tsx.snap
+++ b/src/Pagination/__tests__/__snapshots__/Pagination.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`renders 1`] = `
   direction="row"
 >
   <button
-    class="sc-iGgWBj jjBWwA"
+    class="sc-iGgWBj jrEJLb"
   >
     <p
       class="sc-aXZVg sc-fqkvVR byxNQM dmcJhI"
@@ -18,7 +18,7 @@ exports[`renders 1`] = `
     </p>
   </button>
   <button
-    class="sc-iGgWBj hRPnPA"
+    class="sc-iGgWBj cpulZn"
   >
     <p
       class="sc-aXZVg sc-fqkvVR byxNQM glAOgN"
@@ -30,7 +30,7 @@ exports[`renders 1`] = `
     </p>
   </button>
   <button
-    class="sc-iGgWBj hRPnPA"
+    class="sc-iGgWBj cpulZn"
   >
     <p
       class="sc-aXZVg sc-fqkvVR byxNQM glAOgN"
@@ -42,7 +42,7 @@ exports[`renders 1`] = `
     </p>
   </button>
   <button
-    class="sc-iGgWBj hRPnPA"
+    class="sc-iGgWBj cpulZn"
   >
     <p
       class="sc-aXZVg sc-fqkvVR byxNQM glAOgN"
@@ -54,7 +54,7 @@ exports[`renders 1`] = `
     </p>
   </button>
   <button
-    class="sc-iGgWBj hRPnPA"
+    class="sc-iGgWBj cpulZn"
   >
     <p
       class="sc-aXZVg sc-fqkvVR byxNQM glAOgN"
@@ -66,7 +66,7 @@ exports[`renders 1`] = `
     </p>
   </button>
   <button
-    class="sc-iGgWBj hRPnPA"
+    class="sc-iGgWBj cpulZn"
   >
     <p
       class="sc-aXZVg sc-fqkvVR byxNQM eIOPip"
@@ -78,7 +78,7 @@ exports[`renders 1`] = `
     </p>
   </button>
   <button
-    class="sc-iGgWBj hRPnPA"
+    class="sc-iGgWBj cpulZn"
   >
     <p
       class="sc-aXZVg sc-fqkvVR byxNQM glAOgN"

--- a/src/Pagination/storybook/Pagination.stories.tsx
+++ b/src/Pagination/storybook/Pagination.stories.tsx
@@ -23,7 +23,7 @@ const Template = (props: PaginationProps & { showBg: boolean }) => (
 export const Default = Template.bind({})
 
 Default.args = {
-  total: 7,
+  total: 123,
   partition: 1,
 }
 


### PR DESCRIPTION
## Screenshot / video

<img width="306" alt="Screenshot 2024-03-11 at 11 05 32" src="https://github.com/marshmallow-insurance/smores-react/assets/17195367/d5742ba6-2537-46ea-9c64-7829c45112bb">

## What does this do?

- handle 3 digits on pagination component