### PR TITLE
fix: prevent change on scroll for number input

### DIFF
--- a/src/NumberInput/NumberInput.tsx
+++ b/src/NumberInput/NumberInput.tsx
@@ -149,6 +149,7 @@ export const NumberInput = forwardRef(function NumberInput(
           $frontIcon={frontIcon}
           step={step}
           $fallbackStyle={fallbackStyle}
+          onWheel={(e) => e.currentTarget.blur()}
           onChange={(e: FormEvent<HTMLInputElement>) => {
             onChange && handleChange(e.currentTarget.value)
             onInputChange && onInputChange(e)


### PR DESCRIPTION
## What does this do?
- Prevent scrolling changing the number value

## Screenshot / Video
- No visual change

## Relevant tickets / Documentation
- Suggestion from FNOL testing: https://eatmarshmallows.slack.com/archives/C07P6AZ8VV0/p1733303228197279?thread_ts=1733239467.063109&cid=C07P6AZ8VV0

