### PR TITLE
chore(IconStrict): Add missing `title` to `IconStrict` usages

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -102,6 +102,7 @@ export const Modal: FC<ModalProps> = ({
             {cross && (
               <IconStrict
                 render="cross"
+                title="Close modal"
                 backgroundColor="oatmeal"
                 handleClick={handleClick}
                 size={36}

--- a/src/SearchInput/SearchInput.tsx
+++ b/src/SearchInput/SearchInput.tsx
@@ -281,6 +281,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
                   render="plus"
                   rotate={45}
                   iconColor="marzipan"
+                  title='Clear search'
                   handleClick={handleClearSearch}
                   size={24}
                 />


### PR DESCRIPTION
## What does this do?
- Add missing `title` to `IconStrict` usages. If we dont, it'll default to `'icon-button'`

**NOTE:** We should either:
- Make `title` a mandatory prop
- Or, stop defaulting title to `'icon-button'` and ignore any storybook tests that fail

## Screenshot / Video
<img width="443" alt="Screenshot 2024-10-30 at 15 41 49" src="https://github.com/user-attachments/assets/ef7a43d5-6161-454f-9835-2706ce5d2328">

> Problem