### PR TITLE
fix(React): Fix types after react 19 upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@floating-ui/react": "0.27.3",
         "@lexical/react": "^0.23.0",
-        "@storybook/preview-api": "^8.4.7",
         "body-scroll-lock": "^4.0.0-beta.0",
         "date-fns": "^4.1.0",
         "dompurify": "^3.2.3",
@@ -38,6 +37,7 @@
         "@storybook/addon-essentials": "^8.4.7",
         "@storybook/addon-interactions": "^8.4.7",
         "@storybook/addon-links": "^8.4.7",
+        "@storybook/preview-api": "^8.4.7",
         "@storybook/react": "^8.4.7",
         "@storybook/react-vite": "^8.4.7",
         "@storybook/test": "^8.2.1",
@@ -2167,6 +2167,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "aix"
@@ -2182,6 +2183,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -2197,6 +2199,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -2212,6 +2215,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -2227,6 +2231,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2242,6 +2247,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2257,6 +2263,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -2272,6 +2279,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -2287,6 +2295,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2302,6 +2311,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2317,6 +2327,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2332,6 +2343,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2347,6 +2359,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2362,6 +2375,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2377,6 +2391,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2392,6 +2407,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2407,6 +2423,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2422,6 +2439,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -2437,6 +2455,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -2452,6 +2471,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -2467,6 +2487,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -2482,6 +2503,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -2497,6 +2519,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2512,6 +2535,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2527,6 +2551,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -5504,6 +5529,7 @@
       "version": "8.4.7",
       "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.4.7.tgz",
       "integrity": "sha512-7Z8Z0A+1YnhrrSXoKKwFFI4gnsLbWzr8fnDCU6+6HlDukFYh8GHRcZ9zKfqmy6U3hw2h8H5DrHsxWfyaYUUOoA==",
+      "dev": true,
       "dependencies": {
         "@storybook/csf": "^0.1.11",
         "better-opn": "^3.0.2",
@@ -5534,6 +5560,7 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5545,6 +5572,7 @@
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.11.tgz",
       "integrity": "sha512-dHYFQH3mA+EtnCkHXzicbLgsvzYjcDJ1JWsogbItZogkPHgSJM/Wr71uMkcvw8v9mmCyP4NpXJuu6bPoVsOnzg==",
+      "dev": true,
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -5644,6 +5672,8 @@
       "version": "8.4.7",
       "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.4.7.tgz",
       "integrity": "sha512-0QVQwHw+OyZGHAJEXo6Knx+6/4er7n2rTDE5RYJ9F2E2Lg42E19pfdLlq2Jhoods2Xrclo3wj6GWR//Ahi39Eg==",
+      "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
@@ -7214,6 +7244,7 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
       "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -7224,7 +7255,8 @@
     "node_modules/ast-types/node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -7236,6 +7268,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -7520,6 +7553,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/better-opn/-/better-opn-3.0.2.tgz",
       "integrity": "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==",
+      "dev": true,
       "dependencies": {
         "open": "^8.0.4"
       },
@@ -7583,7 +7617,8 @@
     "node_modules/browser-assert": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
-      "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ=="
+      "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
+      "dev": true
     },
     "node_modules/browserslist": {
       "version": "4.24.0",
@@ -7678,6 +7713,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
@@ -7695,6 +7731,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
       "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -7707,6 +7744,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
       "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "get-intrinsic": "^1.2.6"
@@ -8801,6 +8839,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -8895,6 +8934,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -8911,6 +8951,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9087,6 +9128,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -9301,6 +9343,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -9309,6 +9352,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -9350,6 +9394,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
       "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -9407,6 +9452,7 @@
       "version": "0.24.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
       "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -9446,6 +9492,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.5.0.tgz",
       "integrity": "sha512-+4G/XmakeBAsvJuDugJvtyF1x+XJT4FMocynNpxrvEBViirpfUn2PgNpCHedfWhF4WokNsO/OvMKrmJOIJsI5A==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -9945,6 +9992,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -10519,6 +10567,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
       }
