### PR TITLE
fix: adding position relative to box wrapping select

### DIFF
--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -102,7 +102,7 @@ export const Dropdown = forwardRef(function Dropdown(
 
   return (
     <Field {...fieldProps} htmlFor={id} error={error}>
-      <Box flex alignItems="center">
+      <Box flex alignItems="center" style={{ position: 'relative' }}>
         {frontIcon && (
           <StyledFrontIcon
             $disabled={disabled}


### PR DESCRIPTION
## What does this do?
<!-- 
- A short description of what the PR changes and why it's necessary
- Give the reviewers context
- Is the impact global or localised?
- Any tech debt created or discovered?
-->

adds relative positioning to the box wrapping the select component in the Dropdown component to ensure proper alignment of the front icon

