### PR TITLE
chore(progress-indicator): better styling

### DIFF
--- a/src/ProgressIndicator/components/StepItem.tsx
+++ b/src/ProgressIndicator/components/StepItem.tsx
@@ -106,12 +106,16 @@ const SimpleItem = styled(Box)<StyledComponentProps>`
 const ProgressItem = styled(Box)<StyledComponentProps>`
   position: relative;
   z-index: 1;
+  top: 9px;
+  left: -10px;
+
+  &:last-child {
+    width: auto;
+  }
 `
 const ClickableArea = styled(Box)<StyledComponentProps>`
   position: relative;
   cursor: ${({ $isDisabled }) => ($isDisabled ? 'auto' : 'pointer')};
-  top: 9px;
-  left: -8px;
 `
 
 const ProgressIndicator = styled(Box)<StyledComponentProps>`
@@ -127,15 +131,15 @@ const ProgressIndicator = styled(Box)<StyledComponentProps>`
 const StyledText = styled(Text)`
   margin-top: 2px;
   font-weight: ${theme.font.weight.medium};
+  white-space: nowrap;
 `
 
 const CompletedBar = styled(Box)`
   position: absolute;
   height: 12px;
   width: 100%;
-  top: 50%;
-  left: 0;
-  transform: translateY(calc(-50%));
+  top: 7px;
+  left: 10px;
   background: ${theme.colors.pistachio};
   z-index: 0;
 `


### PR DESCRIPTION
## What does this do?
Fixes an issue where the progress bar on smaller screens breaks the page and adds an overflow.

## Screenshot / Video
### Before
<img width="490" alt="Screenshot 2025-04-15 at 17 27 06" src="https://github.com/user-attachments/assets/f571214e-7769-4bc8-adff-abdfa69e4f5f" />

### After
<img width="508" alt="Screenshot 2025-04-15 at 17 24 55" src="https://github.com/user-attachments/assets/373667e7-f181-4bf2-83c6-ca7f8117b39e" />


## Relevant tickets / Documentation
N/A

## Testing
- Visual