### PR TITLE
fix(link): default margin for icon

### DIFF
--- a/src/Link/Link.tsx
+++ b/src/Link/Link.tsx
@@ -60,7 +60,7 @@ export const Link: FC<LinkProps> = ({
       {iconToRender && isTrailingIcon && (
         <Icon
           mt={{ custom: '3px' }}
-          ml={{ custom: '4px' }}
+          ml="8px"
           render={iconToRender}
           size={typo === 'regular' ? 14 : 12}
           color={highlight ? 'lollipop' : 'liquorice'}


### PR DESCRIPTION
## What does this do?
Fixes the default margin for the icon in the `Link` component to be 8px instead of 4px

## Screenshot / Video
### Old
![Screenshot 2024-10-16 at 09 15 29](https://github.com/user-attachments/assets/9de9f2f9-dee1-4138-b378-febc268d02b2)

### New
![Screenshot 2024-10-16 at 09 15 33](https://github.com/user-attachments/assets/8cdd2278-eed5-470f-b745-aa6dd715de85)

## Relevant tickets / Documentation
- [Notion ticket](https://www.notion.so/getmarshmallow/Link-c895e77c1d1e49bf84e5630b91249aff?pvs=4)

## Testing
- Visual