### PR TITLE
fix: Export `Badge` and `BadgeList`

### DIFF
--- a/src/Badge/index.ts
+++ b/src/Badge/index.ts
@@ -1,0 +1,1 @@
+export { Badge, BadgeProps, BadgeSize } from './Badge'

--- a/src/BadgeList/BadgeList.tsx
+++ b/src/BadgeList/BadgeList.tsx
@@ -5,14 +5,14 @@ import styled from 'styled-components'
 import { Tooltip } from '../Tooltip'
 import type { TooltipProps } from '../Tooltip/Tooltip'
 
-type BadgeWithTooltip = Pick<TooltipProps, 'title' | 'content'> & {
+type WithTooltip = Pick<TooltipProps, 'title' | 'content'> & {
   position?: TooltipProps['position']
 }
 
-type UnionBadge = BadgeProps & { tooltip?: BadgeWithTooltip }
+export type BadgeListBadge = BadgeProps & { tooltip?: WithTooltip }
 
 type Props = {
-  badges: Omit<UnionBadge, 'zIndex'>[]
+  badges: Omit<BadgeListBadge, 'zIndex'>[]
 }
 
 export function BadgeList({ badges }: Props) {
@@ -31,7 +31,7 @@ export function BadgeList({ badges }: Props) {
 }
 
 type WithTooltipProps = {
-  badge: UnionBadge
+  badge: BadgeListBadge
 }
 
 const WithTooltip = ({ badge: { tooltip, ...badge } }: WithTooltipProps) => {

--- a/src/BadgeList/index.ts
+++ b/src/BadgeList/index.ts
@@ -1,0 +1,1 @@
+export { BadgeList, BadgeListBadge } from "./BadgeList"

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,3 +44,5 @@ export * from './utils/space'
 export * from './RichText'
 export * from './RichTextEditor'
 export * from './SegmentedControl'
+export * from "./Badge"
+export * from "./BadgeList"


### PR DESCRIPTION

## What does this do?

- We forgot to export the new `Badge` and `BadgeList` components
- Also export the types and enums for the components