### PR TITLE
feat: add padding props types to `Icon`

### DIFF
--- a/src/Icon/Icon.tsx
+++ b/src/Icon/Icon.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react'
 import styled, { css } from 'styled-components'
-import { MarginProps } from '../utils/space'
+import type { MarginProps, PaddingProps } from '../utils/space'
 
 import { Box } from '../Box'
 import { Color, theme } from '../theme'
@@ -17,7 +17,8 @@ export type IconProps = {
   color?: Color
   /** rotation degrees */
   rotate?: number
-} & MarginProps
+} & MarginProps &
+  PaddingProps
 
 export const Icon: FC<IconProps> = ({
   className = '',

--- a/src/Icon/Icon.tsx
+++ b/src/Icon/Icon.tsx
@@ -26,7 +26,7 @@ export const Icon: FC<IconProps> = ({
   size = 24,
   color = 'liquorice',
   rotate = 0,
-  ...marginProps
+  ...spaceProps
 }) => {
   if (!render || !iconList[render] || render.length === 0) return null
 
@@ -39,14 +39,14 @@ export const Icon: FC<IconProps> = ({
       size={size}
       rotate={rotate}
       color={color}
-      {...marginProps}
+      {...spaceProps}
     >
       <IconComponent />
     </Container>
   )
 }
 
-interface IIcon extends MarginProps {
+interface IIcon extends MarginProps, PaddingProps {
   size: number
   color: Color
   rotate: number


### PR DESCRIPTION
## What does this do?

- Add the typing for padding props to allow downstream to use padding props in `Icon` without typescript errors

`Container` already supports taking in padding we just don't type it.
`Container` is built from `Box`. `Box` implements padding styles from padding props