### PR TITLE
fix(datepicker): optional availableMonths value

### DIFF
--- a/src/Datepicker/Datepicker.tsx
+++ b/src/Datepicker/Datepicker.tsx
@@ -140,8 +140,8 @@ export const Datepicker: FC<DatepickerProps> = ({
         </Circle>
 
         <Heading tag="h4" typo="body-regular">
-          {availableMonths[activeMonthIndex].label}{' '}
-          {showYear && `- ${getYear(availableMonths[activeMonthIndex].date)}`}
+          {availableMonths[activeMonthIndex]?.label}{' '}
+          {showYear && `- ${getYear(availableMonths[activeMonthIndex]?.date)}`}
         </Heading>
 
         <Circle
@@ -162,7 +162,7 @@ export const Datepicker: FC<DatepickerProps> = ({
 
       <Box flex alignItems="center" justifyContent="center">
         <DatesList
-          items={generateDaysForMonth(availableMonths[activeMonthIndex].date)}
+          items={generateDaysForMonth(availableMonths[activeMonthIndex]?.date)}
           showDayLabels={showDayLabels}
           handleDateSelect={handleSelectEvent}
         />


### PR DESCRIPTION
## Screenshot / video
No visual change 

## What does this do?
Make availableMonths optional to het rid of the sentry warning 
https://marshmallow-insurance.sentry.io/issues/5285077374/?project=4504292403838976&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=3
