### PR TITLE
fix(datePicker): first day error and undefined day

### DIFF
--- a/src/Datepicker/DatesList.tsx
+++ b/src/Datepicker/DatesList.tsx
@@ -15,6 +15,7 @@ type Props = {
 }
 
 const getBlankDaysCount = (firstDayOfTheMonth: Date) => {
+  if (!firstDayOfTheMonth) return
   const dayOfTheWeek = getISODay(firstDayOfTheMonth)
   return dayOfTheWeek - 1
 }
@@ -36,7 +37,7 @@ export const DatesList: FC<Props> = ({
             </Text>
           )
         })}
-      {Array(getBlankDaysCount(items[0].date))
+      {Array(getBlankDaysCount(items[0]?.date))
         .fill(null)
         .map((_, index) => (
           <ListButton


### PR DESCRIPTION
## What does this do?
We had a [sentry issue](https://marshmallow-insurance.sentry.io/issues/5842385619/?environment=production&project=4504292403838976&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+my_teams%2C+none%5D&referrer=issue-stream&sort=inbox&statsPeriod=14d&stream_index=0) coming from date picker with an undefined date, this PR aims to fix that.

## Screenshot / Video


## Relevant tickets / Documentation


## Testing

