### PR TITLE
fix(chip): icon size and min/max width

### DIFF
--- a/src/Chip/Chip.tsx
+++ b/src/Chip/Chip.tsx
@@ -63,7 +63,7 @@ export const Chip: FC<ChipProps> = forwardRef<HTMLButtonElement, ChipProps>(
           {icon && (
             <IconComponent
               render={icon}
-              size={20}
+              size={16}
               color={primary ? 'liquorice' : 'cream'}
             />
           )}
@@ -90,7 +90,8 @@ const Container = styled(Box)<IButton>(
     justify-content: ${$icon ? 'space-evenly' : 'center'};
     line-height: 100%;
     padding: 8px 16px 8px ${$icon ? '8px' : '16px'};
-    width: 98px;
+    min-width: 98px;
+    max-width: 120px;
     min-height: 40px;
     cursor: ${disabled || $loading ? 'not-allowed' : 'pointer'};
     opacity: ${disabled ? '0.5' : '1'};

--- a/src/Chip/Chip.tsx
+++ b/src/Chip/Chip.tsx
@@ -91,7 +91,6 @@ const Container = styled(Box)<IButton>(
     line-height: 100%;
     padding: 8px 16px 8px ${$icon ? '8px' : '16px'};
     min-width: 98px;
-    max-width: 120px;
     min-height: 40px;
     cursor: ${disabled || $loading ? 'not-allowed' : 'pointer'};
     opacity: ${disabled ? '0.5' : '1'};


### PR DESCRIPTION
## What does this do?
Fixes the icon size and min/max width for the Chip component

## Screenshot / Video
### Old
![Screenshot 2024-10-16 at 09 22 25](https://github.com/user-attachments/assets/c972b612-3533-4216-9ad9-0b5a807bc59b)
![Screenshot 2024-10-16 at 09 25 48](https://github.com/user-attachments/assets/c51c71e7-7fad-4156-91b9-8438170f494d)

### New
![Screenshot 2024-10-16 at 09 22 29](https://github.com/user-attachments/assets/c9cd67a6-a64c-48ad-a783-0f6ae34ba7ba)
![Screenshot 2024-10-16 at 09 23 41](https://github.com/user-attachments/assets/cc3d9bec-0a93-40b7-b01a-8f65e0b6b135)

## Relevant tickets / Documentation
- [Notion ticket](https://www.notion.so/getmarshmallow/Chip-a3d2a61ef2d2414189f6e8ed16d3edcd?pvs=4)
- [Figma design](https://www.figma.com/design/FqSaizGOyOzXFZNmZ4X0LGMn/%F0%9F%8D%AC-S'mores?m=auto&node-id=14411-158465)

## Testing
- Visual