### PR TITLE
feat(radiogroup): radiogroup and dropdown style

### DIFF
--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -181,13 +181,15 @@ interface SSelect {
   $error: boolean
   $frontIcon?: string
   $fallbackStyle?: boolean
+  value?: string | null
 }
 
 const StyledSelect = styled.select<SSelect>`
   ${resetSelect}
   width: 100%;
   height: 32px;
-
+  color: ${({ value }) =>
+    value === '' ? theme.colors.sesame : theme.colors.liquorice};
   cursor: pointer;
   background-color: ${({ $fallbackStyle }) =>
     $fallbackStyle ? theme.colors.custard : theme.colors.cream};

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -58,7 +58,7 @@ export const Dropdown = forwardRef(function Dropdown(
     showDefaultOption = false,
     customDefaultOption,
     name,
-    value: valueProp,
+    value: valueProp = '',
     defaultValue,
     disabled = false,
     list,
@@ -126,7 +126,7 @@ export const Dropdown = forwardRef(function Dropdown(
           name={name}
           $frontIcon={frontIcon}
           $fallbackStyle={fallbackStyle}
-          value={value ?? ''}
+          value={value}
         >
           {hasOptGroups ? (
             <optgroup label={defaultOptionLabel()}>

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -126,7 +126,7 @@ export const Dropdown = forwardRef(function Dropdown(
           name={name}
           $frontIcon={frontIcon}
           $fallbackStyle={fallbackStyle}
-          value={value ? value : ''}
+          value={value ?? ''}
         >
           {hasOptGroups ? (
             <optgroup label={defaultOptionLabel()}>

--- a/src/RadioGroup/RadioItem.tsx
+++ b/src/RadioGroup/RadioItem.tsx
@@ -142,8 +142,8 @@ const Wrapper = styled.label<
 >`
   display: flex;
   flex-direction: column;
-  cursor: pointer;
-
+  cursor: ${({ $disabled }) => ($disabled ? 'default' : 'pointer')};
+  opacity: ${({ $disabled }) => ($disabled ? '0.5' : '1')};
   ${({
     $displayType,
     checked,
@@ -156,11 +156,9 @@ const Wrapper = styled.label<
       $displayType === 'vertical-card') &&
     css`
       border-radius: 12px;
-      background-color: ${$disabled
-        ? theme.colors.chia
-        : $fallbackStyle
-          ? theme.colors.cream
-          : theme.colors.custard};
+      background-color: ${$fallbackStyle
+        ? theme.colors.cream
+        : theme.colors.custard};
       padding: ${checked ? '10px' : '12px'};
       border: ${checked &&
       ($isError


### PR DESCRIPTION
## What does this do?
Changed the styling of the radiogroup if the option is disabled, changed font color of placeholder text

## Screenshot / Video
<img width="782" alt="image" src="https://github.com/user-attachments/assets/1b734239-0f58-498f-beee-1d0adc62a822" />

<img width="994" alt="image" src="https://github.com/user-attachments/assets/787275fa-6164-4ad0-8c59-2d756216c475" />


## Relevant tickets / Documentation
PR is part of this ticket: https://marshmallow1.atlassian.net/browse/CLM-1364
