### PR TITLE
fix: remove uuid from tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     "storybook": "^8.0.4",
     "styled-components": "^6.1.8",
     "typescript": "^5.0.2",
-    "vitest": "^1.2.2",
-    "vite": "^5.2.6"
+    "vite": "^5.2.6",
+    "vitest": "^1.2.2"
   },
   "dependencies": {
     "@lexical/react": "^0.13.1",

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -8,7 +8,6 @@ import React, {
 } from 'react'
 import { createPortal } from 'react-dom'
 import styled, { css } from 'styled-components'
-import { v4 as uuidv4 } from 'uuid'
 import { Box } from '../Box'
 import { Text } from '../Text'
 import { useEventListener } from '../hooks'
@@ -48,7 +47,7 @@ export const Tooltip: FC<TooltipProps> = ({
   const [childEl, setChildEl] = useState<HTMLElement | null>(null)
   const [tooltipCoords, setTooltipCoords] = useState({ top: 0, left: 0 })
 
-  const randomId = uuidv4()
+  const randomId = crypto.randomUUID()
 
   const checkInbounds = (element: DOMRect): boolean =>
     element.top >= 0 &&


### PR DESCRIPTION
## Screenshot / video

N/A

## What does this do?

- added this in and didnt realise we were importing this from another dependency and not explicitly declaring as a dependency
- removes use of `uuid` and replaces with `crypto.randomUUID()`