### PR TITLE
feat: add onAutoFill prop to TextInput

### DIFF
--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -1,4 +1,10 @@
-import React, { FocusEvent, FormEvent, ForwardedRef, forwardRef } from 'react'
+import React, {
+  FocusEvent,
+  FormEvent,
+  ForwardedRef,
+  forwardRef,
+  HTMLInputAutoCompleteAttribute,
+} from 'react'
 
 import { Box } from '../Box'
 import { Field } from '../fields/Field'
@@ -16,9 +22,9 @@ interface Props extends CommonFieldProps {
   name?: string
   value: string
   onBlur?: (e: FocusEvent<HTMLInputElement>) => void
+  onAutoFill?: () => void
 }
 
-type AutoComplete = 'off' | 'bday-day' | 'bday-month' | 'bday-year'
 type InputMode = 'text' | 'email' | 'numeric'
 
 /** on change or on input required */
@@ -34,7 +40,7 @@ type InputProps = (
       onInputChange: (e: FormEvent<HTMLInputElement>) => void
     }
 ) & {
-  autoCompleteAttr?: AutoComplete
+  autoCompleteAttr?: HTMLInputAutoCompleteAttribute
   inputModeAttr?: InputMode
 }
 
@@ -51,6 +57,7 @@ export const TextInput = forwardRef(function TextInput(
     onBlur,
     onChange,
     onInputChange,
+    onAutoFill,
     disabled = false,
     frontIcon,
     trailingIcon,
@@ -62,6 +69,12 @@ export const TextInput = forwardRef(function TextInput(
   ref: ForwardedRef<HTMLInputElement>,
 ) {
   const id = useUniqueId(idProp)
+
+  const handleAnimationStart = (e: React.AnimationEvent<HTMLInputElement>) => {
+    if (e.animationName === 'onAutoFillStart' && onAutoFill && !!value) {
+      onAutoFill()
+    }
+  }
 
   return (
     <Field {...fieldProps} htmlFor={id} error={error}>
@@ -79,6 +92,7 @@ export const TextInput = forwardRef(function TextInput(
           id={id}
           name={name}
           ref={ref}
+          onAnimationStart={handleAnimationStart}
           placeholder={placeholder}
           value={value}
           $error={error}

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -70,7 +70,7 @@ export const TextInput = forwardRef(function TextInput(
 ) {
   const id = useUniqueId(idProp)
 
-  const handleAnimationStart = (e: React.AnimationEvent<HTMLInputElement>) => {
+  const handleAnimationEnd = (e: React.AnimationEvent<HTMLInputElement>) => {
     if (e.animationName === 'onAutoFillStart' && onAutoFill && !!value) {
       onAutoFill()
     }
@@ -92,7 +92,7 @@ export const TextInput = forwardRef(function TextInput(
           id={id}
           name={name}
           ref={ref}
-          onAnimationStart={handleAnimationStart}
+          onAnimationEnd={handleAnimationEnd}
           placeholder={placeholder}
           value={value}
           $error={error}

--- a/src/TextInput/storybook/Container.tsx
+++ b/src/TextInput/storybook/Container.tsx
@@ -7,14 +7,15 @@ export const Container = () => {
   return (
     <form>
       <TextInput
-        id="textInput4"
-        label="label"
-        name="textInput"
+        type="email"
+        name="email"
+        id="emailTextInput"
+        autoCompleteAttr="email"
+        onAutoFill={() => console.log('i am autoflled' + ' ' + value)}
         onChange={setValue}
         placeholder="Placeholder"
         error={value.length > 7}
         errorMsg="Value is over 7 characters!"
-        trailingIcon="at"
         value={value}
       />
     </form>

--- a/src/fields/components/CommonInput.tsx
+++ b/src/fields/components/CommonInput.tsx
@@ -73,24 +73,10 @@ export const Input = styled.input<IInput>`
 
   &:-webkit-autofill {
     animation-name: onAutoFillStart;
-    animation-duration: 1s;
-  }
-
-  &:not(:-webkit-autofill) {
-    animation-name: onAutoFillCancel;
-    animation-duration: 1s;
+    animation-duration: 2s;
   }
 
   @keyframes onAutoFillStart {
-    from {
-      background-color: inherit;
-    }
-    to {
-      background-color: inherit;
-    }
-  }
-
-  @keyframes onAutoFillCancel {
     from {
       background-color: inherit;
     }

--- a/src/fields/components/CommonInput.tsx
+++ b/src/fields/components/CommonInput.tsx
@@ -70,6 +70,34 @@ export const Input = styled.input<IInput>`
   &::placeholder {
     color: ${theme.colors.sesame};
   }
+
+  &:-webkit-autofill {
+    animation-name: onAutoFillStart;
+    animation-duration: 1s;
+  }
+
+  &:not(:-webkit-autofill) {
+    animation-name: onAutoFillCancel;
+    animation-duration: 1s;
+  }
+
+  @keyframes onAutoFillStart {
+    from {
+      background-color: inherit;
+    }
+    to {
+      background-color: inherit;
+    }
+  }
+
+  @keyframes onAutoFillCancel {
+    from {
+      background-color: inherit;
+    }
+    to {
+      background-color: inherit;
+    }
+  }
 `
 
 export const StyledFrontIcon = styled(Icon)<SIcon>`


### PR DESCRIPTION
## What does this do?
<!-- 
- A short description of what the PR changes and why it's necessary
- Give the reviewers context
- Is the impact global or localised?
- Any tech debt created or discovered?
-->

- adds onAutoFill prop to the TextInput component
- checks for onAutoFillStart animation and to identify when autofill occurs
- this is needed as we use onBlur events for the majority of our fields, however, this does not trigger when a user uses autofill as the browser does not focus the input

NOTE:
- there is one issue with this solution demonstrated in the video though sometimes we can emit an event if a user has a partially entered value, and hovers over a choice for 2s (time taken for the animation duration to end) - not sure this is a huge issue since we will fire again once the user selects the option anyways

## Screenshot / Video
<!--
- applicable for UI changes, can be skipped if not relevant. You can drag and drop images/videos to upload them to GitHub.
- Example with image with fixed width 
  - <img src="https://github.com/marshmallow-insurance/uk-auto-signup-www/assets/57456071/3dbf1ec1-2363-4e20-8236-b1f1581b0953" width="300px" />
shortcuts:
 - Screenshot: cmd + shift + 4
 - Screen recording: cmd + shift + 5
-->



https://github.com/user-attachments/assets/bf3591dd-74e2-40ed-83c4-e6a32edda431


