### PR TITLE
chore(Table): remove redundant `footerColor` prop from TableProps interface

### DIFF
--- a/src/Table/types.ts
+++ b/src/Table/types.ts
@@ -137,8 +137,6 @@ export interface TableProps<T, K = undefined> extends CommonTableProps<T> {
 
   footer?: TableFooter<K>
 
-  /** The cell color of the footer. */
-  footerColor?: Color
   /** The text to show when there is no available data to map through. */
   noDataContent?: ReactNode
 }


### PR DESCRIPTION
Follow-up from https://github.com/marshmallow-insurance/smores-react/pull/4433

Accidentally left an unused `footerColor` property. Haven't release previous changes so safe to remove without breaking.

### Changes
Eliminate the unused footerColor property from the TableProps interface to streamline the code.