### PR TITLE
docs: add jsdoc for onAutoFill prop for TextInput

### DIFF
--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -46,6 +46,14 @@ type InputProps = (
 
 export type TextInputProps = Props & InputProps
 
+/**
+ * A reusable TextInput component that supports various input types, custom styling, icons,
+ * and autofill detection.
+ *
+ * ### Caveats:
+ * - `onAutoFill` triggers after animation end (animation duration is 2s),
+ * the animation starts when a user selects or hovers over an autofill option
+ */
 export const TextInput = forwardRef(function TextInput(
   {
     id: idProp,


### PR DESCRIPTION
## What does this do?
<!-- 
- A short description of what the PR changes and why it's necessary
- Give the reviewers context
- Is the impact global or localised?
- Any tech debt created or discovered?
-->

- explains quirks of `onAutoFill` in jsdoc of TextInput

## Screenshot / Video
<!--
- applicable for UI changes, can be skipped if not relevant. You can drag and drop images/videos to upload them to GitHub.
- Example with image with fixed width 
  - <img src="https://github.com/marshmallow-insurance/uk-auto-signup-www/assets/57456071/3dbf1ec1-2363-4e20-8236-b1f1581b0953" width="300px" />
shortcuts:
 - Screenshot: cmd + shift + 4
 - Screen recording: cmd + shift + 5
-->

![Screenshot 2024-09-09 at 10 39 29](https://github.com/user-attachments/assets/553241ec-ffc3-4931-b6b8-2930a2219236)
![Screenshot 2024-09-09 at 10 39 41](https://github.com/user-attachments/assets/b6718829-0564-40b6-af34-ffe6b959b72f)
