### PR TITLE
fix(progress-indicator): minor changes from implementation

### DIFF
--- a/src/ProgressIndicator/ProgressIndicator.tsx
+++ b/src/ProgressIndicator/ProgressIndicator.tsx
@@ -24,15 +24,16 @@ export const ProgressIndicator = ({
   steps,
   currentStep,
 }: Props) => {
-  const { totalWidth, stepWidth } = calculateProgressWidths(
-    steps.length,
-    simpleStep,
-  )
-
   const visibleSteps = steps.filter((step) => !step.isHidden)
   const currentStepIndex = visibleSteps.findIndex(
     (step) => step.id === currentStep,
   )
+
+  const { totalWidth, stepWidth } = calculateProgressWidths(
+    visibleSteps.length,
+    simpleStep,
+  )
+
   const lastCompletedStepIndex = visibleSteps.findLastIndex(
     (step) =>
       calculateStepState(visibleSteps.indexOf(step), currentStepIndex) ===

--- a/src/ProgressIndicator/ProgressIndicator.tsx
+++ b/src/ProgressIndicator/ProgressIndicator.tsx
@@ -55,7 +55,12 @@ export const ProgressIndicator = ({
   }
 
   return (
-    <Wrapper width={`${totalWidth}px`} flex alignItems="center">
+    <Wrapper
+      width={`${totalWidth}px`}
+      flex
+      justifyContent="flex-start"
+      alignItems="center"
+    >
       <DefaultProgress $simpleStep={simpleStep} />
       <Box flex>
         {visibleSteps.map((step, index) => {
@@ -65,6 +70,7 @@ export const ProgressIndicator = ({
               key={step.id}
               isCompleted={stepState === 'completed'}
               isCurrentStep={stepState === 'current'}
+              isDisabled={stepState === 'disabled'}
               isLastCompleted={lastCompletedStepIndex === index}
               onClick={() => handleStepClick(index, stepState, step)}
               stepWidth={`${stepWidth}px`}

--- a/src/ProgressIndicator/components/StepItem.test.tsx
+++ b/src/ProgressIndicator/components/StepItem.test.tsx
@@ -7,6 +7,7 @@ describe('StepItem', () => {
     isCurrentStep: false,
     isCompleted: false,
     isLastCompleted: false,
+    isDisabled: false,
     isSimple: false,
     onClick: vi.fn(),
     stepWidth: '100px',

--- a/src/ProgressIndicator/components/StepItem.tsx
+++ b/src/ProgressIndicator/components/StepItem.tsx
@@ -9,6 +9,7 @@ import { Icon } from '../../Icon'
 export interface StepItemProps extends Pick<StepData, 'label'> {
   isCompleted?: boolean
   isLastCompleted?: boolean
+  isDisabled: boolean
   isCurrentStep: boolean
   isSimple?: boolean
   onClick: () => void
@@ -25,6 +26,7 @@ export const StepItem = ({
   isCompleted = false,
   isLastCompleted = false,
   isLastItem = false,
+  isDisabled,
 }: StepItemProps) => {
   if (isSimple) {
     return (
@@ -40,22 +42,30 @@ export const StepItem = ({
   return (
     <ProgressItem
       flex
+      alignItems="flex-start"
       $completed={isCompleted}
       $lastCompleted={isLastCompleted}
       width={stepWidth}
-      onClick={onClick}
     >
-      <ProgressIndicator
-        $completed={isCompleted}
-        $currentStep={isCurrentStep}
+      <ClickableArea
         flex
+        direction="column"
         alignItems="center"
-        justifyContent="center"
+        onClick={onClick}
+        $isDisabled={isDisabled}
       >
-        {isCompleted && <Icon render="tick" size={16} color="cream" />}
-      </ProgressIndicator>
+        <ProgressIndicator
+          $completed={isCompleted}
+          $currentStep={isCurrentStep}
+          flex
+          alignItems="center"
+          justifyContent="center"
+        >
+          {isCompleted && <Icon render="tick" size={16} color="cream" />}
+        </ProgressIndicator>
+        <StyledText typo="caption">{label}</StyledText>
+      </ClickableArea>
       {isCompleted && !isLastItem && <CompletedBar />}
-      <FloatingText typo="caption">{label}</FloatingText>
     </ProgressItem>
   )
 }
@@ -64,6 +74,7 @@ interface StyledComponentProps {
   $completed?: boolean
   $lastCompleted?: boolean
   $currentStep?: boolean
+  $isDisabled?: boolean
   $completedStep?: boolean
 }
 
@@ -96,23 +107,25 @@ const ProgressItem = styled(Box)<StyledComponentProps>`
   position: relative;
   z-index: 1;
 `
+const ClickableArea = styled(Box)<StyledComponentProps>`
+  position: relative;
+  cursor: ${({ $isDisabled }) => ($isDisabled ? 'auto' : 'pointer')};
+  top: 9px;
+  left: -8px;
+`
 
 const ProgressIndicator = styled(Box)<StyledComponentProps>`
   border-radius: 50%;
   height: 24px;
   width: 24px;
   position: relative;
-  left: -2px;
   z-index: 1;
   background: ${({ $completed, $currentStep }) =>
     $completed || $currentStep ? theme.colors.pistachio : theme.colors.matcha};
 `
 
-const FloatingText = styled(Text)`
-  position: absolute;
-  top: 0;
-  transform: translateY(calc(-50% + 34px));
-  left: -6px;
+const StyledText = styled(Text)`
+  margin-top: 2px;
   font-weight: ${theme.font.weight.medium};
 `
 
@@ -120,9 +133,9 @@ const CompletedBar = styled(Box)`
   position: absolute;
   height: 12px;
   width: 100%;
-  top: 0;
+  top: 50%;
   left: 0;
-  transform: translateY(calc(-50% + 12px));
+  transform: translateY(calc(-50%));
   background: ${theme.colors.pistachio};
   z-index: 0;
 `


### PR DESCRIPTION
## What does this do?
When implementing into SUF, I've needed to make the following changes

- Only allow the circle and text to be clickable
- Only show cursor pointer on clickable items
- Calculate step width only on visible steps
- Better styling changes to allow all clickable area

## Screenshot / Video

https://github.com/user-attachments/assets/d09057d3-aa1d-487b-9829-2a0ec517391f


https://github.com/user-attachments/assets/4da51b06-4597-44e6-b280-a3880d173828



## Relevant tickets / Documentation
N/A

## Testing
- tests still pass
