### PR TITLE
refactor(IconStrict): Use `title` regardless of `isButton`

### DIFF
--- a/src/IconStrict/IconStrict.tsx
+++ b/src/IconStrict/IconStrict.tsx
@@ -60,7 +60,8 @@ export const IconStrict: FC<IconStrictProps> = ({
   ...otherProps
 }) => {
   const isButton = !!handleClick
-  const defaultLabel = isButton ? (title ? title : 'icon-button') : undefined
+  const defaultLabel =
+    title ?? (isButton ? (title ?? 'icon-button') : undefined)
   return (
     <IconContainer
       id={id}


### PR DESCRIPTION
## What does this do?
- Always use the title attribute when it is present, regardless of whether the icon is rendered as a button or another element.