@@ -10666,6 +10715,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -10754,6 +10804,7 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
       "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
+      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "dunder-proto": "^1.0.0",
@@ -10985,6 +11036,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -11050,6 +11102,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -11076,6 +11129,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -11087,6 +11141,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -11138,6 +11193,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -11473,7 +11529,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/ini": {
       "version": "4.1.1",
@@ -11518,6 +11575,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -11614,6 +11672,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -11670,6 +11729,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -11730,6 +11790,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
       "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -11931,6 +11992,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
       "dependencies": {
         "which-typed-array": "^1.1.16"
       },
@@ -12015,6 +12077,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -14472,6 +14535,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
       "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
+      "dev": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -15335,6 +15399,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -15516,7 +15581,8 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/mustache": {
       "version": "4.2.0",
@@ -18731,6 +18797,7 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
       "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -19259,6 +19326,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -19310,7 +19378,7 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
       "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -19374,6 +19442,7 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -19726,6 +19795,7 @@
       "version": "0.23.7",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.7.tgz",
       "integrity": "sha512-MpQlLZVpqbbxYcqEjwpRWo88sGvjOYoXptySz710RuddNMHx+wPkoNX6YyLZJlXAh5VZr1qmPrTwcTuFMh0Lag==",
+      "dev": true,
       "dependencies": {
         "ast-types": "^0.16.1",
         "esprima": "~4.0.0",
@@ -19740,7 +19810,8 @@
     "node_modules/recast/node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -20661,6 +20732,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -20895,6 +20967,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21128,6 +21201,7 @@
       "version": "8.4.7",
       "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.4.7.tgz",
       "integrity": "sha512-RP/nMJxiWyFc8EVMH5gp20ID032Wvk+Yr3lmKidoegto5Iy+2dVQnUoElZb2zpbVXNHWakGuAkfI0dY1Hfp/vw==",
+      "dev": true,
       "dependencies": {
         "@storybook/core": "8.4.7"
       },
@@ -21784,7 +21858,8 @@
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -21980,6 +22055,7 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -22310,6 +22386,7 @@
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
       "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -23871,6 +23948,7 @@
       "version": "1.1.18",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
       "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
+      "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
@@ -24064,6 +24142,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@storybook/addon-essentials": "^8.4.7",
     "@storybook/addon-interactions": "^8.4.7",
     "@storybook/addon-links": "^8.4.7",
+    "@storybook/preview-api": "^8.4.7",
     "@storybook/react": "^8.4.7",
     "@storybook/react-vite": "^8.4.7",
     "@storybook/test": "^8.2.1",
@@ -86,7 +87,6 @@
   "dependencies": {
     "@floating-ui/react": "0.27.3",
     "@lexical/react": "^0.23.0",
-    "@storybook/preview-api": "^8.4.7",
     "body-scroll-lock": "^4.0.0-beta.0",
     "date-fns": "^4.1.0",
     "dompurify": "^3.2.3",

--- a/src/Badge/Badge.tsx
+++ b/src/Badge/Badge.tsx
@@ -1,4 +1,4 @@
-import React, { useState, type JSX } from 'react';
+import React, { useState, type JSX } from 'react'
 import styled, { css } from 'styled-components'
 import { theme, type Color } from '../theme'
 import { BadgeFallbackImage } from './BadgeFallbackImage'
@@ -18,7 +18,7 @@ export type BadgeProps = {
   zIndex?: number
 }
 
-export function Badge<T extends BadgeProps>({
+export function Badge({
   borderColour = 'lollipop',
   size = BadgeSize.Lg,
   src,

--- a/src/Badge/Badge.tsx
+++ b/src/Badge/Badge.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, type JSX } from 'react';
 import styled, { css } from 'styled-components'
 import { theme, type Color } from '../theme'
 import { BadgeFallbackImage } from './BadgeFallbackImage'

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -56,7 +56,7 @@ const RadioGroupComponent = <Value extends BaseValueType>(
 ) => {
   const name = useUniqueId()
 
-  const optionRefs = useRef<RefObject<HTMLInputElement>[]>([])
+  const optionRefs = useRef<RefObject<HTMLInputElement | null>[]>([])
   useImperativeHandle(ref, () => {
     return {
       focus: () => {
@@ -107,7 +107,7 @@ export const RadioGroup = forwardRef(RadioGroupComponent) as <
   Value extends BaseValueType = BaseValueType,
 >(
   p: RadioGroupProps<Value> & React.RefAttributes<HTMLInputElement>,
-) => ReactElement | null
+) => ReactElement<any> | null
 
 const RadioItemList = styled.div<
   TransientProps<Pick<RadioGroupProps, 'displayType'>>

--- a/src/SearchInput/components/SearchOptions.tsx
+++ b/src/SearchInput/components/SearchOptions.tsx
@@ -38,7 +38,7 @@ export const SearchOptions: FC<SearchOptionsProps> = ({
   searchTerm,
   notFoundComponent,
 }) => {
-  const itemRefs = useRef<React.RefObject<HTMLLIElement>[]>([])
+  const itemRefs = useRef<React.RefObject<HTMLLIElement | null>[]>([])
 
   useEffect(() => {
     itemRefs.current = displayedList.map(

--- a/src/SupportMessage/SupportMessage.tsx
+++ b/src/SupportMessage/SupportMessage.tsx
@@ -60,12 +60,12 @@ type SupportMessageType =
 
 export type SupportMessageProps = {
   className?: string
-  description: string | ReactElement
+  description: string | ReactElement<unknown>
   onClick?: MouseEventHandler
   /**
    * Right side content, usually an icon or a button
    */
-  rightSideComponent?: ReactElement
+  rightSideComponent?: ReactElement<unknown>
   type: SupportMessageType
   title?: string
 } & MarginProps

--- a/src/SupportMessage/SupportMessage.tsx
+++ b/src/SupportMessage/SupportMessage.tsx
@@ -60,12 +60,16 @@ type SupportMessageType =
 
 export type SupportMessageProps = {
   className?: string
-  description: string | ReactElement<unknown>
+  // TODO: React 19 requires the props type by default. It was previously inferred to be 'any'. It would be beneficial to explicitly type this generic value
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  description: string | ReactElement<any>
   onClick?: MouseEventHandler
   /**
    * Right side content, usually an icon or a button
    */
-  rightSideComponent?: ReactElement<unknown>
+  // TODO: React 19 requires the props type by default. It was previously inferred to be 'any'. It would be beneficial to explicitly type this generic value
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  rightSideComponent?: ReactElement<any>
   type: SupportMessageType
   title?: string
 } & MarginProps

--- a/src/Table/components/TableRow.tsx
+++ b/src/Table/components/TableRow.tsx
@@ -1,15 +1,9 @@
 import React, { ReactElement, ReactNode, useState } from 'react'
 import { isReactElement } from '../../utils/isReactElement'
 import { isMappedReactElement } from '../helpers'
-import { TableRowProps, type RowActions as RowActionsType } from '../types'
+import { TableRowProps } from '../types'
 import { RowActions } from './RowActions'
 import { StyledCell, StyledRow } from './commonComponents'
-
-type SubRowProps = {
-  rowPadding: string | undefined
-  columnPadding: string | undefined
-  showActions: ((rowData: unknown) => boolean) | RowActionsType<unknown> | undefined
-}
 
 export const TableRow = <T extends object>({
   rowData,
@@ -100,7 +94,9 @@ export const TableRow = <T extends object>({
             subRowsData &&
             showSubRowsOnExpand &&
             isReactElement(subRowsData) &&
-            React.cloneElement(subRowsData as ReactElement<SubRowProps>, {
+            // TODO: React 19 requires the props type by default. It was previously inferred to be 'any'. It would be beneficial to explicitly type this generic value
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            React.cloneElement(subRowsData as ReactElement<any>, {
               rowPadding: rowPadding,
               columnPadding: columnPadding,
             })}
@@ -109,7 +105,9 @@ export const TableRow = <T extends object>({
             subRowsData &&
             showSubRowsOnExpand &&
             isMappedReactElement(subRowsData) &&
-            (subRowsData as ReactElement<SubRowProps>[]).map((row) =>
+            // TODO: React 19 requires the props type by default. It was previously inferred to be 'any'. It would be beneficial to explicitly type this generic value
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (subRowsData as ReactElement<any>[]).map((row) =>
               React.cloneElement(row, {
                 rowPadding: rowPadding,
                 showActions: showActionsCell,
@@ -118,10 +116,14 @@ export const TableRow = <T extends object>({
 
           {subTable && showSubTableOnExpand && subTableData && (
             <StyledCell colSpan={expandSubProp}>
-              {React.cloneElement(subTableData as ReactElement<SubRowProps>, {
-                rowPadding: rowPadding,
-                columnPadding: columnPadding,
-              })}
+              {
+                // TODO: React 19 requires the props type by default. It was previously inferred to be 'any'. It would be beneficial to explicitly type this generic value
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                React.cloneElement(subTableData as ReactElement<any>, {
+                  rowPadding: rowPadding,
+                  columnPadding: columnPadding,
+                })
+              }
             </StyledCell>
           )}
         </>
@@ -136,7 +138,9 @@ export const TableRow = <T extends object>({
         subRowsData &&
         !showSubRowsOnExpand &&
         isReactElement(subRowsData) &&
-        React.cloneElement(subRowsData as ReactElement<SubRowProps>, {
+        // TODO: React 19 requires the props type by default. It was previously inferred to be 'any'. It would be beneficial to explicitly type this generic value
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        React.cloneElement(subRowsData as ReactElement<any>, {
           rowPadding: rowPadding,
           columnPadding: columnPadding,
         })}
@@ -144,7 +148,9 @@ export const TableRow = <T extends object>({
         subRowsData &&
         !showSubRowsOnExpand &&
         isMappedReactElement(subRowsData) &&
-        (subRowsData as ReactElement<SubRowProps>[]).map((row) =>
+        // TODO: React 19 requires the props type by default. It was previously inferred to be 'any'. It would be beneficial to explicitly type this generic value
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (subRowsData as ReactElement<any>[]).map((row) =>
           React.cloneElement(row, {
             rowPadding: rowPadding,
             columnPadding: columnPadding,
@@ -152,10 +158,14 @@ export const TableRow = <T extends object>({
         )}
       {subTable && subTableData && !showSubTableOnExpand && (
         <StyledCell colSpan={expandSubProp}>
-          {React.cloneElement(subTableData as ReactElement<SubRowProps>, {
-            rowPadding: rowPadding,
-            columnPadding: columnPadding,
-          })}
+          {
+            // TODO: React 19 requires the props type by default. It was previously inferred to be 'any'. It would be beneficial to explicitly type this generic value
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            React.cloneElement(subTableData as ReactElement<any>, {
+              rowPadding: rowPadding,
+              columnPadding: columnPadding,
+            })
+          }
         </StyledCell>
       )}
     </>

--- a/src/Table/components/TableRow.tsx
+++ b/src/Table/components/TableRow.tsx
@@ -1,9 +1,15 @@
 import React, { ReactElement, ReactNode, useState } from 'react'
 import { isReactElement } from '../../utils/isReactElement'
 import { isMappedReactElement } from '../helpers'
-import { TableRowProps } from '../types'
+import { TableRowProps, type RowActions as RowActionsType } from '../types'
 import { RowActions } from './RowActions'
 import { StyledCell, StyledRow } from './commonComponents'
+
+type SubRowProps = {
+  rowPadding: string | undefined
+  columnPadding: string | undefined
+  showActions: ((rowData: unknown) => boolean) | RowActionsType<unknown> | undefined
+}
 
 export const TableRow = <T extends object>({
   rowData,
@@ -83,7 +89,6 @@ export const TableRow = <T extends object>({
           />
         )}
       </StyledRow>
-
       {/**
        * This could be extracted out and cleaned up
        * this section is for expanded rows only
@@ -95,7 +100,7 @@ export const TableRow = <T extends object>({
             subRowsData &&
             showSubRowsOnExpand &&
             isReactElement(subRowsData) &&
-            React.cloneElement(subRowsData as ReactElement, {
+            React.cloneElement(subRowsData as ReactElement<SubRowProps>, {
               rowPadding: rowPadding,
               columnPadding: columnPadding,
             })}
@@ -104,7 +109,7 @@ export const TableRow = <T extends object>({
             subRowsData &&
             showSubRowsOnExpand &&
             isMappedReactElement(subRowsData) &&
-            (subRowsData as ReactElement[]).map((row) =>
+            (subRowsData as ReactElement<SubRowProps>[]).map((row) =>
               React.cloneElement(row, {
                 rowPadding: rowPadding,
                 showActions: showActionsCell,
@@ -113,7 +118,7 @@ export const TableRow = <T extends object>({
 
           {subTable && showSubTableOnExpand && subTableData && (
             <StyledCell colSpan={expandSubProp}>
-              {React.cloneElement(subTableData, {
+              {React.cloneElement(subTableData as ReactElement<SubRowProps>, {
                 rowPadding: rowPadding,
                 columnPadding: columnPadding,
               })}
@@ -121,7 +126,6 @@ export const TableRow = <T extends object>({
           )}
         </>
       )}
-
       {/**
        * This could be extracted out and cleaned up
        * this section is for rendering things under a row,
@@ -132,25 +136,23 @@ export const TableRow = <T extends object>({
         subRowsData &&
         !showSubRowsOnExpand &&
         isReactElement(subRowsData) &&
-        React.cloneElement(subRowsData as ReactElement, {
+        React.cloneElement(subRowsData as ReactElement<SubRowProps>, {
           rowPadding: rowPadding,
           columnPadding: columnPadding,
         })}
-
       {subRows &&
         subRowsData &&
         !showSubRowsOnExpand &&
         isMappedReactElement(subRowsData) &&
-        (subRowsData as ReactElement[]).map((row) =>
+        (subRowsData as ReactElement<SubRowProps>[]).map((row) =>
           React.cloneElement(row, {
             rowPadding: rowPadding,
             columnPadding: columnPadding,
           }),
         )}
-
       {subTable && subTableData && !showSubTableOnExpand && (
         <StyledCell colSpan={expandSubProp}>
-          {React.cloneElement(subTableData, {
+          {React.cloneElement(subTableData as ReactElement<SubRowProps>, {
             rowPadding: rowPadding,
             columnPadding: columnPadding,
           })}

--- a/src/Table/helpers.ts
+++ b/src/Table/helpers.ts
@@ -1,6 +1,6 @@
 import { ReactElement, isValidElement } from 'react'
 
-export const isMappedReactElement = (obj: unknown): obj is ReactElement[] => {
+export const isMappedReactElement = (obj: unknown): obj is ReactElement<unknown>[] => {
   if (!Array.isArray(obj)) return false
   if (!obj[0]) return false
   if (!isValidElement(obj[0])) return false

--- a/src/Table/helpers.ts
+++ b/src/Table/helpers.ts
@@ -1,6 +1,10 @@
 import { ReactElement, isValidElement } from 'react'
 
-export const isMappedReactElement = (obj: unknown): obj is ReactElement<unknown>[] => {
+export const isMappedReactElement = (
+  obj: unknown,
+  // TODO: React 19 requires the props type by default. It was previously inferred to be 'any'. It would be beneficial to explicitly type this generic value
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): obj is ReactElement<any>[] => {
   if (!Array.isArray(obj)) return false
   if (!obj[0]) return false
   if (!isValidElement(obj[0])) return false

--- a/src/Table/types.ts
+++ b/src/Table/types.ts
@@ -31,29 +31,33 @@ export type BaseRowAction<T> = {
   showCondition?: (rowData: T) => boolean
 }
 
-export type RowAction<T> = RowActionButtonDefault<T> | RowActionElementOverride<T>
+export type RowAction<T> =
+  | RowActionButtonDefault<T>
+  | RowActionElementOverride<T>
 
 export type RowActionButtonDefault<T> = {
   iconButton?: Pick<
-  IconStrictProps,
-  'size' | 'render' | 'iconColor' | 'backgroundColor' | 'id' | 'title'
-> & { tooltipText?: string }
-genericButton?: Pick<
-  ButtonProps,
-  | 'children'
-  | 'loading'
-  | 'disabled'
-  | 'primary'
-  | 'secondary'
-  | 'fallbackStyle'
-  | 'textBtn'
-  | 'smallButton'
-  | 'id'
->
-} & BaseRowAction<T> 
+    IconStrictProps,
+    'size' | 'render' | 'iconColor' | 'backgroundColor' | 'id' | 'title'
+  > & { tooltipText?: string }
+  genericButton?: Pick<
+    ButtonProps,
+    | 'children'
+    | 'loading'
+    | 'disabled'
+    | 'primary'
+    | 'secondary'
+    | 'fallbackStyle'
+    | 'textBtn'
+    | 'smallButton'
+    | 'id'
+  >
+} & BaseRowAction<T>
 
 export type RowActionElementOverride<T> = {
-  element: ReactElement<unknown>
+  // TODO: React 19 requires the props type by default. It was previously inferred to be 'any'. It would be beneficial to explicitly type this generic value
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  element: ReactElement<any>
 } & BaseRowAction<T>
 
 export type RowActions<T> = {
@@ -101,13 +105,17 @@ interface CommonTableProps<T> {
   rowBorderColor?: Color
   /** A React element to show when a row is expanded. */
   subTable?: {
-    table: (rowData: T) => ReactElement<unknown>
+    // TODO: React 19 requires the props type by default. It was previously inferred to be 'any'. It would be beneficial to explicitly type this generic value
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    table: (rowData: T) => ReactElement<any>
     showOnExpand?: (rowData: T) => boolean
   }
   /** Settings for sub rows. */
   subRows?: {
     /** Function that returns a React element for the sub row. */
-    rows: (rowData: T) => ReactElement<unknown> | ReactElement<unknown>[]
+    // TODO: React 19 requires the props type by default. It was previously inferred to be 'any'. It would be beneficial to explicitly type this generic value
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rows: (rowData: T) => ReactElement<any> | ReactElement<any>[]
     /** If true, the sub rows will only be shown when the row is expanded. */
     showOnExpand?: (rowData: T) => boolean
   }

--- a/src/Table/types.ts
+++ b/src/Table/types.ts
@@ -53,7 +53,7 @@ genericButton?: Pick<
 } & BaseRowAction<T> 
 
 export type RowActionElementOverride<T> = {
-  element: ReactElement
+  element: ReactElement<unknown>
 } & BaseRowAction<T>
 
 export type RowActions<T> = {
@@ -101,13 +101,13 @@ interface CommonTableProps<T> {
   rowBorderColor?: Color
   /** A React element to show when a row is expanded. */
   subTable?: {
-    table: (rowData: T) => ReactElement
+    table: (rowData: T) => ReactElement<unknown>
     showOnExpand?: (rowData: T) => boolean
   }
   /** Settings for sub rows. */
   subRows?: {
     /** Function that returns a React element for the sub row. */
-    rows: (rowData: T) => ReactElement | ReactElement[]
+    rows: (rowData: T) => ReactElement<unknown> | ReactElement<unknown>[]
     /** If true, the sub rows will only be shown when the row is expanded. */
     showOnExpand?: (rowData: T) => boolean
   }

--- a/src/fields/commonFieldTypes.ts
+++ b/src/fields/commonFieldTypes.ts
@@ -8,10 +8,10 @@ export interface CommonFieldProps extends MarginProps {
   children?: ReactNode
   label?: string
   renderAsTitle?: boolean
-  assistiveText?: string | ReactElement
+  assistiveText?: string | ReactElement<unknown>
   required?: boolean
   error?: boolean
-  errorMsg?: string | ReactElement
+  errorMsg?: string | ReactElement<unknown>
   completed?: boolean
   frontIcon?: Icons
   trailingIcon?: Icons

--- a/src/fields/commonFieldTypes.ts
+++ b/src/fields/commonFieldTypes.ts
@@ -8,10 +8,14 @@ export interface CommonFieldProps extends MarginProps {
   children?: ReactNode
   label?: string
   renderAsTitle?: boolean
-  assistiveText?: string | ReactElement<unknown>
+  // TODO: React 19 requires the props type by default. It was previously inferred to be 'any'. It would be beneficial to explicitly type this generic value
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  assistiveText?: string | ReactElement<any>
   required?: boolean
   error?: boolean
-  errorMsg?: string | ReactElement<unknown>
+  // TODO: React 19 requires the props type by default. It was previously inferred to be 'any'. It would be beneficial to explicitly type this generic value
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  errorMsg?: string | ReactElement<any>
   completed?: boolean
   frontIcon?: Icons
   trailingIcon?: Icons

--- a/src/hooks/useClickOutside/index.ts
+++ b/src/hooks/useClickOutside/index.ts
@@ -6,7 +6,7 @@ export const useOnClickOutside = ({
   ref,
   callback,
 }: {
-  ref: RefObject<HTMLElement>
+  ref: RefObject<HTMLElement | null>
   callback: GenericEventCallback
 }) => {
   const onClickOutsideListener = useCallback(

--- a/src/hooks/useEventListener/index.ts
+++ b/src/hooks/useEventListener/index.ts
@@ -9,7 +9,7 @@ export const useEventListener = ({
 }: {
   eventName: keyof HTMLElementEventMap | string
   callback: GenericEventCallback
-  ref: RefObject<HTMLElement | Document>
+  ref: RefObject<HTMLElement | Document | null>
   capture?: boolean
 }): void => {
   useEffect(() => {

--- a/src/utils/isReactElement.ts
+++ b/src/utils/isReactElement.ts
@@ -1,5 +1,7 @@
 import { ReactElement, isValidElement } from 'react'
 
-export const isReactElement = (obj: unknown): obj is ReactElement<unknown> => {
+// TODO: React 19 requires the props type by default. It was previously inferred to be 'any'. It would be beneficial to explicitly type this generic value
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isReactElement = (obj: unknown): obj is ReactElement<any> => {
   return isValidElement(obj)
 }

--- a/src/utils/isReactElement.ts
+++ b/src/utils/isReactElement.ts
@@ -1,5 +1,5 @@
 import { ReactElement, isValidElement } from 'react'
 
-export const isReactElement = (obj: unknown): obj is ReactElement => {
+export const isReactElement = (obj: unknown): obj is ReactElement<unknown> => {
   return isValidElement(obj)
 }


### PR DESCRIPTION
[INT-69]

## What does this do?
The [React 19 upgrade](https://github.com/marshmallow-insurance/smores-react/pull/4166) has caused types to error. PR here is to fix erroring types

These changes shouldn't be breaking as it should still work in the downstream apps that have older versions of React types (ones that don't have react 19 or 18.3 installed).

> [!NOTE] 
> These changes aren't breaking for downstream apps that haven't upgraded to React 19 yet as the inputs of the changed types haven't changed. Tested on `agent-portal-www` and found no issue.

## Screenshot / Video
Only typing changes

[INT-69]: https://marshmallow1.atlassian.net/browse/INT-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