### PR TITLE
chore(release): Allow pre-release for semantic branch prefixes

### DIFF
--- a/.github/workflows/bump_and_publish.yml
+++ b/.github/workflows/bump_and_publish.yml
@@ -10,14 +10,6 @@ jobs:
   bump-and-publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Check branch
-        run: |
-          if [[ "$GITHUB_REF" != "refs/heads/main" && "$GITHUB_REF" != refs/heads/crumbs-* ]]; then
-            echo "This job can only run on the main branch or branches starting with crumbs-"
-            exit 1
-          fi
-        shell: bash
-        
       - name: Checkout 🛎️
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/preview_bump_and_publish.yml
+++ b/.github/workflows/preview_bump_and_publish.yml
@@ -10,14 +10,6 @@ jobs:
   preview-bump-and-publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Check branch
-        run: |
-          if [[ "$GITHUB_REF" != "refs/heads/main" && "$GITHUB_REF" != refs/heads/crumbs-* ]]; then
-            echo "This job can only run on the main branch or branches starting with crumbs-"
-            exit 1
-          fi
-        shell: bash
-        
       - name: Checkout 🛎️
         uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ So to ensure our CHANGELOG.md is updated automatically and gets the changes we h
 
 ## Release
 
+Only the following branches are supported for release:
+- `main`
+- `feature/*`
+- `chore/*`
+- `fix/*`
+
 #### Preview
 Before releasing, you may want to see the changes that will be included in the next version deployed on NPM, you can do so by:
 
@@ -59,11 +65,11 @@ Note: this workflow will fail if the package version is already on the latest, s
 #### Pre-Releases
 Not too different to your usual workflow!
 
