### PR TITLE
fix: useBodyScrollLock

### DIFF
--- a/src/hooks/useBodyScrollLock/index.ts
+++ b/src/hooks/useBodyScrollLock/index.ts
@@ -5,6 +5,15 @@ import {
   enableBodyScroll,
 } from 'body-scroll-lock'
 
+const enhancedDisabeBodyScroll = (node: HTMLElement | Element) => {
+  disableBodyScroll(node, {
+    reserveScrollBarGap: true,
+    allowTouchMove: () => true,
+  })
+
+  document.body.style.top = `-${window.scrollY}px`
+}
+
 export function useBodyScrollLock({
   node,
   showModal,
@@ -20,10 +29,7 @@ export function useBodyScrollLock({
     if (node === null) return
 
     if (showModal) {
-      disableBodyScroll(node, {
-        reserveScrollBarGap: true,
-        allowTouchMove: () => true,
-      })
+      enhancedDisabeBodyScroll(node)
     } else {
       enableBodyScroll(node)
     }


### PR DESCRIPTION
## Screenshot / video
[Demo](https://www.loom.com/share/67901f6475d84e03b82db99d8f86ba75)

## What does this do?
Solves an issue for iOS devices where opening the modal would scroll body to the top of the screen.
- the change offsets the body by the scroll height when the modal is open

Solution based on https://css-tricks.com/prevent-page-scrolling-when-a-modal-is-open/