### PR TITLE
chore: add testid attributes to datepicker month buttons

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -26,6 +26,7 @@ const config = {
           { type: 'perf', release: 'patch' },
           { type: 'test', release: 'patch' },
           { type: 'revert', release: 'patch' },
+          { type: 'chore', release: 'patch' },
         ],
         parserOpts: {
           noteKeywords: [

--- a/src/Datepicker/Datepicker.tsx
+++ b/src/Datepicker/Datepicker.tsx
@@ -122,6 +122,7 @@ export const Datepicker: FC<DatepickerProps> = ({
       >
         <Circle
           type="button"
+          data-testid="last-month"
           disabled={activeMonthIndex === 0}
           onClick={() => setActiveMonth(activeMonthIndex - 1)}
           onKeyDown={(e) => {
@@ -140,6 +141,7 @@ export const Datepicker: FC<DatepickerProps> = ({
 
         <Circle
           type="button"
+          data-testid="next-month"
           disabled={activeMonthIndex === availableMonths.length - 1}
           onClick={() => setActiveMonth(activeMonthIndex + 1)}
           onKeyDown={(e) => {

--- a/src/IconStrict/IconStrict.tsx
+++ b/src/IconStrict/IconStrict.tsx
@@ -10,6 +10,7 @@ import { focusOutlineStyle } from '../utils/focusOutline'
 import { MarginProps } from '../utils/space'
 
 export type IconStrictProps = {
+  id?: string
   /** className attribute to apply classes from props */
   className?: string
   /** set size of the Icon (including background) */
@@ -46,6 +47,7 @@ const iconSizes = {
 }
 
 export const IconStrict: FC<IconStrictProps> = ({
+  id,
   className = '',
   size = 16,
   render,
@@ -56,6 +58,7 @@ export const IconStrict: FC<IconStrictProps> = ({
   ...marginProps
 }) => (
   <IconContainer
+    id={id}
     forwardedAs={handleClick ? 'button' : 'div'}
     className={className}
     $size={size}

--- a/src/Table/types.ts
+++ b/src/Table/types.ts
@@ -30,7 +30,7 @@ export type RowAction<T> = {
   onClick: (rowData: T) => void
   iconButton?: Pick<
     IconStrictProps,
-    'size' | 'render' | 'iconColor' | 'backgroundColor'
+    'size' | 'render' | 'iconColor' | 'backgroundColor' | 'id'
   >
   genericButton?: Pick<
     ButtonProps,
@@ -42,6 +42,7 @@ export type RowAction<T> = {
     | 'fallbackStyle'
     | 'textBtn'
     | 'smallButton'
+    | 'id'
   >
   showCondition?: (rowData: T) => boolean
 }


### PR DESCRIPTION
## What does this do?

- Add `testid`s to datepicker buttons to allow for better testing
- Adds id to rowActions type for genericButton & iconButton
- Adjusts semantic-release config to patch version for chore releases