### PR TITLE
bump: husky to v9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npm run pre-commit-lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-react": "^7.29.2",
         "eslint-plugin-react-hooks": "^4.1.2",
-        "husky": "^8.0.1",
+        "husky": "^9.0.11",
         "lint-staged": "^15.1.0",
         "prettier": "^3.0.0",
         "react": "^18.2.0",
@@ -14854,15 +14854,15 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
       "dev": true,
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.mjs"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "vitest --silent",
     "updateSnaps": "vitest --u",
     "snyk-protect": "snyk-protect",
-    "prepare": "npm run snyk-protect && husky install",
+    "prepare": "npm run snyk-protect && husky",
     "pre-commit-lint": "npm run check-types && lint-staged",
     "fix-package-lock-conflicts": "echo \"Make sure conflicts in package.json are resolved before running this script\" && npm i --package-lock-only"
   },
@@ -61,7 +61,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-react": "^7.29.2",
     "eslint-plugin-react-hooks": "^4.1.2",
-    "husky": "^8.0.1",
+    "husky": "^9.0.11",
     "lint-staged": "^15.1.0",
     "prettier": "^3.0.0",
     "react": "^18.2.0",


### PR DESCRIPTION
## Screenshot / video

N/A

This PR:
- upgrades [husky to v9](https://github.com/typicode/husky/releases/tag/v9.0.1)
- introduces the optional migration steps
```
v9 is backward compatible with v8, allowing you to freely upgrade and migrate your hooks later.

Here are the steps to migrate:

package.json

{
  "scripts": {
-   "prepare": "husky install"
+   "prepare": "husky"
  }
}
.husky/pre-commit

- #!/usr/bin/env sh
- . "$(dirname -- "$0")/_/husky.sh"
npm test 
Note: sh will be used to run hooks, even if a shebang is set.

If you were using husky as a module:

- const husky = require('husky')
- // ...
+ import husky from 'husky'
+ console.log(husky())
```

closes: https://github.com/marshmallow-insurance/smores-react/pull/3495

(stole from mats PR - https://github.com/marshmallow-insurance/uk-auto-signup-www/pull/6201)