### PR TITLE
feat(progress-indicator): new component

### DIFF
--- a/src/Icon/Icon.tsx
+++ b/src/Icon/Icon.tsx
@@ -34,6 +34,7 @@ export const Icon: FC<IconProps> = ({
   return (
     <Container
       forwardedAs="span"
+      data-testId={`${render}-container`}
       className={className}
       size={size}
       rotate={rotate}

--- a/src/ProgressIndicator/ProgressIndicator.test.tsx
+++ b/src/ProgressIndicator/ProgressIndicator.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ProgressIndicator } from './ProgressIndicator'
+import { StepData } from './types'
+
+describe('ProgressIndicator', () => {
+  const steps: StepData[] = [
+    { id: 'step1', label: 'Step 1', isHidden: false },
+    { id: 'step2', label: 'Step 2', isHidden: false },
+    { id: 'step3', label: 'Step 3', isHidden: false },
+  ]
+
+  const handleStepChange = vi.fn()
+  const onStepClick = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('steps', () => {
+    it('renders all visible steps', () => {
+      render(
+        <ProgressIndicator
+          steps={steps}
+          handleStepChange={handleStepChange}
+          currentStep="step1"
+        />,
+      )
+
+      expect(screen.getByText('Step 1')).toBeTruthy()
+      expect(screen.getByText('Step 2')).toBeTruthy()
+      expect(screen.getByText('Step 3')).toBeTruthy()
+    })
+
+    it("doesn't render hidden steps", () => {
+      render(
+        <ProgressIndicator
+          steps={[
+            ...steps,
+            { id: 'step2-a', label: 'Step 2-a', isHidden: true },
+          ]}
+          handleStepChange={handleStepChange}
+          currentStep="step1"
+        />,
+      )
+
+      expect(screen.getByText('Step 1')).toBeTruthy()
+      expect(screen.getByText('Step 2')).toBeTruthy()
+      expect(screen.getByText('Step 3')).toBeTruthy()
+      expect(screen.queryByText('Step 2-a')).not.toBeTruthy()
+    })
+  })
+
+  describe('onStepClick', () => {
+    it('calls onStepClick when a step is clicked, even if disabled', () => {
+      render(
+        <ProgressIndicator
+          steps={steps}
+          handleStepChange={handleStepChange}
+          onStepClick={onStepClick}
+          currentStep="step1"
+        />,
+      )
+
+      fireEvent.click(screen.getByText('Step 2'))
+
+      expect(onStepClick).toHaveBeenCalledWith({
+        currentStepIndex: 1,
+        currentStepState: 'disabled',
+      })
+    })
+  })
+
+  describe('handleStepChange', () => {
+    it('does not call handleStepChange when clicking a disabled step', () => {
+      render(
+        <ProgressIndicator
+          steps={steps}
+          handleStepChange={handleStepChange}
+          onStepClick={onStepClick}
+          currentStep="step1"
+        />,
+      )
+
+      fireEvent.click(screen.getByText('Step 2'))
+
+      expect(onStepClick).toHaveBeenCalledWith({
+        currentStepIndex: 1,
+        currentStepState: 'disabled',
+      })
+
+      expect(handleStepChange).not.toHaveBeenCalled()
+    })
+    it('calls both handleStepChange & onStepClick on a completed step', () => {
+      render(
+        <ProgressIndicator
+          steps={steps}
+          handleStepChange={handleStepChange}
+          onStepClick={onStepClick}
+          currentStep="step3"
+        />,
+      )
+
+      fireEvent.click(screen.getByText('Step 2'))
+
+      expect(handleStepChange).toHaveBeenCalledWith(steps[1])
+
+      expect(onStepClick).toHaveBeenCalledWith({
+        currentStepIndex: 1,
+        currentStepState: 'completed',
+      })
+    })
+
+    it('calls both handleStepChange & onStepClick on the current step', () => {
+      render(
+        <ProgressIndicator
+          steps={steps}
+          handleStepChange={handleStepChange}
+          onStepClick={onStepClick}
+          currentStep="step3"
+        />,
+      )
+
+      fireEvent.click(screen.getByText('Step 3'))
+
+      expect(handleStepChange).toHaveBeenCalledWith(steps[2])
+
+      expect(onStepClick).toHaveBeenCalledWith({
+        currentStepIndex: 2,
+        currentStepState: 'current',
+      })
+    })
+
+    fireEvent
+  })
+})

--- a/src/ProgressIndicator/ProgressIndicator.tsx
+++ b/src/ProgressIndicator/ProgressIndicator.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { StepData, StepState } from './types'
-import { calculateStepState, calulateProgressWidths } from './helpers'
+import { calculateStepState, calculateProgressWidths } from './helpers'
 import styled from 'styled-components'
 import { theme } from '../theme'
 import { Box } from '../Box'
@@ -24,7 +24,7 @@ export const ProgressIndicator = ({
   steps,
   currentStep,
 }: Props) => {
-  const { totalWidth, stepWidth } = calulateProgressWidths(
+  const { totalWidth, stepWidth } = calculateProgressWidths(
     steps.length,
     simpleStep,
   )

--- a/src/ProgressIndicator/ProgressIndicator.tsx
+++ b/src/ProgressIndicator/ProgressIndicator.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import { StepData, StepState } from './types'
+import { calculateStepState, calulateProgressWidths } from './helpers'
+import styled from 'styled-components'
+import { theme } from '../theme'
+import { Box } from '../Box'
+import { StepItem } from './components/StepItem'
+
+interface Props {
+  steps: ReadonlyArray<StepData>
+  handleStepChange: (step: StepData) => void
+  simpleStep?: boolean
+  onStepClick?: (data: {
+    currentStepIndex: number
+    currentStepState: StepState
+  }) => void
+  currentStep: string
+}
+
+export const ProgressIndicator = ({
+  handleStepChange,
+  onStepClick,
+  simpleStep = false,
+  steps,
+  currentStep,
+}: Props) => {
+  const { totalWidth, stepWidth } = calulateProgressWidths(steps.length)
+
+  const visibleSteps = steps.filter((step) => !step.isHidden)
+  const currentStepIndex = visibleSteps.findIndex(
+    (step) => step.id === currentStep,
+  )
+  const lastCompletedStepIndex = visibleSteps.findLastIndex(
+    (step) =>
+      calculateStepState(visibleSteps.indexOf(step), currentStepIndex) ===
+      'completed',
+  )
+
+  const handleStepClick = (
+    currentStepIndex: number,
+    currentStepState: StepState,
+    stepData: StepData,
+  ) => {
+    if (onStepClick) {
+      onStepClick({ currentStepIndex, currentStepState })
+    }
+
+    if (currentStepState !== 'disabled') {
+      handleStepChange(stepData)
+    } else {
+      console.log('disabled')
+    }
+  }
+
+  return (
+    <Wrapper width={`${totalWidth}px`} flex alignItems="center">
+      {visibleSteps.map((step, index) => {
+        const stepState = calculateStepState(index, currentStepIndex)
+        return (
+          <StepItem
+            key={step.id}
+            isCompleted={stepState === 'completed'}
+            isLastCompleted={lastCompletedStepIndex === index}
+            onClick={() => handleStepClick(index, stepState, step)}
+            stepWidth={`${stepWidth}px`}
+            label={step.label}
+            isSimple={simpleStep}
+          />
+        )
+      })}
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled(Box)`
+  border-radius: 100px;
+  background: ${theme.colors.matcha};
+`

--- a/src/ProgressIndicator/ProgressIndicator.tsx
+++ b/src/ProgressIndicator/ProgressIndicator.tsx
@@ -24,7 +24,10 @@ export const ProgressIndicator = ({
   steps,
   currentStep,
 }: Props) => {
-  const { totalWidth, stepWidth } = calulateProgressWidths(steps.length)
+  const { totalWidth, stepWidth } = calulateProgressWidths(
+    steps.length,
+    simpleStep,
+  )
 
   const visibleSteps = steps.filter((step) => !step.isHidden)
   const currentStepIndex = visibleSteps.findIndex(
@@ -52,7 +55,7 @@ export const ProgressIndicator = ({
 
   return (
     <Wrapper width={`${totalWidth}px`} flex alignItems="center">
-      <DefaultProgress />
+      <DefaultProgress $simpleStep={simpleStep} />
       <Box flex>
         {visibleSteps.map((step, index) => {
           const stepState = calculateStepState(index, currentStepIndex)

--- a/src/ProgressIndicator/ProgressIndicator.tsx
+++ b/src/ProgressIndicator/ProgressIndicator.tsx
@@ -47,32 +47,45 @@ export const ProgressIndicator = ({
 
     if (currentStepState !== 'disabled') {
       handleStepChange(stepData)
-    } else {
-      console.log('disabled')
     }
   }
 
   return (
     <Wrapper width={`${totalWidth}px`} flex alignItems="center">
-      {visibleSteps.map((step, index) => {
-        const stepState = calculateStepState(index, currentStepIndex)
-        return (
-          <StepItem
-            key={step.id}
-            isCompleted={stepState === 'completed'}
-            isLastCompleted={lastCompletedStepIndex === index}
-            onClick={() => handleStepClick(index, stepState, step)}
-            stepWidth={`${stepWidth}px`}
-            label={step.label}
-            isSimple={simpleStep}
-          />
-        )
-      })}
+      <DefaultProgress />
+      <Box flex>
+        {visibleSteps.map((step, index) => {
+          const stepState = calculateStepState(index, currentStepIndex)
+          return (
+            <StepItem
+              key={step.id}
+              isCompleted={stepState === 'completed'}
+              isCurrentStep={stepState === 'current'}
+              isLastCompleted={lastCompletedStepIndex === index}
+              onClick={() => handleStepClick(index, stepState, step)}
+              stepWidth={`${stepWidth}px`}
+              label={step.label}
+              isSimple={simpleStep}
+              isLastItem={index === visibleSteps.length - 1}
+            />
+          )
+        })}
+      </Box>
     </Wrapper>
   )
 }
 
 const Wrapper = styled(Box)`
-  border-radius: 100px;
+  position: relative;
+`
+
+const DefaultProgress = styled(Box)<{ $simpleStep?: boolean }>`
+  z-index: 0;
+  content: '';
+  position: absolute;
   background: ${theme.colors.matcha};
+  width: 100%;
+  height: 12px;
+
+  ${({ $simpleStep }) => $simpleStep && `border-radius:100px;`}
 `

--- a/src/ProgressIndicator/components/StepItem.test.tsx
+++ b/src/ProgressIndicator/components/StepItem.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { StepItem, StepItemProps } from './StepItem'
+describe('StepItem', () => {
+  const defaultProps: StepItemProps = {
+    label: 'Step 1',
+    isCurrentStep: false,
+    isCompleted: false,
+    isLastCompleted: false,
+    isSimple: false,
+    onClick: vi.fn(),
+    stepWidth: '100px',
+    isLastItem: false,
+  }
+
+  it('renders the label correctly and does not render tick if notCompleted', () => {
+    render(<StepItem {...defaultProps} />)
+    expect(screen.getByText('Step 1')).toBeTruthy()
+    expect(screen.findByTestId('tick-container')).not.toBeTruthy()
+  })
+
+  it.only('renders the completed icon when step is completed', () => {
+    render(<StepItem {...defaultProps} isCompleted={true} />)
+    expect(screen.getByTestId('tick-container')).toBeTruthy()
+  })
+
+  it('calls onClick when clicked', () => {
+    render(<StepItem {...defaultProps} />)
+    fireEvent.click(screen.getByText('Step 1'))
+    expect(defaultProps.onClick).toHaveBeenCalled()
+  })
+
+  it('renders a simple item when isSimple is true', () => {
+    render(<StepItem {...defaultProps} isSimple={true} />)
+    expect(screen.queryByText('Step 1')).not.toBeTruthy()
+  })
+})

--- a/src/ProgressIndicator/components/StepItem.test.tsx
+++ b/src/ProgressIndicator/components/StepItem.test.tsx
@@ -16,10 +16,10 @@ describe('StepItem', () => {
   it('renders the label correctly and does not render tick if notCompleted', () => {
     render(<StepItem {...defaultProps} />)
     expect(screen.getByText('Step 1')).toBeTruthy()
-    expect(screen.findByTestId('tick-container')).not.toBeTruthy()
+    expect(screen.queryByTestId('tick-container')).not.toBeTruthy()
   })
 
-  it.only('renders the completed icon when step is completed', () => {
+  it('renders the completed icon when step is completed', () => {
     render(<StepItem {...defaultProps} isCompleted={true} />)
     expect(screen.getByTestId('tick-container')).toBeTruthy()
   })

--- a/src/ProgressIndicator/components/StepItem.tsx
+++ b/src/ProgressIndicator/components/StepItem.tsx
@@ -3,26 +3,29 @@ import { StepData } from 'ProgressIndicator/types'
 import React from 'react'
 import styled, { css } from 'styled-components'
 import { theme } from '../../theme'
+import { Text } from '../../Text'
+import { Icon } from '../../Icon'
 
-export interface Props extends Pick<StepData, 'label' | 'isHidden'> {
+export interface StepItemProps extends Pick<StepData, 'label'> {
   isCompleted?: boolean
   isLastCompleted?: boolean
+  isCurrentStep: boolean
   isSimple?: boolean
   onClick: () => void
   stepWidth: string
+  isLastItem: boolean
 }
 
 export const StepItem = ({
-  isHidden,
+  label,
   isSimple = false,
+  isCurrentStep,
   stepWidth,
+  onClick,
   isCompleted = false,
   isLastCompleted = false,
-}: Props) => {
-  if (isHidden) {
-    return null
-  }
-
+  isLastItem = false,
+}: StepItemProps) => {
   if (isSimple) {
     return (
       <SimpleItem
@@ -35,18 +38,36 @@ export const StepItem = ({
   }
 
   return (
-    <Box flex alignItems="center">
-      normal progress bar
-    </Box>
+    <ProgressItem
+      flex
+      $completed={isCompleted}
+      $lastCompleted={isLastCompleted}
+      width={stepWidth}
+      onClick={onClick}
+    >
+      <ProgressIndicator
+        $completed={isCompleted}
+        $currentStep={isCurrentStep}
+        flex
+        alignItems="center"
+        justifyContent="center"
+      >
+        {isCompleted ? <Icon render="tick" size={16} color="cream" /> : null}
+      </ProgressIndicator>
+      {isCompleted && !isLastItem ? <CompletedBar /> : null}
+      <FloatingText typo="caption">{label}</FloatingText>
+    </ProgressItem>
   )
 }
 
 interface StyledComponentProps {
-  $completed: boolean
-  $lastCompleted: boolean
+  $completed?: boolean
+  $lastCompleted?: boolean
+  $currentStep?: boolean
+  $completedStep?: boolean
 }
 
-const firstChildAndLastCompleted = css`
+const lastCompleted = css`
   border-radius: 0 100px 100px 0;
 
   &:first-child {
@@ -59,11 +80,49 @@ const borderRadiusCss = css<StyledComponentProps>`
     border-radius: 100px 0 0 100px;
   }
 
-  ${({ $lastCompleted }) => $lastCompleted && firstChildAndLastCompleted}
+  ${({ $lastCompleted }) => $lastCompleted && lastCompleted}
 `
 
 const SimpleItem = styled(Box)<StyledComponentProps>`
+  position: relative;
+  z-index: 1;
   ${borderRadiusCss}
 
-  ${({ $completed }) => $completed && `background: ${theme.colors.pistachio};`};
+  background: ${({ $completed }) =>
+    $completed ? theme.colors.pistachio : 'none'};
+`
+
+const ProgressItem = styled(Box)<StyledComponentProps>`
+  position: relative;
+  z-index: 1;
+`
+
+const ProgressIndicator = styled(Box)<StyledComponentProps>`
+  border-radius: 50%;
+  height: 24px;
+  width: 24px;
+  position: relative;
+  left: -2px;
+  z-index: 1;
+  background: ${({ $completed, $currentStep }) =>
+    $completed || $currentStep ? theme.colors.pistachio : theme.colors.matcha};
+`
+
+const FloatingText = styled(Text)`
+  position: absolute;
+  top: 0;
+  transform: translateY(calc(-50% + 34px));
+  left: -6px;
+  font-weight: ${theme.font.weight.medium};
+`
+
+const CompletedBar = styled(Box)`
+  position: absolute;
+  height: 12px;
+  width: 100%;
+  top: 0;
+  left: 0;
+  transform: translateY(calc(-50% + 12px));
+  background: ${theme.colors.pistachio};
+  z-index: 0;
 `

--- a/src/ProgressIndicator/components/StepItem.tsx
+++ b/src/ProgressIndicator/components/StepItem.tsx
@@ -1,0 +1,69 @@
+import { Box } from '../../Box'
+import { StepData } from 'ProgressIndicator/types'
+import React from 'react'
+import styled, { css } from 'styled-components'
+import { theme } from '../../theme'
+
+export interface Props extends Pick<StepData, 'label' | 'isHidden'> {
+  isCompleted?: boolean
+  isLastCompleted?: boolean
+  isSimple?: boolean
+  onClick: () => void
+  stepWidth: string
+}
+
+export const StepItem = ({
+  isHidden,
+  isSimple = false,
+  stepWidth,
+  isCompleted = false,
+  isLastCompleted = false,
+}: Props) => {
+  if (isHidden) {
+    return null
+  }
+
+  if (isSimple) {
+    return (
+      <SimpleItem
+        $completed={isCompleted}
+        $lastCompleted={isLastCompleted}
+        width={stepWidth}
+        height="12px"
+      />
+    )
+  }
+
+  return (
+    <Box flex alignItems="center">
+      normal progress bar
+    </Box>
+  )
+}
+
+interface StyledComponentProps {
+  $completed: boolean
+  $lastCompleted: boolean
+}
+
+const firstChildAndLastCompleted = css`
+  border-radius: 0 100px 100px 0;
+
+  &:first-child {
+    border-radius: 100px;
+  }
+`
+
+const borderRadiusCss = css<StyledComponentProps>`
+  &:first-child {
+    border-radius: 100px 0 0 100px;
+  }
+
+  ${({ $lastCompleted }) => $lastCompleted && firstChildAndLastCompleted}
+`
+
+const SimpleItem = styled(Box)<StyledComponentProps>`
+  ${borderRadiusCss}
+
+  ${({ $completed }) => $completed && `background: ${theme.colors.pistachio};`};
+`

--- a/src/ProgressIndicator/components/StepItem.tsx
+++ b/src/ProgressIndicator/components/StepItem.tsx
@@ -52,9 +52,9 @@ export const StepItem = ({
         alignItems="center"
         justifyContent="center"
       >
-        {isCompleted ? <Icon render="tick" size={16} color="cream" /> : null}
+        {isCompleted && <Icon render="tick" size={16} color="cream" />}
       </ProgressIndicator>
-      {isCompleted && !isLastItem ? <CompletedBar /> : null}
+      {isCompleted && !isLastItem && <CompletedBar />}
       <FloatingText typo="caption">{label}</FloatingText>
     </ProgressItem>
   )

--- a/src/ProgressIndicator/helpers.test.ts
+++ b/src/ProgressIndicator/helpers.test.ts
@@ -1,0 +1,33 @@
+import { calculateStepState, calulateProgressWidths } from './helpers'
+
+describe('progress incidator helpers', () => {
+  describe('calulateProgressWidths', () => {
+    it('should return the correct total width and step width', () => {
+      const stepCount = 5
+
+      const expected = {
+        totalWidth: 320,
+        stepWidth: 80,
+      }
+      expect(calulateProgressWidths(stepCount)).toEqual(expected)
+    })
+  })
+
+  describe('calculateStepState', () => {
+    it("should return 'current' for the current step", () => {
+      const index = 2
+      const currentStepIndex = 2
+      expect(calculateStepState(index, currentStepIndex)).toEqual('current')
+    })
+    it("should return 'completed' for a completed step", () => {
+      const index = 1
+      const currentStepIndex = 2
+      expect(calculateStepState(index, currentStepIndex)).toEqual('completed')
+    })
+    it("should return 'disabled' for a disabled step", () => {
+      const index = 3
+      const currentStepIndex = 2
+      expect(calculateStepState(index, currentStepIndex)).toEqual('disabled')
+    })
+  })
+})

--- a/src/ProgressIndicator/helpers.test.ts
+++ b/src/ProgressIndicator/helpers.test.ts
@@ -1,7 +1,7 @@
-import { calculateStepState, calulateProgressWidths } from './helpers'
+import { calculateStepState, calculateProgressWidths } from './helpers'
 
 describe('progress incidator helpers', () => {
-  describe('calulateProgressWidths', () => {
+  describe('calculateProgressWidths', () => {
     it('should return the correct total width and step width', () => {
       const stepCount = 5
 
@@ -9,7 +9,7 @@ describe('progress incidator helpers', () => {
         totalWidth: 320,
         stepWidth: 80,
       }
-      expect(calulateProgressWidths(stepCount)).toEqual(expected)
+      expect(calculateProgressWidths(stepCount)).toEqual(expected)
     })
 
     it('should return the correct total width and step width for simple steps', () => {
@@ -18,7 +18,7 @@ describe('progress incidator helpers', () => {
         totalWidth: 320,
         stepWidth: 64,
       }
-      expect(calulateProgressWidths(stepCount, true)).toEqual(expected)
+      expect(calculateProgressWidths(stepCount, true)).toEqual(expected)
     })
   })
 

--- a/src/ProgressIndicator/helpers.test.ts
+++ b/src/ProgressIndicator/helpers.test.ts
@@ -11,6 +11,15 @@ describe('progress incidator helpers', () => {
       }
       expect(calulateProgressWidths(stepCount)).toEqual(expected)
     })
+
+    it('should return the correct total width and step width for simple steps', () => {
+      const stepCount = 5
+      const expected = {
+        totalWidth: 320,
+        stepWidth: 64,
+      }
+      expect(calulateProgressWidths(stepCount, true)).toEqual(expected)
+    })
   })
 
   describe('calculateStepState', () => {

--- a/src/ProgressIndicator/helpers.ts
+++ b/src/ProgressIndicator/helpers.ts
@@ -8,9 +8,10 @@ interface ReturnValue {
 }
 
 export const calulateProgressWidths = (stepCount: number): ReturnValue => {
+  // As the last item doesn't have a line, we need to subtract 1 from the step count
   return {
     totalWidth: TOTAL_WIDTH,
-    stepWidth: TOTAL_WIDTH / stepCount,
+    stepWidth: TOTAL_WIDTH / (stepCount - 1),
   }
 }
 

--- a/src/ProgressIndicator/helpers.ts
+++ b/src/ProgressIndicator/helpers.ts
@@ -1,0 +1,28 @@
+import { StepState } from './types'
+
+const TOTAL_WIDTH = 320
+
+interface ReturnValue {
+  totalWidth: number
+  stepWidth: number
+}
+
+export const calulateProgressWidths = (stepCount: number): ReturnValue => {
+  return {
+    totalWidth: TOTAL_WIDTH,
+    stepWidth: TOTAL_WIDTH / stepCount,
+  }
+}
+
+export const calculateStepState = (
+  index: number,
+  currentStepIndex: number,
+): StepState => {
+  if (index === currentStepIndex) {
+    return 'current'
+  } else if (index < currentStepIndex || currentStepIndex === -1) {
+    return 'completed'
+  }
+
+  return 'disabled'
+}

--- a/src/ProgressIndicator/helpers.ts
+++ b/src/ProgressIndicator/helpers.ts
@@ -7,11 +7,15 @@ interface ReturnValue {
   stepWidth: number
 }
 
-export const calulateProgressWidths = (stepCount: number): ReturnValue => {
-  // As the last item doesn't have a line, we need to subtract 1 from the step count
+export const calulateProgressWidths = (
+  stepCount: number,
+  isSimpleSteps?: boolean,
+): ReturnValue => {
+  // if not simple steps, we need to subtract 1 from the step count as the last item doesn't have a line
+  const stepsToUse = isSimpleSteps ? stepCount : stepCount - 1
   return {
     totalWidth: TOTAL_WIDTH,
-    stepWidth: TOTAL_WIDTH / (stepCount - 1),
+    stepWidth: TOTAL_WIDTH / stepsToUse,
   }
 }
 

--- a/src/ProgressIndicator/helpers.ts
+++ b/src/ProgressIndicator/helpers.ts
@@ -7,7 +7,7 @@ interface ReturnValue {
   stepWidth: number
 }
 
-export const calulateProgressWidths = (
+export const calculateProgressWidths = (
   stepCount: number,
   isSimpleSteps?: boolean,
 ): ReturnValue => {

--- a/src/ProgressIndicator/index.ts
+++ b/src/ProgressIndicator/index.ts
@@ -1,0 +1,2 @@
+export { ProgressIndicator } from './ProgressIndicator'
+export { StepData } from './types'

--- a/src/ProgressIndicator/storybook/ProgressIndicator.stories.tsx
+++ b/src/ProgressIndicator/storybook/ProgressIndicator.stories.tsx
@@ -9,14 +9,64 @@ import { StepData } from 'ProgressIndicator/types'
 const BgWrapper = styled(Box)`
   background: ${theme.colors.coconut};
 `
+// steps: ReadonlyArray<StepData>
+// handleStepChange: (step: StepData) => void
+// simpleStep?: boolean
+// onStepClick?: (data: {
+//   currentStepIndex: number
+//   currentStepState: StepState
+// }) => void
+// currentStep: string
 
 const meta: Meta<typeof ProgressIndicator> = {
   title: 'ProgressIndicator',
   component: ProgressIndicator,
-  // argTypes: { handlePageChange: { action: 'pageChanged' } },
+  argTypes: {
+    handleStepChange: {
+      table: {
+        type: { detail: 'Function used to handle clicking a step' },
+      },
+    },
+    onStepClick: {
+      table: {
+        type: {
+          detail:
+            'Function used to run functions that should run on click of a step but not always as part of the handleStepChange function',
+        },
+        defaultValue: { summary: 'test', detail: 'deta' },
+      },
+    },
+    currentStep: {
+      table: {
+        type: {
+          detail:
+            'String used to determine the current step, this should the ID of one of the steps.',
+        },
+      },
+    },
+    simpleStep: {
+      table: {
+        type: {
+          detail:
+            'Boolean used to determine if we should render the simple step view. Note: the simple step layout has limited functionality e.g. No onClick function',
+        },
+        defaultValue: {
+          summary: 'false',
+          detail: 'defaults to false and will show the normal step layout',
+        },
+      },
+    },
+
+    // simpleStep: { description: 'used to determine ', 'type' },
+  },
   decorators: [
     (Story) => (
-      <BgWrapper px="16px" height="100px" flex alignItems="center">
+      <BgWrapper
+        height="100px"
+        flex
+        alignItems="center"
+        justifyContent="center"
+      >
         <Story />
       </BgWrapper>
     ),
@@ -31,34 +81,29 @@ const defaultSteps: StepData[] = [
   {
     label: 'Step 1',
     id: '1',
-    pathList: ['/1'],
   },
   {
     label: 'Step 2',
     id: '2',
-    pathList: ['/2'],
   },
   {
     label: 'Step 3',
     id: '3',
-    pathList: ['/3'],
   },
   {
     label: 'Step 4',
     id: '4',
-    pathList: ['/4'],
   },
   {
     label: 'Step 5',
     id: '5',
-    pathList: ['/5'],
   },
 ]
 
 export const Default: Story = {
   args: {
     steps: defaultSteps,
-    currentStep: '5',
+    currentStep: '1',
     onStepClick: () => console.log('step click function'),
     handleStepChange: () => console.log('step change function'),
   },

--- a/src/ProgressIndicator/storybook/ProgressIndicator.stories.tsx
+++ b/src/ProgressIndicator/storybook/ProgressIndicator.stories.tsx
@@ -6,17 +6,32 @@ import { theme } from '../../theme'
 import { ProgressIndicator } from '../ProgressIndicator'
 import { StepData } from 'ProgressIndicator/types'
 
+const defaultSteps: StepData[] = [
+  {
+    label: 'Step 1',
+    id: '1',
+  },
+  {
+    label: 'Step 2',
+    id: '2',
+  },
+  {
+    label: 'Step 3',
+    id: '3',
+  },
+  {
+    label: 'Step 4',
+    id: '4',
+  },
+  {
+    label: 'Step 5',
+    id: '5',
+  },
+]
+
 const BgWrapper = styled(Box)`
   background: ${theme.colors.coconut};
 `
-// steps: ReadonlyArray<StepData>
-// handleStepChange: (step: StepData) => void
-// simpleStep?: boolean
-// onStepClick?: (data: {
-//   currentStepIndex: number
-//   currentStepState: StepState
-// }) => void
-// currentStep: string
 
 const meta: Meta<typeof ProgressIndicator> = {
   title: 'ProgressIndicator',
@@ -75,29 +90,6 @@ const meta: Meta<typeof ProgressIndicator> = {
 export default meta
 
 type Story = StoryObj<typeof ProgressIndicator>
-
-const defaultSteps: StepData[] = [
-  {
-    label: 'Step 1',
-    id: '1',
-  },
-  {
-    label: 'Step 2',
-    id: '2',
-  },
-  {
-    label: 'Step 3',
-    id: '3',
-  },
-  {
-    label: 'Step 4',
-    id: '4',
-  },
-  {
-    label: 'Step 5',
-    id: '5',
-  },
-]
 
 export const Default: Story = {
   args: {

--- a/src/ProgressIndicator/storybook/ProgressIndicator.stories.tsx
+++ b/src/ProgressIndicator/storybook/ProgressIndicator.stories.tsx
@@ -1,0 +1,75 @@
+import { Meta, StoryObj } from '@storybook/react'
+import React from 'react'
+import styled from 'styled-components'
+import { Box } from '../../Box'
+import { theme } from '../../theme'
+import { ProgressIndicator } from '../ProgressIndicator'
+import { StepData } from 'ProgressIndicator/types'
+
+const BgWrapper = styled(Box)`
+  background: ${theme.colors.coconut};
+`
+
+const meta: Meta<typeof ProgressIndicator> = {
+  title: 'ProgressIndicator',
+  component: ProgressIndicator,
+  // argTypes: { handlePageChange: { action: 'pageChanged' } },
+  decorators: [
+    (Story) => (
+      <BgWrapper px="16px" height="100px" flex alignItems="center">
+        <Story />
+      </BgWrapper>
+    ),
+  ],
+}
+
+export default meta
+
+type Story = StoryObj<typeof ProgressIndicator>
+
+const defaultSteps: StepData[] = [
+  {
+    label: 'Step 1',
+    id: '1',
+    pathList: ['/1'],
+  },
+  {
+    label: 'Step 2',
+    id: '2',
+    pathList: ['/2'],
+  },
+  {
+    label: 'Step 3',
+    id: '3',
+    pathList: ['/3'],
+  },
+  {
+    label: 'Step 4',
+    id: '4',
+    pathList: ['/4'],
+  },
+  {
+    label: 'Step 5',
+    id: '5',
+    pathList: ['/5'],
+  },
+]
+
+export const Default: Story = {
+  args: {
+    steps: defaultSteps,
+    currentStep: '5',
+    onStepClick: () => console.log('step click function'),
+    handleStepChange: () => console.log('step change function'),
+  },
+}
+
+export const simpleStepLayout: Story = {
+  args: {
+    steps: defaultSteps,
+    currentStep: '5',
+    onStepClick: () => console.log('step click function'),
+    handleStepChange: () => console.log('step change function'),
+    simpleStep: true,
+  },
+}

--- a/src/ProgressIndicator/storybook/ProgressIndicator.stories.tsx
+++ b/src/ProgressIndicator/storybook/ProgressIndicator.stories.tsx
@@ -33,7 +33,6 @@ const meta: Meta<typeof ProgressIndicator> = {
           detail:
             'Function used to run functions that should run on click of a step but not always as part of the handleStepChange function',
         },
-        defaultValue: { summary: 'test', detail: 'deta' },
       },
     },
     currentStep: {

--- a/src/ProgressIndicator/storybook/ProgressIndicator.stories.tsx
+++ b/src/ProgressIndicator/storybook/ProgressIndicator.stories.tsx
@@ -70,8 +70,6 @@ const meta: Meta<typeof ProgressIndicator> = {
         },
       },
     },
-
-    // simpleStep: { description: 'used to determine ', 'type' },
   },
   decorators: [
     (Story) => (

--- a/src/ProgressIndicator/types.ts
+++ b/src/ProgressIndicator/types.ts
@@ -3,6 +3,5 @@ export type StepState = 'completed' | 'current' | 'disabled'
 export interface StepData {
   label: string
   id: string
-  pathList: string[]
   isHidden?: boolean
 }

--- a/src/ProgressIndicator/types.ts
+++ b/src/ProgressIndicator/types.ts
@@ -1,0 +1,8 @@
+export type StepState = 'completed' | 'current' | 'disabled'
+
+export interface StepData {
+  label: string
+  id: string
+  pathList: string[]
+  isHidden?: boolean
+}


### PR DESCRIPTION
## What does this do?
A new progress indicator component to show progress within form steps. This has the following props

- `steps`: An array of objects with the following properties
  - `handleStepChange`: A function that runs on step change, does not run if the step is `disabled` (A step is considered `disabled` if it's not the current step or a completed step)
  - `onStepClick`: A function that runs on step click. This is always run regardless of step state
  - `simpleStep`: sets the component to a "simple" view (see below screenshots)
  - `currentStep`: the current step the form should be on

> [!NOTE]
Whilst this is only used in the signup flow, this is part of the components library so we don't have any deviation going forward.

## Screenshot / Video
### Normal progress indicator
![Screenshot 2025-04-08 at 15 22 03](https://github.com/user-attachments/assets/a34a07e4-1d0b-48d3-93c7-62465939d0df)

https://github.com/user-attachments/assets/2c4a31c1-41d1-4a3d-a135-b4e01fce555d

### Simple progress indicator
![Screenshot 2025-04-08 at 15 29 11](https://github.com/user-attachments/assets/948ce159-aeb2-41ac-bc49-144ec266b1ba)

https://github.com/user-attachments/assets/eee6d8c5-ece5-4354-a718-64338b4ff4c9

## Relevant tickets / Documentation
- [Component within design system](https://www.figma.com/design/FqSaizGOyOzXFZNmZ4X0LGMn/%F0%9F%8D%AC-S-mores?node-id=6862-27666&m=dev&focus-id=21455-112418)

## Testing
- New unit tests added for each component
