### PR TITLE
chore: add semantic-release dry run on main merge

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -19,6 +19,11 @@ jobs:
         run: |
           npm ci
           npm run build-storybook
+      - name: Preview Publish 🦫
+        env:
+          GITHUB_TOKEN: ${{ secrets.MARSHMALLOW_CI_PAT }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release --dry-run
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4
         with:


### PR DESCRIPTION
## Screenshot / video

N/A

## What does this do?

- adds `npx run semantic-release --dry-run` to the on merge command
- this is to hopefully catch any issues with publishing before running the GHA workflow (also saves use using the `preview bump & publish` GHA everytime if we dont want to)