-1. Checkout a new branch with the prefix `crumbs-<your-branch-name>`
+1. Checkout a new branch with the prefix `(feature|chore|fix)/<your-branch-name>` e.g. `feature/awesome-new-feature`
 2. Open a PR and create your changes as normal using semantic-commits!
 3. Goto our [github workflows](https://github.com/marshmallow-insurance/smores-react/actions)
 4. Click `Bump and Publish` or `Preview Bump and Publish`
-5. Press `Run workflow` and select `crumbs-<your-branch-name>` branch.
+5. Press `Run workflow` and select `<your-full-branch-name>` branch.
 6. Wait for release!
 7. This can be done multiple times and it will increment your pre-release package version!
 8. When you're happy with the changes, simply squash and merge the PR and release `main`!

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "dompurify": "^3.1.7",
         "fuse.js": "^7.0.0",
         "lexical": "^0.18.0",
+        "micromatch": "^4.0.8",
         "polished": "^4.1.3"
       },
       "devDependencies": {
@@ -8236,7 +8237,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -11013,7 +11013,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -12785,7 +12784,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -16450,7 +16448,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -20241,7 +20239,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -23278,7 +23275,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "dompurify": "^3.1.7",
     "fuse.js": "^7.0.0",
     "lexical": "^0.18.0",
+    "micromatch": "^4.0.8",
     "polished": "^4.1.3"
   },
   "peerDependencies": {

--- a/release.config.js
+++ b/release.config.js
@@ -10,7 +10,7 @@ const config = {
     'main',
     {
       name: '(feature|fix|chore)/*',
-      prerelease: 'crumbs-${name}',
+      prerelease: `crumbs-${branch.split('/').pop()}`,
     },
   ],
   repositoryUrl: 'https://github.com/marshmallow-insurance/smores-react.git',

--- a/release.config.js
+++ b/release.config.js
@@ -5,6 +5,18 @@ const config = {
   branches: [
     'main',
     {
+      name: 'feature/*',
+      prerelease: true,
+    },
+    {
+      name: 'fix/*',
+      prerelease: true,
+    },
+    {
+      name: 'chore/*',
+      prerelease: true,
+    },
+    {
       name: 'crumbs-*',
       prerelease: true,
     },

--- a/release.config.js
+++ b/release.config.js
@@ -87,6 +87,7 @@ const isAcceptedBranch = micromatch.isMatch(
 
 if (!isAcceptedBranch) {
   console.log(`Branch ${branch} is not accepted for release. Skipping release.`)
+  console.log(`Accepted branches: ${config.branches.join(', ')}. [Micromatch](https://github.com/micromatch/micromatch?tab=readme-ov-file#matching-features) is used for matching.`)
   process.exit(0)
 }
 

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,6 @@
-const ref = process.env.GITHUB_REF
-const branch = ref.split('/').pop()
+const branch = process.env.GITHUB_REF_NAME
+
+
 
 const micromatch = require('micromatch');
 

--- a/release.config.js
+++ b/release.config.js
@@ -1,6 +1,8 @@
 const ref = process.env.GITHUB_REF
 const branch = ref.split('/').pop()
 
+const micromatch = require('micromatch');
+
 /**
  * @type {import('semantic-release').GlobalConfig}
  */
@@ -77,6 +79,13 @@ const config = {
       },
     ],
   ],
+}
+
+const isAcceptedBranch = micromatch.isMatch(branch, config.branches.map(b => typeof b === 'object' ? b.name : b))
+
+if (!isAcceptedBranch) {
+  console.log(`Branch ${branch} is not accepted for release. Skipping release.`)
+  process.exit(0)
 }
 
 const isPrereleaseBranch = config.branches.some(

--- a/release.config.js
+++ b/release.config.js
@@ -1,7 +1,5 @@
 const branch = process.env.GITHUB_REF_NAME
 
-
-
 const micromatch = require('micromatch');
 
 /**

--- a/release.config.js
+++ b/release.config.js
@@ -10,7 +10,7 @@ const config = {
     'main',
     {
       name: '(feature|fix|chore)/*',
-      prerelease: `crumbs-${branch.split('/').pop()}`,
+      prerelease: 'crumbs-${name.replace(/\\//g, "-")}',
     },
   ],
   repositoryUrl: 'https://github.com/marshmallow-insurance/smores-react.git',

--- a/release.config.js
+++ b/release.config.js
@@ -10,7 +10,6 @@ const config = {
     {
       name: '(feature|fix|chore)/*',
       prerelease: true,
-      channel: 'crumbs'
     },
   ],
   repositoryUrl: 'https://github.com/marshmallow-insurance/smores-react.git',

--- a/release.config.js
+++ b/release.config.js
@@ -8,7 +8,7 @@ const config = {
   branches: [
     'main',
     {
-      name: '@(feature,fix,chore)/*',
+      name: '(feature|fix|chore)/*',
       prerelease: true,
       channel: 'crumbs'
     },

--- a/release.config.js
+++ b/release.config.js
@@ -11,6 +11,7 @@ const config = {
     {
       name: '(feature|fix|chore)/*',
       prerelease: 'crumbs',
+      channel: 'crumbs',
     },
   ],
   repositoryUrl: 'https://github.com/marshmallow-insurance/smores-react.git',

--- a/release.config.js
+++ b/release.config.js
@@ -10,8 +10,7 @@ const config = {
     'main',
     {
       name: '(feature|fix|chore)/*',
-      prerelease: 'crumbs',
-      channel: 'crumbs',
+      prerelease: true,
     },
   ],
   repositoryUrl: 'https://github.com/marshmallow-insurance/smores-react.git',

--- a/release.config.js
+++ b/release.config.js
@@ -1,24 +1,16 @@
 const ref = process.env.GITHUB_REF
 const branch = ref.split('/').pop()
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 const config = {
   branches: [
     'main',
     {
-      name: 'feature/*',
+      name: '@{feature,fix,chore}/*',
       prerelease: true,
-    },
-    {
-      name: 'fix/*',
-      prerelease: true,
-    },
-    {
-      name: 'chore/*',
-      prerelease: true,
-    },
-    {
-      name: 'crumbs-*',
-      prerelease: true,
+      channel: 'crumbs'
     },
   ],
   repositoryUrl: 'https://github.com/marshmallow-insurance/smores-react.git',

--- a/release.config.js
+++ b/release.config.js
@@ -10,7 +10,7 @@ const config = {
     'main',
     {
       name: '(feature|fix|chore)/*',
-      prerelease: true,
+      prerelease: 'crumbs-${name}',
     },
   ],
   repositoryUrl: 'https://github.com/marshmallow-insurance/smores-react.git',

--- a/release.config.js
+++ b/release.config.js
@@ -1,6 +1,6 @@
 const branch = process.env.GITHUB_REF_NAME
 
-const micromatch = require('micromatch');
+const micromatch = require('micromatch')
 
 /**
  * @type {import('semantic-release').GlobalConfig}
@@ -10,7 +10,7 @@ const config = {
     'main',
     {
       name: '(feature|fix|chore)/*',
-      prerelease: "crumbs",
+      prerelease: 'crumbs',
     },
   ],
   repositoryUrl: 'https://github.com/marshmallow-insurance/smores-react.git',
@@ -80,7 +80,10 @@ const config = {
   ],
 }
 
-const isAcceptedBranch = micromatch.isMatch(branch, config.branches.map(b => typeof b === 'object' ? b.name : b))
+const isAcceptedBranch = micromatch.isMatch(
+  branch,
+  config.branches.map((b) => (typeof b === 'object' ? b.name : b)),
+)
 
 if (!isAcceptedBranch) {
   console.log(`Branch ${branch} is not accepted for release. Skipping release.`)
@@ -88,10 +91,7 @@ if (!isAcceptedBranch) {
 }
 
 const isPrereleaseBranch = config.branches.some(
-  (b) =>
-    typeof b === 'object' &&
-    branch.includes(b.name.slice(0, -1)) &&
-    b.prerelease,
+  (b) => typeof b === 'object' && isAcceptedBranch && b.prerelease,
 )
 
 if (!isPrereleaseBranch) {

--- a/release.config.js
+++ b/release.config.js
@@ -8,7 +8,7 @@ const config = {
   branches: [
     'main',
     {
-      name: '@{feature,fix,chore}/*',
+      name: '@(feature,fix,chore)/*',
       prerelease: true,
       channel: 'crumbs'
     },

--- a/release.config.js
+++ b/release.config.js
@@ -9,7 +9,7 @@ const config = {
     'main',
     {
       name: '(feature|fix|chore)/*',
-      prerelease: true,
+      prerelease: "crumbs",
     },
   ],
   repositoryUrl: 'https://github.com/marshmallow-insurance/smores-react.git',


### PR DESCRIPTION
## What does this do?
Allow for pre-releases on semantic branch prefixes including:
- `feature/*`
- `fix/*`
- `chore/*`

Removed prefix:
- `crumbs-*`

All accepted prefixes can create a pre-release that'll use the current lib version and suffix it with `crumbs-<branch-name>.x` (`x` being the next available pre-release version)

## Relevant tickets / Documentation
- As part of [FE discussion on Slack](https://eatmarshmallows.slack.com/archives/C06636QJ6Q4/p1728383695116449?thread_ts=1728382767.690179&cid=C06636QJ6Q4)
## Testing
- Working on [CI](https://github.com/marshmallow-insurance/smores-react/actions/runs/11571164758/job/32208452065#step:5:107)