### PR TITLE
feat(RadioGroup): add 'horizontal-normal' display type and update styles

### DIFF
--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -124,23 +124,29 @@ export const RadioGroup = forwardRef(RadioGroupComponent) as <
   Value extends BaseValueType = BaseValueType,
 >(
   p: RadioGroupProps<Value> & React.RefAttributes<HTMLInputElement>,
-) => ReactElement<any> | null
+) => ReactElement | null
 
 const RadioItemList = styled.div<
   TransientProps<Pick<RadioGroupProps, 'displayType' | 'justifyContent'>>
 >`
   display: flex;
   gap: ${ITEM_GAP}px;
+  justify-content: ${({ $justifyContent }) => $justifyContent ?? 'flex-start'};
 
   ${({ $displayType }) => {
-    if ($displayType === 'horizontal-card') {
-      return `
+    switch ($displayType) {
+      case 'horizontal-normal':
+        return `
         flex-direction: row;
-        flex-wrap: wrap;
-      `
+        align-items: center;
+        `
+      case 'horizontal-card':
+        return `
+          flex-direction: row;
+          flex-wrap: wrap;
+        `
+      default:
+        return 'flex-direction: column;'
     }
-
-    return `flex-direction: column;`
   }}
-  justify-content: ${({ $justifyContent }) => $justifyContent ?? 'flex-start'};
 `

--- a/src/RadioGroup/storybook/RadioGroup.stories.tsx
+++ b/src/RadioGroup/storybook/RadioGroup.stories.tsx
@@ -48,6 +48,12 @@ export const Interactive: Story = {
   },
 }
 
+export const HorizontalNormal: Story = {
+  args: {
+    displayType: 'horizontal-normal',
+  },
+}
+
 export const Vertical: Story = {
   args: {
     displayType: 'vertical-card',

--- a/src/RadioGroup/types.ts
+++ b/src/RadioGroup/types.ts
@@ -1,6 +1,21 @@
 export type IconPosition = 'center' | 'start'
 
-export type DisplayType = 'normal' | 'vertical-card' | 'horizontal-card'
+/**
+ * Defines the display type for the RadioGroup component.
+ *
+ * @remarks
+ * An additional type 'horizontal-normal' represents a temporary solution implemented to quickly support
+ * design requirements without introducing breaking changes. In the long term,
+ * a refactor of the RadioGroup component is planned to provide more flexible
+ * display options in a more maintainable way.
+ * Ref ticket: https://marshmallow1.atlassian.net/browse/CLM-1509
+ *
+ */
+export type DisplayType =
+  | 'normal'
+  | 'horizontal-normal'
+  | 'vertical-card'
+  | 'horizontal-card'
 
 export type BaseValueType = string | boolean | null
 


### PR DESCRIPTION
Temporary Enhancement: Add horizontal-normal Display Type to RadioGroup

This pull request introduces a temporary display type, horizontal-normal, to the RadioGroup component. This addition addresses immediate design requirements without introducing breaking changes, ahead of a planned refactor of the component for improved flexibility and maintainability.

Key Updates:
	•	New Display Type: Added horizontal-normal to the DisplayType type definition to meet specific layout needs. This implementation is explicitly intended as a short-term solution.
	•	Styling Logic: Updated the RadioItemList component to support the new display type, using a switch statement to cleanly handle different layouts.
	•	Storybook Documentation: Added a new story (HorizontalNormal) to demonstrate and test the new display type for better visibility and validation during development.

⚠️ This update is a stopgap solution to unblock current design work. A more robust and flexible refactor of the RadioGroup component is planned for the future.

## Screenshot / Video
<!--
- applicable for UI changes, can be skipped if not relevant. You can drag and drop images/videos to upload them to GitHub.
- Example with image with fixed width 
  - <img src="https://github.com/marshmallow-insurance/uk-auto-signup-www/assets/57456071/3dbf1ec1-2363-4e20-8236-b1f1581b0953" width="300px" />
shortcuts:
 - Screenshot: cmd + shift + 4
 - Screen recording: cmd + shift + 5
-->
<img width="847" alt="Screenshot 2025-05-19 at 11 54 33" src="https://github.com/user-attachments/assets/8f86ad1f-8f03-4603-b23f-495e66f76c2c" />

## Relevant tickets / Documentation
<!--
- Link to any relevant issue tracking software (jira, GitHub etc), documentation (PRDs, engineering plans, Figma designs) or slack threads
- If applicable, list any new documentation that has been created/updated e.g. diagrams/flows etc
-->

https://marshmallow1.atlassian.net/browse/CLM-1509
