### PR TITLE
chore: cleanup noisy `Table` documentation

### DIFF
--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -8,37 +8,15 @@ import { TableProps } from './types'
 /**
  * A table component that displays data with various features such as expandable rows, striped rows, and fixed headers.
  *
- * Caveats:
- * - subRows should always have the same columns as the Parent table.
- * - stripedColor wont be applied to subRows or subTables.
- * - rowActions will always need an onClick, this will be automatically passed onto the ReactNode you place & will be selectable
- * - rows will scale depending on the cell content size
- * - using clickableRow with clickable cells, ensure you use e.stopPropagation in your cells onClick
+ * ## Caveats:
+ * - `subRows` should always have the same columns as the Parent table
+ * - `stripedColor` wont be applied to `subRows` or `subTables`
+ * - `rowActions` will always need an `onClick`, this will be automatically passed onto the `ReactNode` you place & will be selectable
+ * - Rows will scale depending on the cell content size
+ * - Using `clickableRow` with clickable cells, ensure you use `e.stopPropagation` in your cells `onClick`
  *
- * Improvements:
+ * ## Improvements:
  * - It would be nice if we expandable logic inside this component, e.g the presence of certain props would automatically add this
- * -
- *
- * @template T - The type of data the table displays.
- * @property {T[]} data - Array of data to be displayed in the table.
- * @property {TableColumn<T>[]} columns - Array of columns to display in the table.
- * @property {boolean} [hasKeyline=false] - If true, the table header will have a key line.
- * @property {boolean} [fixedHeader=false] - If true, the table header will be fixed/sticky.
- * @property {string} [headerHeight] - Sets the height of the header.
- * @property {function(T): boolean} [expandable] - A function to determine if a row is expandable.
- * @property {Color} [stripedColor] - If present, the table rows will have alternating colors.
- * @property {Color} [headerColor='mascarpone'] - The color for the table header.
- * @property {Color} [rowColor='custard'] - The default color for each table row.
- * @property {Color} [rowBorderColor='oatmeal'] - The default color for each table row border.
- * @property {ReactElement} [subTable] - A React element to show when a row is expanded.
- * @property {Object} [subRows] - Settings for sub rows.
- * @property {function(T): ReactElement} subRows.rows - Function that returns a React element for the sub row.
- * @property {boolean} [subRows.showOnExpand=false] - If true, the sub rows will only be shown when the row is expanded.
- * @property {RowAction<T>[]} [rowActions] - Array of actions that can be performed on each row.
- * @property {function<T>: void} [clickableRow] - Function to apply to a row, to make the entire row clickable, useful for navigation.
- * @property {string} [rowPadding] - The Y padding for each row.
- * @property {string} [columnPadding] - The X padding for each row.
- * @property {string} [noDataContent] - The text to show when there is no available data to map through.
  */
 export const Table = <T extends object>({
   columns,

--- a/src/Table/types.ts
+++ b/src/Table/types.ts
@@ -70,32 +70,52 @@ export interface TableColumn<T> {
   cell?: RowCellRenderer<T>
 }
 
+/** @template T - The type of data the table displays. */
 interface CommonTableProps<T> {
+  /** Array of columns to display in the table. */
   columns: TableColumn<T>[]
+  /** Sets the height of the header. */
   headerHeight?: string
+  /** If true, the table header will be fixed/sticky. */
   fixedHeader?: boolean
+  /** If true, the table header will have a key line. */
   hasKeyline?: boolean
+  /** If present, the table rows will have alternating colors. */
   stripedColor?: Color
+  /** A function to determine if a row is expandable. */
   expandable?: (rowData: T) => boolean
+  /** The color for the table header. */
   headerColor?: Color
+  /** The default color for each table row. */
   rowColor?: Color
+  /** The default color for each table row border. */
   rowBorderColor?: Color
+  /** A React element to show when a row is expanded. */
   subTable?: {
     table: (rowData: T) => ReactElement
     showOnExpand?: (rowData: T) => boolean
   }
+  /** Settings for sub rows. */
   subRows?: {
+    /** Function that returns a React element for the sub row. */
     rows: (rowData: T) => ReactElement | ReactElement[]
+    /** If true, the sub rows will only be shown when the row is expanded. */
     showOnExpand?: (rowData: T) => boolean
   }
+  /** Function to apply to a row, to make the entire row clickable, useful for navigation. */
   clickableRow?: (rowData: T) => void
+  /** Array of actions that can be performed on each row. */
   rowActions?: RowActions<T>
+  /** The Y padding for each row. */
   rowPadding?: string
+  /** The X padding for each row. */
   columnPadding?: string
 }
 
 export interface TableProps<T> extends CommonTableProps<T> {
+  /** Array of data to be displayed in the table. */
   data: T[]
+  /** The text to show when there is no available data to map through. */
   noDataContent?: ReactNode
 }
 


### PR DESCRIPTION
## Screenshot / video
### Before
<img width="1201" alt="Screenshot 2024-05-20 at 17 23 25" src="https://github.com/marshmallow-insurance/smores-react/assets/63399235/c3694ca8-230a-4337-bfca-e6fcb1d0e625">

### After
<img width="1199" alt="Screenshot 2024-05-20 at 17 31 37" src="https://github.com/marshmallow-insurance/smores-react/assets/63399235/e025773b-0645-4fe7-b2a8-e9853b409860">

## What does this do?

- Cleanup JSDoc of `Table` component to ensure we don't get a noisy blob when viewing the Storybook docs for the component