### PR TITLE
chore: fix vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,11 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    include: ['src/**/__tests__/*'],
-    exclude: ['**/node_modules/**', '**/*.stories.js', 'src/utils/**'],
+    include: [
+      '**/__tests__/**/*.{js,ts}',
+      '**/*.test.{js,ts}',
+      '**/*.spec.{js,ts}',
+    ],
+    exclude: ['**/node_modules/**', '**/*.stories.{js,ts}'],
   },
 })


### PR DESCRIPTION
## What does this do?
<!-- 
- A short description of what the PR changes and why it's necessary
- Give the reviewers context
- Is the impact global or localised?
- Any tech debt created or discovered?
-->

vitest config was not grabbing all appropriate test files - so running npm run test, would not actually test all file