### PR TITLE
Revert "chore(deps-dev): bump conventional-changelog-conventionalcommits from 7.0.2 to 8.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@types/testing-library__react": "^10.2.0",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.2.0",
-        "conventional-changelog-conventionalcommits": "^8.0.0",
+        "conventional-changelog-conventionalcommits": "^7.0.2",
         "eslint": "^7.9.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-react": "^7.29.2",
@@ -11030,15 +11030,15 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
-      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/testing-library__react": "^10.2.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.2.0",
-    "conventional-changelog-conventionalcommits": "^8.0.0",
+    "conventional-changelog-conventionalcommits": "^7.0.2",
     "eslint": "^7.9.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-react": "^7.29.2",

--- a/release.config.js
+++ b/release.config.js
@@ -26,6 +26,7 @@ const config = {
           { type: 'perf', release: 'patch' },
           { type: 'test', release: 'patch' },
           { type: 'revert', release: 'patch' },
+          { type: 'Revert', release: 'patch' },
           { type: 'chore', release: 'patch' },
         ],
         parserOpts: {
@@ -54,6 +55,7 @@ const config = {
             { type: 'perf', section: 'Performance Improvements' },
             { type: 'test', section: 'Tests' },
             { type: 'revert', hidden: true },
+            { type: 'Revert', hidden: true },
             { type: '*', section: 'Others' },
           ],
         },


### PR DESCRIPTION
Reverts marshmallow-insurance/smores-react#3709

- causing actions to fail: https://github.com/marshmallow-insurance/smores-react/actions/runs/8986485386/job/24682705192
- seems to be causing this issue: https://github.com/conventional-changelog/conventional-changelog/issues/1267