### PR TITLE
feat(tag): added optional onclick prop to tag comp

### DIFF
--- a/src/Tag/Tag.tsx
+++ b/src/Tag/Tag.tsx
@@ -17,6 +17,7 @@ export type TagProps = {
   className?: string
   icon?: Icons
   iconColor?: Color
+  onClick?: () => void
 } & MarginProps
 
 export const Tag: FC<TagProps> = ({
@@ -27,6 +28,7 @@ export const Tag: FC<TagProps> = ({
   className,
   icon,
   iconColor,
+  onClick,
   ...marginProps
 }) => (
   <Wrapper
@@ -36,6 +38,7 @@ export const Tag: FC<TagProps> = ({
     {...marginProps}
     alignContent="center"
     justifyContent="center"
+    onClick={onClick}
   >
     {icon && (
       <TagIcon


### PR DESCRIPTION
## What does this do?
Added optional onClick property for Tag componnet

## Screenshot / Video
<img width="84" alt="image" src="https://github.com/user-attachments/assets/de226128-0c77-4b13-8937-739f048c59cb" />
