### PR TITLE
feat: Allow autocomplete and inputmode for TextInput

### DIFF
--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -18,8 +18,11 @@ interface Props extends CommonFieldProps {
   onBlur?: (e: FocusEvent<HTMLInputElement>) => void
 }
 
+type AutoComplete = 'off' | 'bday-day	' | 'bday-month' | 'bday-year'
+type InputMode = 'text' | 'email' | 'numeric'
+
 /** on change or on input required */
-type InputProps =
+type InputProps = (
   | {
       /** on change is required and on input optional */
       onChange: (e: string) => void
@@ -30,6 +33,10 @@ type InputProps =
       onChange?: (e: string) => void
       onInputChange: (e: FormEvent<HTMLInputElement>) => void
     }
+) & {
+  autoComplete?: AutoComplete
+  inputMode?: InputMode
+}
 
 export type TextInputProps = Props & InputProps
 
@@ -48,6 +55,8 @@ export const TextInput = forwardRef(function TextInput(
     frontIcon,
     trailingIcon,
     fallbackStyle,
+    autoComplete = 'off',
+    inputMode,
     ...fieldProps
   }: TextInputProps,
   ref: ForwardedRef<HTMLInputElement>,
@@ -75,12 +84,13 @@ export const TextInput = forwardRef(function TextInput(
           $error={error}
           $frontIcon={frontIcon}
           $fallbackStyle={fallbackStyle}
-          autoComplete="off"
+          autoComplete={autoComplete}
           onChange={(e: FormEvent<HTMLInputElement>) => {
             onChange && onChange(e.currentTarget.value)
             onInputChange && onInputChange(e)
           }}
           onBlur={onBlur}
+          inputMode={inputMode}
         />
         {trailingIcon && (
           <StyledTrailingIcon


### PR DESCRIPTION
## Screenshot / video
[Demo](https://www.loom.com/share/0dd53f211b794fec952d8107d20dd4c6)

## What does this do?
- Allows TextInput to take autocomplete and inputmode attribute.
- autocomplete specifies what data we are expecting ([mdn](https://www.w3schools.com/tags/att_input_autocomplete.asp))
- input mode specifies which keyboard to show ([mdn](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode))

Part of [M1 date of birth input](https://github.com/orgs/marshmallow-insurance/projects/7/views/29?pane=issue&itemId=67350316)
