### PR TITLE
breaking change: allow update default value for rich text editor

### DIFF
--- a/src/RichTextEditor/RichTextEditor.tsx
+++ b/src/RichTextEditor/RichTextEditor.tsx
@@ -1,30 +1,30 @@
-import React, { FC } from 'react'
-import { MarginProps } from '../utils/space'
+import { CodeHighlightNode, CodeNode } from '@lexical/code'
+import { $generateNodesFromDOM } from '@lexical/html'
+import { AutoLinkNode, LinkNode } from '@lexical/link'
+import { ListItemNode, ListNode } from '@lexical/list'
+import { TRANSFORMERS } from '@lexical/markdown'
+import { LexicalComposer } from '@lexical/react/LexicalComposer'
+import { ContentEditable } from '@lexical/react/LexicalContentEditable'
+import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary'
+import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin'
+import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin'
+import { ListPlugin } from '@lexical/react/LexicalListPlugin'
+import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPlugin'
+import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin'
+import { HeadingNode, QuoteNode } from '@lexical/rich-text'
+import DOMPurify from 'dompurify'
+import { $createParagraphNode, $getRoot, LexicalEditor } from 'lexical'
+import React, { FC, useState } from 'react'
 import styled from 'styled-components'
 import { Box } from '../Box'
 import { theme } from '../theme'
-import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin'
-import { ContentEditable } from '@lexical/react/LexicalContentEditable'
-import { LexicalComposer } from '@lexical/react/LexicalComposer'
-import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary'
+import { MarginProps } from '../utils/space'
 import CustomAutoLinkPlugin from './plugins/AutoLinkPlugin'
-import { AutoLinkNode, LinkNode } from '@lexical/link'
-import { ListNode, ListItemNode } from '@lexical/list'
-import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin'
-import ToolbarPlugin from './plugins/ToolbarPlugin'
-import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin'
-import { ListPlugin } from '@lexical/react/LexicalListPlugin'
-import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPlugin'
-import { TRANSFORMERS } from '@lexical/markdown'
-import { HeadingNode, QuoteNode } from '@lexical/rich-text'
-import { CodeHighlightNode, CodeNode } from '@lexical/code'
-import { $generateNodesFromDOM } from '@lexical/html'
-import { $createParagraphNode, $getRoot, LexicalEditor } from 'lexical'
-import DOMPurify from 'dompurify'
 import { EditorUpdatePlugin } from './plugins/EditorUpdatePlugin'
