### PR TITLE
fix: success supportMessage icon

### DIFF
--- a/src/SupportMessage/SupportMessage.tsx
+++ b/src/SupportMessage/SupportMessage.tsx
@@ -47,7 +47,7 @@ const styles: Record<SupportMessageType, StylesItem> = {
     iconColor: 'apple',
     backgroundColor: theme.colors.mint,
     hoverBackgroundColor: darken(0.1, theme.colors.mint),
-    icon: 'included',
+    icon: 'circle-tick',
   },
 }
 


### PR DESCRIPTION
## Screenshot / video
before
![Screenshot 2024-04-17 at 09 01 23](https://github.com/marshmallow-insurance/smores-react/assets/57456071/2870848b-e192-4f58-9f28-52c5c4236114)

after
![Screenshot 2024-04-17 at 09 01 02](https://github.com/marshmallow-insurance/smores-react/assets/57456071/01771d22-145c-4637-a744-e4806178dbf1)



## What does this do?

- updates support message success variant icon to the correct icon
