### PR TITLE
feat: Add `hideTableHeader` prop to `Table`

### DIFF
--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -36,24 +36,27 @@ export const Table = <T extends object>({
   rowPadding,
   columnPadding,
   noDataContent,
+  hideTableHeader = false,
 }: TableProps<T>) => {
   const showActionsCell = expandable || rowActions
   const expandSubProp = showActionsCell ? columns.length + 1 : columns.length
   return (
     <StyledTable>
-      <thead>
-        <TableHeader
-          columns={columns}
-          fixedHeader={fixedHeader}
-          headerHeight={headerHeight}
-          subTable={subTable}
-          headerColor={headerColor}
-          rowActions={rowActions}
-          columnPadding={columnPadding}
-          expandable={expandable}
-          hasKeyline={hasKeyline}
-        />
-      </thead>
+      {!hideTableHeader && (
+        <thead>
+          <TableHeader
+            columns={columns}
+            fixedHeader={fixedHeader}
+            headerHeight={headerHeight}
+            subTable={subTable}
+            headerColor={headerColor}
+            rowActions={rowActions}
+            columnPadding={columnPadding}
+            expandable={expandable}
+            hasKeyline={hasKeyline}
+          />
+        </thead>
+      )}
       <tbody>
         {data.length === 0 && (
           <StyledCell

--- a/src/Table/storybook/Table.stories.tsx
+++ b/src/Table/storybook/Table.stories.tsx
@@ -174,10 +174,9 @@ SubTable.args = {
         <Table
           columns={columnsV2}
           data={data}
-          headerColor="mascarpone"
           rowColor="matcha"
-          fixedHeader={false}
           rowActions={{ actions: rowActions }}
+          hideTableHeader
         />
       )
     },

--- a/src/Table/types.ts
+++ b/src/Table/types.ts
@@ -110,6 +110,8 @@ interface CommonTableProps<T> {
   rowPadding?: string
   /** The X padding for each row. */
   columnPadding?: string
+  /** Hides the table header. Table defaults to always showing the header. */
+  hideTableHeader?: boolean
 }
 
 export interface TableProps<T> extends CommonTableProps<T> {


### PR DESCRIPTION
## Screenshot / video
Hidden table header in a subtable:
<img width="1410" alt="Screenshot 2024-05-22 at 09 39 25" src="https://github.com/marshmallow-insurance/smores-react/assets/63399235/64400e3e-5435-4775-92ad-845d6341ca45">

## What does this do?

- Allows configuring tables to not render a table header. This is to support designs like this ([figma link](https://www.figma.com/design/SB6QnXvPF55xSNs3ohsK5W/Customer-Profile?m=auto&node-id=5168%3A50353&t=7Ngvn6Tc0RXtcxsY-1)):
<img width="735" alt="Screenshot 2024-05-22 at 09 40 51" src="https://github.com/marshmallow-insurance/smores-react/assets/63399235/1bd40636-1bda-4740-92cb-ca9c5be9c11e">
