### PR TITLE
fix(caret): pass className to component

### DIFF
--- a/src/Icon/iconFiles/Caret.tsx
+++ b/src/Icon/iconFiles/Caret.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 
-const Caret = () => (
+const Caret = ({ className }: { className?: string }) => (
   <svg
     width="100%"
     height="100%"
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    className={className}
   >
     <path
       d="M19.66 8.248a1 1 0 00-1.412.095L12 15.482l-6.248-7.14a1 1 0 10-1.504 1.317l7 8a.995.995 0 001.504 0l7-8a1 1 0 00-.093-1.411z"


### PR DESCRIPTION
## Screenshot / video

N/A

## What does this do?

Pass `className` to caret component to propagate styled component styles correctly