### PR TITLE
chore: add alt text to badge story to prevent accessibility test failing

### DIFF
--- a/src/Badge/Badge.stories.tsx
+++ b/src/Badge/Badge.stories.tsx
@@ -3,28 +3,29 @@ import { Badge, BadgeSize } from './Badge'
 import { BadgeSrcExample } from './storybook-data'
 
 const meta: Meta<typeof Badge> = {
-    title: 'Badge',
-    component: Badge,
-    args: {
-    },
+  title: 'Badge',
+  component: Badge,
+  args: {
+    title: 'badge',
+  },
 }
 
 export default meta
 type Story = StoryObj<typeof Badge>
 
 export const Primary: Story = {
-    args: {
-        borderColour: "lollipop",
-        size: BadgeSize.Lg,
-        src: BadgeSrcExample
-    },
+  args: {
+    borderColour: 'lollipop',
+    size: BadgeSize.Lg,
+    src: BadgeSrcExample,
+  },
 }
 
 export const Disabled: Story = {
-    args: {
-        borderColour: "lollipop",
-        size: BadgeSize.Lg,
-        src: BadgeSrcExample,
-        disabled: true
-    },
+  args: {
+    borderColour: 'lollipop',
+    size: BadgeSize.Lg,
+    src: BadgeSrcExample,
+    disabled: true,
+  },
 }


### PR DESCRIPTION
## Screenshot / video

N/A

## What does this do?

- adds default title to badge storybook args
- stops accessibility tests from failing in CI