### PR TITLE
feat(SupportMessage): Add `ref` prop to `SupportMessage` component

### DIFF
--- a/src/SupportMessage/SupportMessage.tsx
+++ b/src/SupportMessage/SupportMessage.tsx
@@ -1,5 +1,5 @@
 import { darken } from 'polished'
-import React, { FC, MouseEventHandler, ReactElement } from 'react'
+import React, { forwardRef, MouseEventHandler, ReactElement } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Box } from '../Box'
@@ -66,44 +66,43 @@ export type SupportMessageProps = {
   title?: string
 } & MarginProps
 
-export const SupportMessage: FC<SupportMessageProps> = ({
-  className,
-  description,
-  onClick,
-  type = 'info',
-  title,
-  ...marginProps
-}) => {
-  return (
-    <Wrapper
-      className={className}
-      $type={type}
-      onClick={onClick}
-      {...marginProps}
-    >
-      <IconWrapper>
-        <Icon
-          size={20}
-          render={styles[type].icon}
-          color={styles[type].iconColor}
-        />
-      </IconWrapper>
-      <Box flex direction="column" mx="8px">
-        {title && <Title>{title}</Title>}
-        {isReactElement(description) ? (
-          <DescriptionBox>{description}</DescriptionBox>
-        ) : (
-          <Description tag="p">{description}</Description>
-        )}
-      </Box>
-      {onClick && (
-        <Box ml={{ custom: 'auto' }}>
-          <Icon size={16} render="caret" color="marzipan" rotate={270} />
+export const SupportMessage = forwardRef<HTMLDivElement, SupportMessageProps>(
+  function SupportMessage(
+    { className, description, onClick, type = 'info', title, ...marginProps },
+    ref,
+  ) {
+    return (
+      <Wrapper
+        ref={ref}
+        className={className}
+        $type={type}
+        onClick={onClick}
+        {...marginProps}
+      >
+        <IconWrapper>
+          <Icon
+            size={20}
+            render={styles[type].icon}
+            color={styles[type].iconColor}
+          />
+        </IconWrapper>
+        <Box flex direction="column" mx="8px">
+          {title && <Title>{title}</Title>}
+          {isReactElement(description) ? (
+            <DescriptionBox>{description}</DescriptionBox>
+          ) : (
+            <Description tag="p">{description}</Description>
+          )}
         </Box>
-      )}
-    </Wrapper>
-  )
-}
+        {onClick && (
+          <Box ml={{ custom: 'auto' }}>
+            <Icon size={16} render="caret" color="marzipan" rotate={270} />
+          </Box>
+        )}
+      </Wrapper>
+    )
+  },
+)
 
 interface IWrapper {
   $type: SupportMessageType


### PR DESCRIPTION
## What does this do?
<!-- 
- A short description of what the PR changes and why it's necessary
- Give the reviewers context
- Is the impact global or localised?
- Any tech debt created or discovered?
-->

## Screenshot / Video
<!--
- applicable for UI changes, can be skipped if not relevant. You can drag and drop images/videos to upload them to GitHub.
- Example with image with fixed width 
  - <img src="https://github.com/marshmallow-insurance/uk-auto-signup-www/assets/57456071/3dbf1ec1-2363-4e20-8236-b1f1581b0953" width="300px" />
shortcuts:
 - Screenshot: cmd + shift + 4
 - Screen recording: cmd + shift + 5
-->

## Relevant tickets / Documentation
<!--
- Link to any relevant issue tracking software (jira, GitHub etc), documentation (PRDs, engineering plans, Figma designs) or slack threads
- If applicable, list any new documentation that has been created/updated e.g. diagrams/flows etc
-->

## Testing
<!--
- Tests should have been updated/created to cover the changes made in this PR, if not please explain why
-->
