### PR TITLE
feat(SupportMessage): Add `rightSideComponent` prop

### DIFF
--- a/src/SupportMessage/SupportMessage.tsx
+++ b/src/SupportMessage/SupportMessage.tsx
@@ -62,6 +62,10 @@ export type SupportMessageProps = {
   className?: string
   description: string | ReactElement
   onClick?: MouseEventHandler
+  /**
+   * Right side content, usually an icon or a button
+   */
+  rightSideComponent?: ReactElement
   type: SupportMessageType
   title?: string
 } & MarginProps
@@ -70,7 +74,8 @@ export const SupportMessage: FC<SupportMessageProps> = ({
   className,
   description,
   onClick,
-  type = 'info',
+  rightSideComponent,
+  type,
   title,
   ...marginProps
 }) => {
@@ -96,7 +101,8 @@ export const SupportMessage: FC<SupportMessageProps> = ({
           <Description tag="p">{description}</Description>
         )}
       </Box>
-      {onClick && (
+      {rightSideComponent}
+      {onClick && rightSideComponent === undefined && (
         <Box ml={{ custom: 'auto' }}>
           <Icon size={16} render="caret" color="marzipan" rotate={270} />
         </Box>

--- a/src/SupportMessage/storybook/SupportMessage.stories.tsx
+++ b/src/SupportMessage/storybook/SupportMessage.stories.tsx
@@ -1,46 +1,62 @@
 import React from 'react'
 import { Link } from '../../Link'
-import { SupportMessage, SupportMessageProps } from '../SupportMessage'
+import { SupportMessage } from '../SupportMessage'
 import { CollectionPage } from './Collection'
+import type { Meta, StoryObj } from '@storybook/react'
+import { Box } from '../../Box'
 
-export default {
+const meta: Meta<typeof SupportMessage> = {
   title: 'SupportMessage',
   component: SupportMessage,
-}
-
-const Template = (props: SupportMessageProps) => (
-  <SupportMessage {...props}>Support message for customer</SupportMessage>
-)
-
-export const Default = Template.bind({})
-
-const supportMessageArgs: SupportMessageProps = {
-  type: 'info',
-  title: undefined,
-  description: 'Some description text',
-}
-
-Default.args = supportMessageArgs
-
-export const WithCustomDescription = Template.bind({})
-
-WithCustomDescription.args = {
-  type: 'info',
-  title: 'A SupportMessage using the Link component',
-  description: (
-    <div>
-      Some text rendered using a <Link href={''}>Link</Link>
-    </div>
+  args: {
+    type: 'info',
+    title: undefined,
+    description: 'Some description text',
+  },
+  render: (args) => (
+    <SupportMessage {...args}>Support message for customer</SupportMessage>
   ),
 }
 
-export const Clickable = Template.bind({})
+export default meta
+type Story = StoryObj<typeof SupportMessage>
 
-Clickable.args = {
-  type: 'info',
-  title: 'An interactive SupportMessage',
-  description: 'Click me!',
-  onClick: () => alert('Clicked!'),
+export const WithCustomDescription: Story = {
+  args: {
+    type: 'info',
+    title: 'A SupportMessage using the Link component',
+    description: (
+      <div>
+        Some text rendered using a <Link href={''}>Link</Link>
+      </div>
+    ),
+  },
 }
 
-export const Collection = CollectionPage.bind({})
+export const Clickable: Story = {
+  args: {
+    type: 'info',
+    title: 'An interactive SupportMessage',
+    description: 'Click me!',
+    onClick: () => alert('Clicked!'),
+  },
+}
+
+export const WithRightSideComponent: Story = {
+  args: {
+    type: 'info',
+    title: 'An interactive SupportMessage',
+    rightSideComponent: (
+      <Box ml={{ custom: 'auto' }}>
+        <Link href={undefined as unknown as string}>
+          This is a right side component
+        </Link>
+      </Box>
+    ),
+    description: 'Click me!',
+  },
+}
+
+export const Collection: Story = {
+  decorators: [() => <CollectionPage />],
+}


### PR DESCRIPTION
## What does this do?
- Adds `rightSideComponent` prop, allowing right side of the `SupportMessage`'s content to be configurable
- Updated component story, using new [Component Story Format (CSF)](https://storybook.js.org/docs/api/csf) API

Needed to add text on the right side of the component (see below for images and a link to designs)
## Screenshot / Video

https://github.com/user-attachments/assets/b7c8f922-ad23-4466-8385-259a0f323392

> Storybook demo

## Relevant tickets / Documentation
<img width="892" alt="Screenshot 2024-10-31 at 15 08 15" src="https://github.com/user-attachments/assets/9cbefa64-be83-454a-9a57-94f3ad2458c7">

- [Figma Designs](https://www.figma.com/design/SB6QnXvPF55xSNs3ohsK5W/Customer-Profile?m=auto&node-id=4942-89422&t=9mzKmwHzKdpJFDxM-1)
- closes https://github.com/marshmallow-insurance/multi-product/issues/662
- Used in https://github.com/marshmallow-insurance/uk-auto-agent-portal-www/pull/7339
