### PR TITLE
fix(labelText): default to 4px

### DIFF
--- a/src/LabelledText/LabelledText.tsx
+++ b/src/LabelledText/LabelledText.tsx
@@ -14,7 +14,7 @@ export type LabelledTextProps = {
 export const LabelledText: FC<LabelledTextProps> = ({
   label,
   children,
-  labelMargin = 8,
+  labelMargin = 4,
   ...marginProps
 }) => (
   <Container {...marginProps} $labelMargin={labelMargin + 'px'}>


### PR DESCRIPTION
## What does this do?
Updates the default `labelMargin` value in the `LabelledText` component from 8px to 4px.

## Screenshot / Video
### Old
![Screenshot 2024-10-16 at 09 07 07](https://github.com/user-attachments/assets/8d57c5a6-3264-4cae-9959-5b3f2abce44b)
### New
![Screenshot 2024-10-16 at 09 07 12](https://github.com/user-attachments/assets/5172b526-33f5-46b4-96f9-cc3de5f7431b)

## Relevant tickets / Documentation
- [Notion ticket](https://www.notion.so/getmarshmallow/Labelled-Text-3dcefac9e5a349a2a467ba06a735f1b3?pvs=4)

## Testing
- Visual