### PR TITLE
feat(Table-RowAction): Allow passing `title` to a row action

### DIFF
--- a/src/Table/types.ts
+++ b/src/Table/types.ts
@@ -30,7 +30,7 @@ export type RowAction<T> = {
   onClick: (rowData: T) => void
   iconButton?: Pick<
     IconStrictProps,
-    'size' | 'render' | 'iconColor' | 'backgroundColor' | 'id'
+    'size' | 'render' | 'iconColor' | 'backgroundColor' | 'id' | 'title'
   > & { tooltipText?: string }
   genericButton?: Pick<
     ButtonProps,


### PR DESCRIPTION
## What does this do?

Currently unable to add the `title` prop to a row action in a table, this change fixes this. Row action Icons ar currently defaulting to the `icon-button`.

- Allow adding `title` to row action