### PR TITLE
feat(icon): add tooltips to table row action icon buttons

### DIFF
--- a/src/Table/components/RowActions.tsx
+++ b/src/Table/components/RowActions.tsx
@@ -7,6 +7,7 @@ import { focusOutlineStyle } from '../../utils/focusOutline'
 import { isReactElement } from '../../utils/isReactElement'
 import { RowActionsProps } from '../types'
 import { StyledCell } from './commonComponents'
+import { Tooltip } from '../../Tooltip'
 
 export const RowActions = <T extends object>({
   rowData,
@@ -52,14 +53,28 @@ export const RowActions = <T extends object>({
                       {action.genericButton.children}
                     </Button>
                   )}
-                  {action.iconButton && (
-                    <IconStrict
-                      {...action.iconButton}
-                      handleClick={(e) => {
-                        handleAction(e, action.onClick)
-                      }}
-                    />
-                  )}
+                  {action.iconButton &&
+                    (action.iconButton?.tooltipText ? (
+                      <Tooltip
+                        content={action.iconButton.tooltipText}
+                        position={'bottom'}
+                        tooltipColor={'bubblegum'}
+                      >
+                        <IconStrict
+                          {...action.iconButton}
+                          handleClick={(e) => {
+                            handleAction(e, action.onClick)
+                          }}
+                        />
+                      </Tooltip>
+                    ) : (
+                      <IconStrict
+                        {...action.iconButton}
+                        handleClick={(e) => {
+                          handleAction(e, action.onClick)
+                        }}
+                      />
+                    ))}
                 </Wrapper>
               )
             }

--- a/src/Table/storybook/storyUtils.tsx
+++ b/src/Table/storybook/storyUtils.tsx
@@ -122,6 +122,16 @@ export const rowActions = [
   },
   {
     iconButton: {
+      render: 'alert',
+      backgroundColor: 'mascarpone',
+      size: 36,
+      tooltipText: 'mascarpone tooltip',
+    },
+    onClick: () => exampleOnClick('info icon'),
+    showCondition: (row: DataRow) => row.id === 1,
+  },
+  {
+    iconButton: {
       render: 'info',
       backgroundColor: 'peanut',
       size: 36,

--- a/src/Table/types.ts
+++ b/src/Table/types.ts
@@ -31,7 +31,7 @@ export type RowAction<T> = {
   iconButton?: Pick<
     IconStrictProps,
     'size' | 'render' | 'iconColor' | 'backgroundColor' | 'id'
-  >
+  > & { tooltipText?: string }
   genericButton?: Pick<
     ButtonProps,
     | 'children'

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -11,7 +11,7 @@ import styled, { css } from 'styled-components'
 import { Box } from '../Box'
 import { Text } from '../Text'
 import { useEventListener } from '../hooks'
-import { theme } from '../theme'
+import { Color, theme } from '../theme'
 import { debounce } from '../utils/debounce'
 
 type Position = 'top' | 'bottom' | 'left' | 'right'
@@ -27,6 +27,7 @@ export interface TooltipProps {
   fallbackStyle?: boolean
   zIndex?: number
   portalContainer?: Element | DocumentFragment
+  tooltipColor?: Color
 }
 
 export const Tooltip: FC<TooltipProps> = ({
@@ -39,6 +40,7 @@ export const Tooltip: FC<TooltipProps> = ({
   fallbackStyle = false,
   zIndex = 10,
   portalContainer = document.body,
+  tooltipColor,
 }) => {
   const documentRef = useRef<Document>(document)
   const tipContainer = useRef<HTMLDivElement>(null)
@@ -196,6 +198,7 @@ export const Tooltip: FC<TooltipProps> = ({
             $maxWidth={maxWidth}
             $fallbackStyle={fallbackStyle}
             $zIndex={zIndex}
+            $background={tooltipColor}
             style={{
               position: 'absolute',
               top: `${tooltipCoords.top}px`,
@@ -322,10 +325,12 @@ export const Tip = styled.div<{
   $maxWidth?: number
   $fallbackStyle?: boolean
   $zIndex: number
+  $background?: Color
 }>`
   position: absolute;
   margin: auto;
-  background: ${theme.colors.custard};
+  background: ${({ $background }) =>
+    $background ? theme.colors[$background] : theme.colors.custard};
   padding: 16px 12px 20px;
   border-radius: 16px;
   max-width: 450px;
@@ -348,7 +353,10 @@ export const Tip = styled.div<{
     content: '';
     border-style: solid;
     border-width: 12px 12px 12px 0;
-    border-color: transparent ${theme.colors.custard} transparent transparent;
+    border-color: transparent
+      ${({ $background }) =>
+        $background ? theme.colors[$background] : theme.colors.custard}
+      transparent transparent;
     position: absolute;
   }
 


### PR DESCRIPTION
## Screenshot / video
![image](https://github.com/marshmallow-insurance/smores-react/assets/166642181/fe89dbe7-9574-45f6-bbeb-3b89322c2e79)

## What does this do?
(Part of hackathon)
Adding an optional tooltip to table row action buttons.

Will be used in agent portal to add a tooltip to invoice actions as shown on the screenshot.
