### PR TITLE
bump: BREAKING CHANGES, type module and deleting components

### DIFF
--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -89,7 +89,7 @@ const RadioGroupComponent = <Value extends BaseValueType>(
               label={option.label}
               value={option.value}
               checked={isSelected}
-              //@ts-expect-error TODO: refine this type
+              //@ts-expect-error TODO: address this type inconsistency in another PR
               onChange={onChange}
               onBlur={onBlur}
               displayType={displayType}

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -29,7 +29,7 @@ export type RadioGroupProps<Value extends BaseValueType = BaseValueType> = {
     value: Value
     bodyCopy?: string
   }>
-  onChange: (value: BaseValueType) => void
+  onChange: (value: Value) => void
   onBlur?: (e: FocusEvent<HTMLInputElement>) => void
   value: Value
   displayType?: DisplayType
@@ -89,6 +89,7 @@ const RadioGroupComponent = <Value extends BaseValueType>(
               label={option.label}
               value={option.value}
               checked={isSelected}
+              //@ts-expect-error TODO: refine this type
               onChange={onChange}
               onBlur={onBlur}
               displayType={displayType}

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -89,7 +89,7 @@ const RadioGroupComponent = <Value extends BaseValueType>(
               label={option.label}
               value={option.value}
               checked={isSelected}
-              //@ts-expect-error TODO: address this type inconsistency in another PR
+              // @ts-expect-error TODO: address this type inconsistency in another PR
               onChange={onChange}
               onBlur={onBlur}
               displayType={displayType}


### PR DESCRIPTION
## What does this do?
<!-- 
- A short description of what the PR changes and why it's necessary
- Give the reviewers context
- Is the impact global or localised?
- Any tech debt created or discovered?
-->

PR to bump for a Major version for the following breaking changes:

1. Deleting `Emoji` and `Brandcard` components (unused internally)
2. Adjusting package.json to type: "module", this will require some changes for our components using Vitest

Steps to fix (2.)

Add the following to vitest.config - 

```
      deps: {
        inline: ['@mrshmllw/smores-react'],
      },
```

