### PR TITLE
chore: removing reactFC typing for renderInput

### DIFF
--- a/src/CurrencyInput/storybook/CurrencyInput.stories.tsx
+++ b/src/CurrencyInput/storybook/CurrencyInput.stories.tsx
@@ -24,7 +24,7 @@ const meta: Meta<typeof CurrencyInput> = {
 
 export default meta
 
-const InteractiveTemplate: React.FC<CurrencyInputProps> = (args) => {
+const InteractiveTemplate = (args: CurrencyInputProps) => {
   const [{ value }, updateArgs] = useArgs<CurrencyInputProps>()
 
   const handleChange = (e: string) => {

--- a/src/Dropdown/storybook/Dropdown.stories.tsx
+++ b/src/Dropdown/storybook/Dropdown.stories.tsx
@@ -27,7 +27,7 @@ const meta: Meta<DropdownProps> = {
 export default meta
 type Story = StoryObj<DropdownProps>
 
-const InteractiveTemplate: React.FC<DropdownProps> = (args) => {
+const InteractiveTemplate = (args: DropdownProps) => {
   const [{ value }, updateArgs] = useArgs<DropdownProps>()
 
   const handleChange = (e: string) => {

--- a/src/NumberInput/storybook/NumberInput.stories.tsx
+++ b/src/NumberInput/storybook/NumberInput.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof NumberInput> = {
   },
 }
 
-const InteractiveTemplate: React.FC<NumberInputProps> = (args) => {
+const InteractiveTemplate = (args: NumberInputProps) => {
   const [{ value }, updateArgs] = useArgs<NumberInputProps>()
 
   const handleChange = (e: string | number) => {

--- a/src/TextInput/storybook/TextInput.stories.tsx
+++ b/src/TextInput/storybook/TextInput.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<TextInputProps> = {
 export default meta
 type Story = StoryObj<TextInputProps>
 
-const InteractiveTemplate: React.FC<TextInputProps> = (args) => {
+const InteractiveTemplate = (args: TextInputProps) => {
   const [{ value }, updateArgs] = useArgs<TextInputProps>()
 
   const handleChange = (e: string) => {

--- a/src/Textarea/storybook/Textarea.stories.tsx
+++ b/src/Textarea/storybook/Textarea.stories.tsx
@@ -12,7 +12,7 @@ export default meta
 
 type Story = StoryObj<typeof Textarea>
 
-const InteractiveTemplate: React.FC<TextareaProps> = (args) => {
+const InteractiveTemplate = (args: TextareaProps) => {
   const [{ value }, updateArgs] = useArgs<TextareaProps>()
 
   const handleChange = (e: string) => {


### PR DESCRIPTION
## What does this do?
Removes the `React.FC` typing from the `InteractiveTemplate` function in the `CurrencyInput`, `Dropdown`, `NumberInput`, `TextInput`, and `Textarea` components as this is not the valid type for `renderInput`

## Screenshot / Video
N/A

## Relevant tickets / Documentation
N/A

## Testing
- Manually tested storybook still works