### PR TITLE
chore: move step item full indicator and add test id to clickable area

### DIFF
--- a/src/ProgressIndicator/components/StepItem.tsx
+++ b/src/ProgressIndicator/components/StepItem.tsx
@@ -49,6 +49,7 @@ export const StepItem = ({
     >
       <ClickableArea
         flex
+        data-testid={`step-item-${label}`}
         direction="column"
         alignItems="center"
         onClick={onClick}
@@ -139,7 +140,7 @@ const CompletedBar = styled(Box)`
   height: 12px;
   width: 100%;
   top: 7px;
-  left: 10px;
+  left: 13px;
   background: ${theme.colors.pistachio};
   z-index: 0;
 `


### PR DESCRIPTION
## What does this do?
- Minor UI adjustment to fix when the "full" indicator leaves a gap in some cases.
- Adding a test Id to the clickable area for better testing

## Screenshot / Video
N/A

## Relevant tickets / Documentation
N/A

## Testing
Visual