### PR TITLE
Key line option to table

### DIFF
--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -22,6 +22,7 @@ import { TableProps } from './types'
  * @template T - The type of data the table displays.
  * @property {T[]} data - Array of data to be displayed in the table.
  * @property {TableColumn<T>[]} columns - Array of columns to display in the table.
+ * @property {boolean} [hasHeaderKeyline=false] - If true, the table header will have a key line.
  * @property {boolean} [fixedHeader=false] - If true, the table header will be fixed/sticky.
  * @property {string} [headerHeight] - Sets the height of the header.
  * @property {function(T): boolean} [expandable] - A function to determine if a row is expandable.
@@ -43,6 +44,7 @@ export const Table = <T extends object>({
   columns,
   data,
   fixedHeader = true,
+  hasHeaderKeyline = false,
   expandable,
   subTable,
   subRows,
@@ -71,6 +73,7 @@ export const Table = <T extends object>({
           rowActions={rowActions}
           columnPadding={columnPadding}
           expandable={expandable}
+          hasKeyline={hasHeaderKeyline}
         />
       </thead>
       <tbody>

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -22,7 +22,7 @@ import { TableProps } from './types'
  * @template T - The type of data the table displays.
  * @property {T[]} data - Array of data to be displayed in the table.
  * @property {TableColumn<T>[]} columns - Array of columns to display in the table.
- * @property {boolean} [hasHeaderKeyline=false] - If true, the table header will have a key line.
+ * @property {boolean} [hasKeyline=false] - If true, the table header will have a key line.
  * @property {boolean} [fixedHeader=false] - If true, the table header will be fixed/sticky.
  * @property {string} [headerHeight] - Sets the height of the header.
  * @property {function(T): boolean} [expandable] - A function to determine if a row is expandable.
@@ -44,7 +44,7 @@ export const Table = <T extends object>({
   columns,
   data,
   fixedHeader = true,
-  hasHeaderKeyline = false,
+  hasKeyline = false,
   expandable,
   subTable,
   subRows,
@@ -73,7 +73,7 @@ export const Table = <T extends object>({
           rowActions={rowActions}
           columnPadding={columnPadding}
           expandable={expandable}
-          $hasKeyline={hasHeaderKeyline}
+          hasKeyline={hasKeyline}
         />
       </thead>
       <tbody>

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -73,7 +73,7 @@ export const Table = <T extends object>({
           rowActions={rowActions}
           columnPadding={columnPadding}
           expandable={expandable}
-          hasKeyline={hasHeaderKeyline}
+          $hasKeyline={hasHeaderKeyline}
         />
       </thead>
       <tbody>

--- a/src/Table/components/TableHeader.tsx
+++ b/src/Table/components/TableHeader.tsx
@@ -10,7 +10,7 @@ export const TableHeader = <T extends object>({
   headerHeight,
   columnPadding,
   expandable,
-  hasKeyline,
+  $hasKeyline,
 }: TableHeaderProps<T>) => {
   return (
     <StyledRow>
@@ -23,7 +23,7 @@ export const TableHeader = <T extends object>({
           maxWidth={column.maxWidth}
           headerColor={headerColor}
           columnPadding={columnPadding}
-          hasKeyline={hasKeyline}
+          $hasKeyline={$hasKeyline}
         >
           {column.name}
         </StyledHeaderCell>
@@ -35,7 +35,7 @@ export const TableHeader = <T extends object>({
           minWidth={rowActions?.minWidth}
           headerColor={headerColor}
           columnPadding={columnPadding}
-          hasKeyline={hasKeyline}
+          $hasKeyline={$hasKeyline}
         >
           Actions
         </StyledHeaderCell>

--- a/src/Table/components/TableHeader.tsx
+++ b/src/Table/components/TableHeader.tsx
@@ -10,6 +10,7 @@ export const TableHeader = <T extends object>({
   headerHeight,
   columnPadding,
   expandable,
+  hasKeyline,
 }: TableHeaderProps<T>) => {
   return (
     <StyledRow>
@@ -22,6 +23,7 @@ export const TableHeader = <T extends object>({
           maxWidth={column.maxWidth}
           headerColor={headerColor}
           columnPadding={columnPadding}
+          hasKeyline={hasKeyline}
         >
           {column.name}
         </StyledHeaderCell>
@@ -33,6 +35,7 @@ export const TableHeader = <T extends object>({
           minWidth={rowActions?.minWidth}
           headerColor={headerColor}
           columnPadding={columnPadding}
+          hasKeyline={hasKeyline}
         >
           Actions
         </StyledHeaderCell>

--- a/src/Table/components/TableHeader.tsx
+++ b/src/Table/components/TableHeader.tsx
@@ -10,7 +10,7 @@ export const TableHeader = <T extends object>({
   headerHeight,
   columnPadding,
   expandable,
-  $hasKeyline,
+  hasKeyline,
 }: TableHeaderProps<T>) => {
   return (
     <StyledRow>
@@ -23,7 +23,7 @@ export const TableHeader = <T extends object>({
           maxWidth={column.maxWidth}
           headerColor={headerColor}
           columnPadding={columnPadding}
-          $hasKeyline={$hasKeyline}
+          $hasKeyline={hasKeyline}
         >
           {column.name}
         </StyledHeaderCell>
@@ -35,7 +35,7 @@ export const TableHeader = <T extends object>({
           minWidth={rowActions?.minWidth}
           headerColor={headerColor}
           columnPadding={columnPadding}
-          $hasKeyline={$hasKeyline}
+          $hasKeyline={hasKeyline}
         >
           Actions
         </StyledHeaderCell>

--- a/src/Table/components/commonComponents.tsx
+++ b/src/Table/components/commonComponents.tsx
@@ -16,6 +16,8 @@ export const StyledTable = styled.table<TableStylesProps>`
 
 export const StyledHeaderCell = styled.th<TableStylesProps>`
   background: ${theme.colors.coconut};
+  border-bottom: ${({ hasKeyline }) =>
+    hasKeyline ? `1px solid ${theme.colors.liquorice}` : 'none'};
   position: ${({ fixedHeader }) => (fixedHeader ? 'sticky' : 'auto')};
   top: 0;
   z-index: 2;

--- a/src/Table/components/commonComponents.tsx
+++ b/src/Table/components/commonComponents.tsx
@@ -16,8 +16,8 @@ export const StyledTable = styled.table<TableStylesProps>`
 
 export const StyledHeaderCell = styled.th<TableStylesProps>`
   background: ${theme.colors.coconut};
-  border-bottom: ${({ hasKeyline }) =>
-    hasKeyline ? `1px solid ${theme.colors.liquorice}` : 'none'};
+  border-bottom: ${({ $hasKeyline }) =>
+    $hasKeyline ? `1px solid ${theme.colors.liquorice}` : 'none'};
   position: ${({ fixedHeader }) => (fixedHeader ? 'sticky' : 'auto')};
   top: 0;
   z-index: 2;

--- a/src/Table/storybook/Table.stories.tsx
+++ b/src/Table/storybook/Table.stories.tsx
@@ -32,6 +32,7 @@ Default.args = {
   columns: columns.slice(0, 6),
   data,
   fixedHeader: true,
+  hasHeaderKeyline: true,
 }
 
 export const BasicTable = Template.bind({})

--- a/src/Table/storybook/Table.stories.tsx
+++ b/src/Table/storybook/Table.stories.tsx
@@ -32,7 +32,6 @@ Default.args = {
   columns: columns.slice(0, 6),
   data,
   fixedHeader: true,
-  hasHeaderKeyline: true,
 }
 
 export const BasicTable = Template.bind({})

--- a/src/Table/types.ts
+++ b/src/Table/types.ts
@@ -4,7 +4,7 @@ import { IconStrictProps } from '../IconStrict'
 import { Color } from '../theme'
 
 export type TableStylesProps = {
-  hasKeyline?: boolean
+  $hasKeyline?: boolean
   fixedHeader?: boolean
   headerHeight?: string
   stripedColor?: Color
@@ -73,7 +73,7 @@ interface CommonTableProps<T> {
   columns: TableColumn<T>[]
   headerHeight?: string
   fixedHeader?: boolean
-  hasKeyline?: boolean
+  $hasKeyline?: boolean
   stripedColor?: Color
   expandable?: (rowData: T) => boolean
   headerColor?: Color

--- a/src/Table/types.ts
+++ b/src/Table/types.ts
@@ -4,6 +4,7 @@ import { IconStrictProps } from '../IconStrict'
 import { Color } from '../theme'
 
 export type TableStylesProps = {
+  hasKeyline?: boolean
   fixedHeader?: boolean
   headerHeight?: string
   stripedColor?: Color
@@ -72,6 +73,7 @@ interface CommonTableProps<T> {
   columns: TableColumn<T>[]
   headerHeight?: string
   fixedHeader?: boolean
+  hasKeyline?: boolean
   stripedColor?: Color
   expandable?: (rowData: T) => boolean
   headerColor?: Color
@@ -94,6 +96,7 @@ interface CommonTableProps<T> {
 export interface TableProps<T> extends CommonTableProps<T> {
   data: T[]
   noDataContent?: ReactNode
+  hasHeaderKeyline?: boolean
 }
 
 export interface TableRowProps<T> extends CommonTableProps<T> {

--- a/src/Table/types.ts
+++ b/src/Table/types.ts
@@ -73,7 +73,7 @@ interface CommonTableProps<T> {
   columns: TableColumn<T>[]
   headerHeight?: string
   fixedHeader?: boolean
-  $hasKeyline?: boolean
+  hasKeyline?: boolean
   stripedColor?: Color
   expandable?: (rowData: T) => boolean
   headerColor?: Color
@@ -96,7 +96,6 @@ interface CommonTableProps<T> {
 export interface TableProps<T> extends CommonTableProps<T> {
   data: T[]
   noDataContent?: ReactNode
-  hasHeaderKeyline?: boolean
 }
 
 export interface TableRowProps<T> extends CommonTableProps<T> {


### PR DESCRIPTION
## Screenshot / video

https://github.com/marshmallow-insurance/smores-react/assets/44034297/6df3b27c-9063-4a8c-affc-2db886dd5c96



## What does this do?

On the credit hire page a requirement come from Alistair to have key line on the table 
[Design](https://www.figma.com/file/Gq8kllU6kzQ95pxfpf4sCX/Credit-Hire-add-on?type=design&node-id=1582-28408&mode=design&t=6unFNuGLxL3swsjp-0)
[Ticket](https://www.notion.so/getmarshmallow/Budapest-Kanban-Board-696ab44f2fa74d18846e44e27af1331c?p=44b0099ffb9242ddad318c3cc5910fa4&pm=s)
<img width="693" alt="Screenshot 2024-03-14 at 17 50 50" src="https://github.com/marshmallow-insurance/smores-react/assets/44034297/a784e647-bf03-4810-a769-6aea69b682b1">
[Sub-Task](https://www.notion.so/getmarshmallow/Budapest-Kanban-Board-696ab44f2fa74d18846e44e27af1331c?p=132ffb6c22fb4a8fb2d741e9140d291c&pm=s)

