### PR TITLE
chore(dependabot): group `lexical` libraries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,8 @@ updates:
     groups:
       lexical:
         patterns:
-          - "@leixcal*"
-          - "lexical*"
+          - "@lexical**"
+          - "lexical**"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Screenshot / video
<img width="1022" alt="Screenshot 2024-06-05 at 11 32 37" src="https://github.com/marshmallow-insurance/smores-react/assets/63399235/647f7b49-c987-4650-981e-b519603e93fe">


## What does this do?

- Group `lexical` libraries together when dependabot creates a PR to bump versions

Previous config had a typo and might've not been catching the extra segment e.g. `/`