### PR TITLE
feat(RowActions): Allow `onClick` events to be awaited

### DIFF
--- a/src/Table/components/RowActions.tsx
+++ b/src/Table/components/RowActions.tsx
@@ -16,12 +16,12 @@ export const RowActions = <T extends object>({
   isExpanded,
   toggleExpansion,
 }: RowActionsProps<T>) => {
-  const handleAction = (
+  const handleAction = async (
     e: MouseEvent | FormEvent<HTMLButtonElement>,
-    action: (rowData: T) => void,
+    action: (rowData: T) => void | Promise<void>,
   ) => {
     e.stopPropagation()
-    action(rowData)
+    await action(rowData)
   }
 
   return (
@@ -37,8 +37,8 @@ export const RowActions = <T extends object>({
                 <Wrapper flex key={actionIndex}>
                   {isReactElement(action.element) &&
                     React.cloneElement(action.element, {
-                      onClick: (e: MouseEvent) => {
-                        handleAction(e, action.onClick)
+                      onClick: async (e: MouseEvent) => {
+                        await handleAction(e, action.onClick)
                       },
                       tabIndex: 0,
                       className: 'reactElementRowAction',
@@ -46,8 +46,8 @@ export const RowActions = <T extends object>({
                   {action.genericButton && !isReactElement(action.element) && (
                     <Button
                       {...action.genericButton}
-                      handleClick={(e) => {
-                        handleAction(e, action.onClick)
+                      handleClick={async (e) => {
+                        await handleAction(e, action.onClick)
                       }}
                     >
                       {action.genericButton.children}
@@ -62,16 +62,16 @@ export const RowActions = <T extends object>({
                       >
                         <IconStrict
                           {...action.iconButton}
-                          handleClick={(e) => {
-                            handleAction(e, action.onClick)
+                          handleClick={async (e) => {
+                            await handleAction(e, action.onClick)
                           }}
                         />
                       </Tooltip>
                     ) : (
                       <IconStrict
                         {...action.iconButton}
-                        handleClick={(e) => {
-                          handleAction(e, action.onClick)
+                        handleClick={async (e) => {
+                          await handleAction(e, action.onClick)
                         }}
                       />
                     ))}


### PR DESCRIPTION
## Screenshot / video

No visual changes. Just adding more functionality

## Test release
https://github.com/marshmallow-insurance/smores-react/actions/runs/11233376670

## What does this do?

The way we've designed how we pass the `onClick` event to a table action is a little restrictive.

Because of this restriction, In AP, we want to run an action after `onClick` has finished, these changes allow us to await the `onClick` handler that is passed down to the custom `element` of a row action.

This **_SHOULD NOT_** change anything downstream as these `onClick` events are typed with a `void` return type - downstream services using this component **_SHOULD NOT_** be assigning the return value of the `onClick` function passed to a custom `element`.