### PR TITLE
Pin third-party actions to specific commit shas

### DIFF
--- a/.github/workflows/autoApproveDependabotPullRequests.yml
+++ b/.github/workflows/autoApproveDependabotPullRequests.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.6.0
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Determine whether to run

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -20,13 +20,13 @@ jobs:
           npm ci
           npm run build-storybook
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages
           folder: storybook-static
           clean: true
       - name: Fossa dependency analysis 🐛
-        uses: fossas/fossa-action@main
+        uses: fossas/fossa-action@93a52ecf7c3ac7eb40f5de77fd69b1a19524de94
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
## What does this do?

This prevents supply chain attacks in case the action is exploited and overrides the tag with malicious code.
