### PR TITLE
feat(rowActions): refactor `RowActions` typing to discriminated union type

### DIFF
--- a/src/Table/components/RowActions.tsx
+++ b/src/Table/components/RowActions.tsx
@@ -35,7 +35,7 @@ export const RowActions = <T extends object>({
             if (!action.showCondition || action.showCondition(rowData)) {
               return (
                 <Wrapper flex key={actionIndex}>
-                  {isReactElement(action.element) &&
+                  {"element" in action && isReactElement(action.element) &&
                     React.cloneElement(action.element, {
                       onClick: (e: MouseEvent) => {
                         handleAction(e, action.onClick)
@@ -43,7 +43,7 @@ export const RowActions = <T extends object>({
                       tabIndex: 0,
                       className: 'reactElementRowAction',
                     })}
-                  {action.genericButton && !isReactElement(action.element) && (
+                  {!("element" in action) && action.genericButton && (
                     <Button
                       {...action.genericButton}
                       handleClick={(e) => {
@@ -53,7 +53,7 @@ export const RowActions = <T extends object>({
                       {action.genericButton.children}
                     </Button>
                   )}
-                  {action.iconButton &&
+                  {!("element" in action) && action.iconButton &&
                     (action.iconButton?.tooltipText ? (
                       <Tooltip
                         content={action.iconButton.tooltipText}

--- a/src/Table/types.ts
+++ b/src/Table/types.ts
@@ -1,3 +1,4 @@
+import React from 'react'
 import { ReactElement, ReactNode } from 'react'
 import { ButtonProps } from '../Button/Button'
 import { IconStrictProps } from '../IconStrict'
@@ -25,27 +26,35 @@ export type TableStylesProps = {
 
 export type Primitive = string | number | boolean | bigint
 
-export type RowAction<T> = {
-  element?: ReactElement
+export type BaseRowAction<T> = {
   onClick: (rowData: T) => void
-  iconButton?: Pick<
-    IconStrictProps,
-    'size' | 'render' | 'iconColor' | 'backgroundColor' | 'id' | 'title'
-  > & { tooltipText?: string }
-  genericButton?: Pick<
-    ButtonProps,
-    | 'children'
-    | 'loading'
-    | 'disabled'
-    | 'primary'
-    | 'secondary'
-    | 'fallbackStyle'
-    | 'textBtn'
-    | 'smallButton'
-    | 'id'
-  >
   showCondition?: (rowData: T) => boolean
 }
+
+export type RowAction<T> = RowActionButtonDefault<T> | RowActionElementOverride<T>
+
+export type RowActionButtonDefault<T> = {
+  iconButton?: Pick<
+  IconStrictProps,
+  'size' | 'render' | 'iconColor' | 'backgroundColor' | 'id' | 'title'
+> & { tooltipText?: string }
+genericButton?: Pick<
+  ButtonProps,
+  | 'children'
+  | 'loading'
+  | 'disabled'
+  | 'primary'
+  | 'secondary'
+  | 'fallbackStyle'
+  | 'textBtn'
+  | 'smallButton'
+  | 'id'
+>
+} & BaseRowAction<T> 
+
+export type RowActionElementOverride<T> = {
+  element: ReactElement
+} & BaseRowAction<T>
 
 export type RowActions<T> = {
   actions: RowAction<T>[]


### PR DESCRIPTION
## What does this do?
Refactor `RowAction` typing.

When `element` is present then `genericButton` and `iconButton` should not be passed.
This refactor ensures the type system understands this restriction and errors when fields are being passed that shouldn't.

For example, before you could do:
```tsx
{
  element: <CustomButton />
  iconButton: {
    render: 'new-window',
    backgroundColor: 'oatmeal',
    size: 36,
    tooltipText: 'Start in new tab',
  },
  onClick: (item) => handleStartReviewClick(item.policyNumber, item.reviewId, true),
},
```

Now the same will error
```tsx
{
  element: <CustomButton />
  iconButton: { // !! iconButton is not expected !!
    render: 'new-window',
    backgroundColor: 'oatmeal',
    size: 36,
    tooltipText: 'Start in new tab',
  },
  onClick: (item) => handleStartReviewClick(item.policyNumber, item.reviewId, true),
},
```

> [!NOTE]
> This improvement works well with your IDE's autocomplete 👌
>  If `element` is set autocomplete won't suggest `iconButton` or `genericButton`

## Screenshot / Video
 - No visual changes
