### PR TITLE
fix(dateOfBirthValidator): Unable to build downstream apps because of missing import

### DIFF
--- a/src/utils/dateOfBirth/dateOfBirthValidator.ts
+++ b/src/utils/dateOfBirth/dateOfBirthValidator.ts
@@ -9,7 +9,7 @@ import {
 } from './dateOfBirthValidator.utils'
 import { FieldValidationError, InputValidationError } from './schema'
 
-import { DateObject } from 'TextDateOfBirthInput'
+import { DateObject } from '../../TextDateOfBirthInput'
 
 export const dateOfBirthValidator = (dateObject: DateObject) => {
   const invalidFields = getInvalidInputFields(dateObject)


### PR DESCRIPTION
[INT-68]

## What does this do?
- Fix unable to build downstream apps because of missing import

When building out package assets, the asserts' imports aren't coerced into relative imports which break namespace imports like the one found in this PR.

## Screenshot / Video
<img width="1483" alt="Screenshot 2025-01-09 at 11 15 11" src="https://github.com/user-attachments/assets/f0498b84-2fd1-435b-a319-8a8ab1816f22" />

## Testing
Downstream


[INT-68]: https://marshmallow1.atlassian.net/browse/INT-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