### PR TITLE
chore(dependabot): Set versioning strategy to `increase`, ensuring package.json and lockfile are always in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: '/'
+    # Always increase package version to the latest version even if lockfile is the only thing required to change
+    versioning-strategy: increase
     schedule:
       interval: daily
       time: '05:00'


### PR DESCRIPTION
## What does this do?

We are getting dependabot PRs that is only updating the lockfile and not the package json aswell. We ideally want both to be in sync (even if they might not be required to be).
- Ensure dependabot keeps package json and lockfile versioning in sync

Dependabot PRs that are only changing lockfile:
- https://github.com/marshmallow-insurance/smores-react/pull/3854
- https://github.com/marshmallow-insurance/smores-react/pull/3853
- https://github.com/marshmallow-insurance/smores-react/pull/3852

Dependabot docs:
- [versioning strategy](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy)
