### PR TITLE
Revert "PE-1116 Use centralized dependabot auto-approve workflow (#4046)

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,9 +1,0 @@
-name: Approve and Merge Dependabot PRs
-
-on:
-  pull_request_target:
-    branches: [ main ]
-
-jobs:
-  auto-merge-dependabot:
-    uses: marshmallow-insurance/actions-reusable-workflows/.github/workflows/auto-merge-dependabot.yml@main

--- a/.github/workflows/autoApproveDependabotPullRequests.yml
+++ b/.github/workflows/autoApproveDependabotPullRequests.yml
@@ -1,0 +1,41 @@
+name: Auto approve Dependabot pull requests
+on:
+  pull_request_target:
+    branches: [ main ]
+
+jobs:
+  approve-job:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.6.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Determine whether to run
+        id: should-run
+        run: |
+          case "${{ steps.dependabot-metadata.outputs.update-type }}" in
+              version-update:semver-patch) should_run=true ;;
+              version-update:semver-minor) should_run=true ;;
+              *) should_run=false ;;
+          esac
+          echo should_run=$should_run >> $GITHUB_OUTPUT
+      - name: Approve Pull Request
+        if: steps.should-run.outputs.should_run == 'true'
+        uses: hmarr/auto-approve-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add squash and merge comment to PR
+        if: steps.should-run.outputs.should_run == 'true'
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.AUTO_MERGE_DEPENDABOT_PR }}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '@dependabot squash and merge'
+            })


### PR DESCRIPTION
This reverts commit b637866ab359a9dedabf9313d34f288425681ca4.

GitHub docs says we can't do this because smores is a public repo:
> [Actions and reusable workflows stored in private repositories cannot be used in public repositories](https://docs.github.com/en/actions/sharing-automations/sharing-actions-and-workflows-from-your-private-repository)
