### PR TITLE
feat: Add 'title' attribute to  props

### DIFF
--- a/src/IconStrict/IconStrict.tsx
+++ b/src/IconStrict/IconStrict.tsx
@@ -25,6 +25,8 @@ export type IconStrictProps = {
   handleClick?: (e: FormEvent<HTMLButtonElement>) => void
   /** rotation degrees */
   rotate?: number
+  /** Title attribute */
+  title?: string
 } & MarginProps
 
 const iconSizes = {
@@ -55,6 +57,7 @@ export const IconStrict: FC<IconStrictProps> = ({
   backgroundColor,
   rotate,
   handleClick,
+  title,
   ...marginProps
 }) => (
   <IconContainer
@@ -62,6 +65,7 @@ export const IconStrict: FC<IconStrictProps> = ({
     forwardedAs={handleClick ? 'button' : 'div'}
     className={className}
     $size={size}
+    title={title}
     {...marginProps}
     $backgroundColor={backgroundColor}
     onClick={handleClick}


### PR DESCRIPTION
## What does this do?

- Add `title` prop to allow adding the title attribute to `IconStrict`

## Why?
- AP has a few icon buttons that have no tooltips to describe actions in text. Allowing adding the `title` attribute forces the browser to surface text when hovering these buttons