+import ToolbarPlugin from './plugins/ToolbarPlugin'
 
 export interface RichTextEditorProps extends MarginProps {
-  defaultValue?: string
+  value?: string
   maxHeight?: string
   height?: string
   outline?: boolean
@@ -32,17 +32,44 @@ export interface RichTextEditorProps extends MarginProps {
 }
 
 export const RichTextEditor: FC<RichTextEditorProps> = ({
-  defaultValue,
+  value,
   height,
   outline = false,
   maxHeight = '300px',
   onChange,
   ...props
 }) => {
+  const [editorState, setEditorState] = useState<null | LexicalEditor>(null)
+
+  editorState &&
+    editorState.update(() => {
+      const parser = new DOMParser()
+      const dom = parser.parseFromString(
+        value ? DOMPurify.sanitize(value) : '<p></p>',
+        'text/html',
+      )
+      const root = $getRoot()
+      root.clear()
+      const nodes = $generateNodesFromDOM(editorState, dom)
+
+      nodes
+        .filter((node) => node.__type !== 'linebreak')
+        .map((node) => {
+          if (node.__type === 'text') {
+            const paragraphNode = $createParagraphNode()
+            paragraphNode.append(node)
+            return paragraphNode
+          }
+          return node
+        })
+        .forEach((node) => root.append(node))
+    })
+
   const defaultEditorState = (editor: LexicalEditor) => {
+    setEditorState(editor)
     const parser = new DOMParser()
     const dom = parser.parseFromString(
-      defaultValue ? DOMPurify.sanitize(defaultValue) : '<p></p>',
+      value ? DOMPurify.sanitize(value) : '<p></p>',
       'text/html',
     )
     const nodes = $generateNodesFromDOM(editor, dom)

--- a/src/RichTextEditor/RichTextEditor.tsx
+++ b/src/RichTextEditor/RichTextEditor.tsx
@@ -13,7 +13,13 @@ import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPl
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin'
 import { HeadingNode, QuoteNode } from '@lexical/rich-text'
 import DOMPurify from 'dompurify'
-import { $createParagraphNode, $getRoot, LexicalEditor } from 'lexical'
+import {
+  $createParagraphNode,
+  $getRoot,
+  LexicalEditor,
+  LexicalNode,
+  RootNode,
+} from 'lexical'
 import React, { FC, useState } from 'react'
 import styled from 'styled-components'
 import { Box } from '../Box'
@@ -29,6 +35,20 @@ export interface RichTextEditorProps extends MarginProps {
   height?: string
   outline?: boolean
   onChange: (e: string) => void
+}
+
+const appendNodes = (root: RootNode, nodes: LexicalNode[]) => {
+  nodes
+    .filter((node) => node.__type !== 'linebreak')
+    .map((node) => {
+      if (node.__type === 'text') {
+        const paragraphNode = $createParagraphNode()
+        paragraphNode.append(node)
+        return paragraphNode
+      }
+      return node
+    })
+    .forEach((node) => root.append(node))
 }
 
 export const RichTextEditor: FC<RichTextEditorProps> = ({
@@ -51,18 +71,7 @@ export const RichTextEditor: FC<RichTextEditorProps> = ({
       const root = $getRoot()
       root.clear()
       const nodes = $generateNodesFromDOM(editorState, dom)
-
-      nodes
-        .filter((node) => node.__type !== 'linebreak')
-        .map((node) => {
-          if (node.__type === 'text') {
-            const paragraphNode = $createParagraphNode()
-            paragraphNode.append(node)
-            return paragraphNode
-          }
-          return node
-        })
-        .forEach((node) => root.append(node))
+      appendNodes(root, nodes)
     })
 
   const defaultEditorState = (editor: LexicalEditor) => {
@@ -76,17 +85,7 @@ export const RichTextEditor: FC<RichTextEditorProps> = ({
     const root = $getRoot()
     root.clear()
 
-    nodes
-      .filter((node) => node.__type !== 'linebreak')
-      .map((node) => {
-        if (node.__type === 'text') {
-          const paragraphNode = $createParagraphNode()
-          paragraphNode.append(node)
-          return paragraphNode
-        }
-        return node
-      })
-      .forEach((node) => root.append(node))
+    appendNodes(root, nodes)
   }
 
   const initialConfig = {

--- a/src/RichTextEditor/storybook/Collection.tsx
+++ b/src/RichTextEditor/storybook/Collection.tsx
@@ -16,24 +16,18 @@ export const CollectionPage: FC = () => {
           <RichTextEditor
             outline
             onChange={(e) => console.log(e)}
-            defaultValue={
-              `<div dir=\"ltr\"><div>Testing some features of the rich text viewer. This is an example of an email sent from gmail.<br></div><div><ul><li style=\"margin-left:15px\">bullet</li><li style=\"margin-left:15px\">points<br></li></ul><div><ol><li style=\"margin-left:15px\">numbered</li><li style=\"margin-left:15px\">list</li></ol><div><font size=\"4\">Different</font> <b><i>text</i></b> <u style=\"background-color:rgb(0,255,255)\">formatting</u></div></div></div><div><br></div><span class=\"gmail_signature_prefix\">-- </span><br><div dir=\"ltr\" class=\"gmail_signature\" data-smartmail=\"gmail_signature\"><div dir=\"ltr\"><span style=\"color:rgb(136,136,136);font-family:Roboto,RobotoDraft,Helvetica,Arial,sans-serif\"><font size=\"4\"><b>Liam Piesley</b></font></span><div style=\"color:rgb(136,136,136);font-family:Roboto,RobotoDraft,Helvetica,Arial,sans-serif;font-size:12.8px\"><div>Software Engineer</div><div>Marshmallow</div><div><a href=\"http://www.marshmallow.com/\" rel=\"noreferrer\" style=\"color:rgb(17,85,204)\" target=\"_blank\">www.marshmallow.com</a></div><div><br></div><div><img src=\"https://i.imgur.com/psgAauI.png\" width=\"200\" height=\"39\"><br></div></div></div></div></div>\r\n`
-            }
+            value={`<div dir=\"ltr\"><div>Testing some features of the rich text viewer. This is an example of an email sent from gmail.<br></div><div><ul><li style=\"margin-left:15px\">bullet</li><li style=\"margin-left:15px\">points<br></li></ul><div><ol><li style=\"margin-left:15px\">numbered</li><li style=\"margin-left:15px\">list</li></ol><div><font size=\"4\">Different</font> <b><i>text</i></b> <u style=\"background-color:rgb(0,255,255)\">formatting</u></div></div></div><div><br></div><span class=\"gmail_signature_prefix\">-- </span><br><div dir=\"ltr\" class=\"gmail_signature\" data-smartmail=\"gmail_signature\"><div dir=\"ltr\"><span style=\"color:rgb(136,136,136);font-family:Roboto,RobotoDraft,Helvetica,Arial,sans-serif\"><font size=\"4\"><b>Liam Piesley</b></font></span><div style=\"color:rgb(136,136,136);font-family:Roboto,RobotoDraft,Helvetica,Arial,sans-serif;font-size:12.8px\"><div>Software Engineer</div><div>Marshmallow</div><div><a href=\"http://www.marshmallow.com/\" rel=\"noreferrer\" style=\"color:rgb(17,85,204)\" target=\"_blank\">www.marshmallow.com</a></div><div><br></div><div><img src=\"https://i.imgur.com/psgAauI.png\" width=\"200\" height=\"39\"><br></div></div></div></div></div>\r\n`}
           />
         </Row>
         <Row label="Small Editor">
           <RichTextEditor
             onChange={(e) => console.log(e)}
-            defaultValue={
-              `<p>small</p>`
-            }
+            value={`<p>small</p>`}
             height="84px"
           />
         </Row>
         <Row label="No default value">
-          <RichTextEditor
-            onChange={(e) => console.log(e)}
-          />
+          <RichTextEditor onChange={(e) => console.log(e)} />
         </Row>
       </Box>
     </Box>
@@ -51,9 +45,7 @@ const Row: FC<{ label: string; children?: ReactNode }> = ({
           {label}
         </Text>
       </Box>
-      <Children>
-        {children}
-      </Children>
+      <Children>{children}</Children>
     </RowWrapper>
   )
 }

--- a/src/RichTextEditor/storybook/Example.tsx
+++ b/src/RichTextEditor/storybook/Example.tsx
@@ -6,8 +6,8 @@ export const Example = () => {
   return (
     <RichTextEditor
       onChange={(e) => console.log(e)}
-      maxHeight='1000px'
-      defaultValue={`
+      maxHeight="1000px"
+      value={`
         <h1>H1 Header</h1>
         <h2>H2 Header</h2>
         <h3>H3 Header</h3>

--- a/src/RichTextEditor/storybook/RichText.stories.tsx
+++ b/src/RichTextEditor/storybook/RichText.stories.tsx
@@ -13,11 +13,12 @@ const Template = (props: RichTextEditorProps) => <RichTextEditor {...props} />
 export const Default = Template.bind({})
 
 Default.args = {
-  defaultValue: '<h1>Header</h1><h2>Subheading</h2><p>A paragraph of text with a <a href="https://liamp.uk">link</a></p>',
+  value:
+    '<h1>Header</h1><h2>Subheading</h2><p>A paragraph of text with a <a href="https://liamp.uk">link</a></p>',
   onChange: () => {},
-  height: "300px",
-  maxHeight: "300px",
-  outline: true
+  height: '300px',
+  maxHeight: '300px',
+  outline: true,
 }
 
 export const Collection = CollectionPage.bind({})


### PR DESCRIPTION
## What does this do?

- Change `defaultValue` to `value` in rich text editor (breaking change)
- Allow the value provided to the rich text editor to be updated - for use in email templating