### PR TITLE
chore: group `storybook` with other related deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,7 @@ updates:
           - "patch"
       storybook-dependencies:
         patterns:
-          - "@storybook*"
+          - "storybook*"
           - "@storybook/*"
         update-types:
           - "minor"


### PR DESCRIPTION
Missed by https://github.com/marshmallow-insurance/smores-react/pull/3769


## What does this do?

- get dependabot to group `storybook` with other storybook deps 