### PR TITLE
fix: remove fossa check on PR creation

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,7 +22,3 @@ jobs:
       - name: Test 🧪
         run: |
           npm run test
-      - name: Fossa dependency analysis 🐛
-        uses: fossas/fossa-action@main
-        with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
## Screenshot / video

N/A

## What does this do?

- this is causing dependabot builds to fail and not auto-merge
- platform only run this on merge to main, so not needed on PR
- https://eatmarshmallows.slack.com/archives/C04CQU4U84T/p1711122322089539
