### PR TITLE
chore: group related packages for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,14 @@ updates:
       ts-eslint:
         patterns:
           - "@typescript-eslint*"
+      storybook-dependencies:
+        patterns:
+          - "@storybook*"
+          - "@storybook/*"
+      semantic-release-dependencies:
+        patterns:
+          - "@semantic-release*"
+          - "@semantic-release/*"
+      babel-dependencies:
+        patterns:
+          - "@babel/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,17 +16,32 @@ updates:
         patterns:
           - "@leixcal*"
           - "lexical*"
+        update-types:
+          - "minor"
+          - "patch"
       ts-eslint:
         patterns:
           - "@typescript-eslint*"
+        update-types:
+          - "minor"
+          - "patch"
       storybook-dependencies:
         patterns:
           - "@storybook*"
           - "@storybook/*"
+        update-types:
+          - "minor"
+          - "patch"
       semantic-release-dependencies:
         patterns:
           - "@semantic-release*"
           - "@semantic-release/*"
+        update-types:
+          - "minor"
+          - "patch"
       babel-dependencies:
         patterns:
           - "@babel/*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
### The spam:

<img width="1430" alt="Screenshot 2024-05-21 at 17 11 07" src="https://github.com/marshmallow-insurance/smores-react/assets/63399235/a0ea2154-94b7-459e-bda4-eaba49b4f681">

## What does this do?

- group more packages to avoid PR spam from dependabot
- explicitly only group `minor` and `patch` versions