### PR TITLE
fix: semantic-release config as esmodule

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -93,4 +93,4 @@ if (!isPrereleaseBranch) {
   ])
 }
 
-module.exports = config
+export default config


### PR DESCRIPTION
## What does this do?
<!-- 
- A short description of what the PR changes and why it's necessary
- Give the reviewers context
- Is the impact global or localised?
- Any tech debt created or discovered?
-->

- updates the `release.config.js` file to export the `config` object as a default export (esmodule format rather than commonjs, now that we have added the `type: module` in `package.json`

