### PR TITLE
fix: add breaking change config to semantic release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -18,6 +18,7 @@ const config = {
       {
         preset: 'angular',
         releaseRules: [
+          { breaking: true, release: 'major' },
           { type: 'feat', release: 'minor' },
           { type: 'fix', release: 'patch' },
           { type: 'docs', release: 'patch' },


### PR DESCRIPTION
## What does this do?
<!-- 
- A short description of what the PR changes and why it's necessary
- Give the reviewers context
- Is the impact global or localised?
- Any tech debt created or discovered?
-->

In https://github.com/marshmallow-insurance/smores-react/pull/4263#issuecomment-2674951765, we discussed how we need to override the conventional commit naming in order for semantic release to identify a breaking change as a major release.

This PR adds a config based on [default rules](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js) in order to respect the breaking change in the `releaseRules` order.

Example of Github action flows:
Recognised major update to v12 by presence of `BREAKING CHANGE: ` in the footer - [ref](https://github.com/marshmallow-insurance/smores-react/actions/runs/13498114124/job/37709851380)
Without the config change
https://github.com/marshmallow-insurance/smores-react/actions/runs/13497862202/job/37709103463


## Screenshot / Video
<!--
- applicable for UI changes, can be skipped if not relevant. You can drag and drop images/videos to upload them to GitHub.
- Example with image with fixed width 
  - <img src="https://github.com/marshmallow-insurance/uk-auto-signup-www/assets/57456071/3dbf1ec1-2363-4e20-8236-b1f1581b0953" width="300px" />
shortcuts:
 - Screenshot: cmd + shift + 4
 - Screen recording: cmd + shift + 5
-->
n/a

## Relevant tickets / Documentation
<!--
- Link to any relevant issue tracking software (jira, GitHub etc), documentation (PRDs, engineering plans, Figma designs) or slack threads
- If applicable, list any new documentation that has been created/updated e.g. diagrams/flows etc
-->
n/a

## Testing
<!--
- Tests should have been updated/created to cover the changes made in this PR, if not please explain why
-->
n/a
