### PR TITLE
feat(Badge): Fallback to `title` when badge image fails to load

### DIFF
--- a/src/Badge/Badge.tsx
+++ b/src/Badge/Badge.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useState } from 'react'
 import styled, { css } from 'styled-components'
 import { theme, type Color } from '../theme'
+import { BadgeFallbackImage } from './BadgeFallbackImage'
 
 export enum BadgeSize {
   Sm = '24px',
@@ -10,21 +11,23 @@ export enum BadgeSize {
 
 export type BadgeProps = {
   src: string | JSX.Element
+  title?: string
   borderColour?: Color
   size?: BadgeSize
   disabled?: boolean
   zIndex?: number
 }
 
-// TODO: add box-shadow transition
-// TODO: add fallback image when image doesn't load - use a marshal?
 export function Badge<T extends BadgeProps>({
   borderColour = 'lollipop',
   size = BadgeSize.Lg,
   src,
   disabled,
   zIndex,
+  title,
 }: BadgeProps) {
+  const [hasFailed, setHasFailed] = useState(false)
+
   if (typeof src === 'string') {
     return (
       <Container
@@ -33,7 +36,18 @@ export function Badge<T extends BadgeProps>({
         $src={src}
         $disabled={disabled}
         $zIndex={zIndex}
-      />
+      >
+        {hasFailed && <BadgeFallbackImage title={title} />}
+        {!hasFailed && (
+          <img
+            width={'100%'}
+            height={'100%'}
+            src={src}
+            alt={title}
+            onError={() => setHasFailed(true)}
+          />
+        )}
+      </Container>
     )
   }
 
@@ -60,6 +74,7 @@ type ContainerProps = {
 
 const Container = styled.div<ContainerProps>((props) => {
   return css`
+    background-color: ${props.$borderColour};
     background-image: ${props.$src ? `url(${props.$src})` : 'none'};
     background-position: center;
     background-size: cover;

--- a/src/Badge/BadgeFallbackImage.tsx
+++ b/src/Badge/BadgeFallbackImage.tsx
@@ -1,0 +1,39 @@
+import React, { useRef } from 'react'
+import { theme } from '../theme'
+import { Text } from '../Text'
+import styled from 'styled-components'
+
+type Props = {
+  title?: string
+}
+
+export function BadgeFallbackImage({ title }: Props) {
+  const bgColour = useRef(
+    fallbackBackgroundColours[
+      Math.floor(Math.random() * fallbackBackgroundColours.length)
+    ],
+  )
+  return (
+    <StyledFallbackImage $backgroundColour={bgColour.current}>
+      <Text typo="caption" color="liquorice" style={{ fontWeight: 'bold' }}>
+        {title?.substring(0, 2) ?? null}
+      </Text>
+    </StyledFallbackImage>
+  )
+}
+
+const fallbackBackgroundColours = [
+  theme.colors.lollipop,
+  theme.colors.marshmallowPink,
+  theme.colors.bubblegum,
+  theme.colors.fairyFloss,
+]
+
+const StyledFallbackImage = styled.div<{ $backgroundColour: string }>`
+  background-color: ${(props) => props.$backgroundColour};
+  display: flex;
+  place-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+`

--- a/src/BadgeList/BadgeList.stories.tsx
+++ b/src/BadgeList/BadgeList.stories.tsx
@@ -12,28 +12,24 @@ export default meta
 
 type Story = StoryObj<typeof BadgeList>
 
+const createTemplateBadge = () => {
+  return {
+    src: BadgeSrcExample,
+    title: 'Barry Scott',
+    tooltip: {
+      title: 'This is a tooltip',
+      content: 'This is the content of the tooltip',
+    },
+  }
+}
+
 export const Primary: Story = {
   args: {
     badges: [
-      {
-        src: BadgeSrcExample,
-        tooltip: {
-          title: 'This is a tooltip',
-          content: 'This is the content of the tooltip',
-        },
-      },
-      {
-        src: BadgeSrcExample,
-        disabled: true,
-      },
-      {
-        src: BadgeSrcExample,
-        disabled: true,
-        tooltip: {
-          title: 'This is a tooltip',
-          content: 'This is the content of the tooltip',
-        },
-      },
+      createTemplateBadge(),
+      { ...createTemplateBadge(), disabled: true },
+      { ...createTemplateBadge(), disabled: true },
+      { ...createTemplateBadge(), disabled: true },
     ],
   },
 }
@@ -42,25 +38,20 @@ export const MediumSize: Story = {
   args: {
     size: BadgeSize.Md,
     badges: [
-      {
-        src: BadgeSrcExample,
-        tooltip: {
-          title: 'This is a tooltip',
-          content: 'This is the content of the tooltip',
-        },
-      },
-      {
-        src: BadgeSrcExample,
-        disabled: true,
-      },
-      {
-        src: BadgeSrcExample,
-        disabled: true,
-        tooltip: {
-          title: 'This is a tooltip',
-          content: 'This is the content of the tooltip',
-        },
-      },
+      createTemplateBadge(),
+      { ...createTemplateBadge(), disabled: true },
+      { ...createTemplateBadge(), disabled: true },
+    ],
+  },
+}
+
+export const BadgeFallback: Story = {
+  args: {
+    limit: 4,
+    badges: [
+      createTemplateBadge(),
+      {...createTemplateBadge(), src: 'example/404.jpg' },
+      createTemplateBadge(),
     ],
   },
 }
@@ -69,45 +60,14 @@ export const BadgeLimit: Story = {
   args: {
     limit: 4,
     badges: [
-      {
-        src: BadgeSrcExample,
-        tooltip: {
-          title: 'This is a tooltip',
-          content: 'This is the content of the tooltip',
-        },
-      },
-      {
-        src: BadgeSrcExample,
-        disabled: true,
-        tooltip: {
-          title: 'This is a tooltip',
-          content: 'This is the content of the tooltip',
-        },
-      },
-      {
-        src: BadgeSrcExample,
-        disabled: true,
-        tooltip: {
-          title: 'This is a tooltip',
-          content: 'This is the content of the tooltip',
-        },
-      },
-      {
-        src: BadgeSrcExample,
-        disabled: true,
-        tooltip: {
-          title: 'This is a tooltip',
-          content: 'This is the content of the tooltip',
-        },
-      },
-      {
-        src: BadgeSrcExample,
-        disabled: true,
-        tooltip: {
-          title: 'This is a tooltip',
-          content: 'This is the content of the tooltip',
-        },
-      },
+      createTemplateBadge(),
+      { ...createTemplateBadge() },
+      { ...createTemplateBadge() },
+      { ...createTemplateBadge(), disabled: true },
+      { ...createTemplateBadge(), disabled: true },
+      { ...createTemplateBadge(), disabled: true },
+      { ...createTemplateBadge(), disabled: true },
+      { ...createTemplateBadge(), disabled: true },
     ],
   },
 }

--- a/src/BadgeList/BadgeList.stories.tsx
+++ b/src/BadgeList/BadgeList.stories.tsx
@@ -47,10 +47,13 @@ export const MediumSize: Story = {
 
 export const BadgeFallback: Story = {
   args: {
-    limit: 4,
+    limit: 5,
     badges: [
-      createTemplateBadge(),
+      {...createTemplateBadge(), src: '' },
       {...createTemplateBadge(), src: 'example/404.jpg' },
+      createTemplateBadge(),
+      createTemplateBadge(),
+      createTemplateBadge(),
       createTemplateBadge(),
     ],
   },

--- a/src/BadgeList/BadgeList.tsx
+++ b/src/BadgeList/BadgeList.tsx
@@ -43,6 +43,7 @@ export function BadgeList({ badges, limit, size }: Props) {
 
       {limitExcess !== undefined && Boolean(limitExcess) && (
         <Badge
+          title={`+${limitExcess}`}
           borderColour="oatmeal"
           size={size}
           src={<ExcessBadge excess={limitExcess} />}
@@ -123,7 +124,9 @@ const WithTooltip = ({ badge: { tooltip, ...badge } }: WithTooltipProps) => {
 
 const Container = styled(Box)`
   & > * {
-    transition: margin 0.2s ease-in-out, padding 0.2s ease-in-out;
+    transition:
+      margin 0.2s ease-in-out,
+      padding 0.2s ease-in-out;
     margin-right: -15px;
   }
 

--- a/src/BadgeList/BadgeList.tsx
+++ b/src/BadgeList/BadgeList.tsx
@@ -29,7 +29,6 @@ export function BadgeList({ badges, limit, size }: Props) {
 
   return (
     <Container flex>
-      {/* TODO: off by one adjustments work, just hard to read, refactor for human eyes 👁️👄👁️ */}
       {badges.slice(0, maxBadges).map((badge, index) => (
         <WithTooltip
           key={typeof badge.src === 'string' ? badge.src : index}


### PR DESCRIPTION
## Screenshot / video

<img width="298" alt="Screenshot 2024-06-05 at 16 36 07" src="https://github.com/marshmallow-insurance/smores-react/assets/63399235/13652a0b-23d1-4f5b-9a1e-75f826c4bf97">


## What does this do?

- Fallback to using `title` when badge image fails to load. Uses first 2 characters of title
