### PR TITLE
chore: Replace webflow url with marshmallow asset url

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -8,7 +8,7 @@ import { ResetCss } from './ResetCss'
 const GlobalStyle = createGlobalStyle`
    @font-face {
     font-family: 'Circular';
-    src: url('https://uploads-ssl.webflow.com/5baa461315ee32413d16236d/5f7f0665430aaedf8cb0bbf3_CircularXXSub-RegularSubset.woff2')
+    src: url('https://assets.marshmallow.com/fonts/CircularXXSub-RegularSubset.woff2')
       format('woff2');
     font-weight: 400;
     font-style: normal;
@@ -17,7 +17,7 @@ const GlobalStyle = createGlobalStyle`
 
   @font-face {
     font-family: 'Circular';
-    src: url('https://uploads-ssl.webflow.com/5baa461315ee32413d16236d/5f7f066540b11e802f892996_CircularXXWeb-Medium.woff2')
+    src: url('https://assets.marshmallow.com/fonts/CircularXXWeb-Medium.woff2')
       format('woff2');
     font-weight: 500;
     font-style: normal;
@@ -26,7 +26,7 @@ const GlobalStyle = createGlobalStyle`
 
   @font-face {
     font-family: 'Circular';
-    src: url('https://uploads-ssl.webflow.com/5baa461315ee32413d16236d/5f7f0665ddfa22dd5375ca6e_CircularXXWeb-Bold.woff2')
+    src: url('https://assets.marshmallow.com/fonts/CircularXXWeb-Bold.woff2')
       format('woff2');
     font-weight: 700;
     font-style: normal;

--- a/src/fontStyle.ts
+++ b/src/fontStyle.ts
@@ -4,7 +4,7 @@ import { theme } from './theme'
 export const FontStyle = createGlobalStyle`
   @font-face {
     font-family: 'Circular';
-    src: url('https://uploads-ssl.webflow.com/5baa461315ee32413d16236d/5f7f0665430aaedf8cb0bbf3_CircularXXSub-RegularSubset.woff2') format('woff2');
+    src: url('https://assets.marshmallow.com/fonts/CircularXXSub-RegularSubset.woff2') format('woff2');
     font-weight: ${theme.font.weight.normal};
     font-style: normal;
     font-display: swap;
@@ -12,7 +12,7 @@ export const FontStyle = createGlobalStyle`
 
   @font-face {
     font-family: 'Circular';
-    src: url('https://uploads-ssl.webflow.com/5baa461315ee32413d16236d/5f7f066540b11e802f892996_CircularXXWeb-Medium.woff2') format('woff2');
+    src: url('https://assets.marshmallow.com/fonts/CircularXXWeb-Medium.woff2') format('woff2');
     font-weight: ${theme.font.weight.medium};
     font-style: normal;
     font-display: swap;
@@ -20,7 +20,7 @@ export const FontStyle = createGlobalStyle`
 
   @font-face {
     font-family: 'Circular';
-    src: url('https://uploads-ssl.webflow.com/5baa461315ee32413d16236d/5f7f0665ddfa22dd5375ca6e_CircularXXWeb-Bold.woff2') format('woff2');
+    src: url('https://assets.marshmallow.com/fonts/CircularXXWeb-Bold.woff2') format('woff2');
     font-weight: ${theme.font.weight.bold};
     font-style: normal;
     font-display: swap;


### PR DESCRIPTION
This PR removes any webflow url and replaces it with an assets.marshmallow.com url, webflow will be depreacted in the coming months. This PR was generated using multi-gitter
