### PR TITLE
fix(Badge): Change some badge props to be optional

### DIFF
--- a/src/Badge/Badge.tsx
+++ b/src/Badge/Badge.tsx
@@ -9,8 +9,8 @@ export enum BadgeSize {
 }
 
 type Props = {
-    borderColour: Color;
-    size: BadgeSize;
+    borderColour?: Color;
+    size?: BadgeSize;
     src: string;
     disabled?: boolean;
 }


### PR DESCRIPTION
## What does this do?

- Some badge props don't need to be required as we fallback to default values. Only `src` is required