### PR TITLE
refactor(CLM-156): Allow snackbar toasts to show over modals

### DIFF
--- a/src/Snackbar/README.md
+++ b/src/Snackbar/README.md
@@ -1,0 +1,122 @@
+# Snackbar
+
+The Snackbar component is used to display short, non-disruptive messages to users.
+
+## Implementation Details
+
+The Snackbar component uses React Portal to render outside the normal DOM hierarchy. This allows it to properly overlay all other components, including Modals, that also use portals.
+
+## Usage
+
+```jsx
+import { SnackbarContainer, useSnackbar } from '@mrshmllw/smores-react'
+
+// Wrap your application with the SnackbarContainer
+const App = () => {
+  return (
+    <SnackbarContainer>
+      <YourAppContent />
+    </SnackbarContainer>
+  )
+}
+
+// Use the useSnackbar hook to add snackbars
+const SomeComponent = () => {
+  const { addSnackbar } = useSnackbar()
+
+  const handleClick = () => {
+    addSnackbar({
+      message: 'Your message here',
+      leadingIcon: 'tick',  // Optional icon
+      canManuallyClose: true,  // Allow users to dismiss the snackbar
+      autoCloseTime: 5,  // Auto-close after 5 seconds (default is 4)
+      showCloseIcon: false  // Use text "Dismiss" instead of an X icon
+    })
+  }
+
+  return (
+    <Button onClick={handleClick}>Show Snackbar</Button>
+  )
+}
+```
+
+## Working with Modals
+
+Snackbars now properly overlay Modals thanks to the React Portal implementation. The Snackbar will appear centered directly over the modal content. Here's an example showing both components together:
+
+```jsx
+import { SnackbarContainer, useSnackbar, Modal, Button, Text } from '@mrshmllw/smores-react'
+import { useState } from 'react'
+
+const App = () => (
+  <SnackbarContainer>
+    <PageWithModalAndSnackbar />
+  </SnackbarContainer>
+)
+
+const PageWithModalAndSnackbar = () => {
+  const { addSnackbar } = useSnackbar()
+  const [showModal, setShowModal] = useState(false)
+
+  return (
+    <>
+      <Button primary onClick={() => setShowModal(true)} mr="16px">
+        Open Modal
+      </Button>
+      <Button
+        secondary
+        onClick={() => {
+          // This snackbar will appear centered directly over the modal
+          addSnackbar({
+            leadingIcon: 'warning',
+            message: 'Important notification!',
+            canManuallyClose: true,
+          })
+        }}
+      >
+        Show Snackbar
+      </Button>
+
+      <Modal
+        title="Sample Modal"
+        showModal={showModal}
+        handleClick={() => setShowModal(false)}
+      >
+        <Text>
+          Click the "Show Snackbar" button to see how the snackbar
+          appears centered directly over this modal.
+        </Text>
+      </Modal>
+    </>
+  )
+}
+```
+
+## Props
+
+### SnackbarContainer Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| children | ReactNode | - | The content to be rendered inside the container |
+| portalContainer | Element \| DocumentFragment | document.body | DOM element where the snackbar will be rendered |
+
+### Snackbar Message Options
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| message | string | - | Text to display in the snackbar |
+| autoCloseTime | 4-10 | 4 | Time in seconds before the snackbar auto-closes |
+| leadingIcon | Icon name | - | Optional icon to display before the message |
+| canManuallyClose | boolean | false | Whether users can dismiss the snackbar |
+| showCloseIcon | boolean | false | Whether to show an X icon (true) or "Dismiss" text (false) |
+
+## Z-Index Behavior
+
+The Snackbar component now uses React Portal to render at the root level of the DOM, which allows it to properly overlay Modal components. It has a z-index of 1000, which is higher than the Modal's z-index of 999.
+
+This implementation resolves the issue where Modals would always appear on top of Snackbars due to different stacking contexts.
+
+## Positioning
+
+Snackbars are now positioned in the center of the screen, directly over any open modal content. This positioning ensures important notifications are prominently displayed regardless of other UI elements. 

--- a/src/Snackbar/SnackbarContainer.tsx
+++ b/src/Snackbar/SnackbarContainer.tsx
@@ -1,15 +1,20 @@
 import React, {
   createContext,
   FC,
-  ReactNode,
   useCallback,
   useContext,
   useRef,
   useState,
 } from 'react'
+import { createPortal } from 'react-dom'
 import styled from 'styled-components'
 import { SnackbarItem } from './SnackbarItem'
-import { CreateSnack, Snackbar, SnackbarContextType } from './types'
+import {
+  CreateSnack,
+  Snackbar,
+  SnackbarContextType,
+  SnackbarContainerProps,
+} from './types'
 
 export const SnackbarContext = createContext<SnackbarContextType>({
   addSnackbar: () => {
@@ -19,8 +24,9 @@ export const SnackbarContext = createContext<SnackbarContextType>({
 
 export const useSnackbarContext = () => useContext(SnackbarContext)
 
-export const SnackbarContainer: FC<{ children?: ReactNode }> = ({
+export const SnackbarContainer: FC<SnackbarContainerProps> = ({
   children,
+  portalContainer = document.body,
 }) => {
   const snackbarIdRef = useRef(0)
   const [snackbars, setSnackbars] = useState<Snackbar[]>([])
@@ -51,15 +57,18 @@ export const SnackbarContainer: FC<{ children?: ReactNode }> = ({
       }}
     >
       {children}
-      <SnackbarWrapper>
-        {snackbars.map((snackbar) => (
-          <SnackbarItem
-            key={snackbar.id}
-            {...snackbar}
-            deleteSnack={deleteSnackbar}
-          />
-        ))}
-      </SnackbarWrapper>
+      {createPortal(
+        <SnackbarWrapper>
+          {snackbars.map((snackbar) => (
+            <SnackbarItem
+              key={snackbar.id}
+              {...snackbar}
+              deleteSnack={deleteSnackbar}
+            />
+          ))}
+        </SnackbarWrapper>,
+        portalContainer,
+      )}
     </SnackbarContext.Provider>
   )
 }

--- a/src/Snackbar/storybook/Snackbar.stories.tsx
+++ b/src/Snackbar/storybook/Snackbar.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta, StoryObj } from '@storybook/react'
-import React, { FC } from 'react'
+import React, { FC, useState } from 'react'
 import { Button } from '../../Button'
+import { Modal } from '../../Modal'
+import { Text } from '../../Text'
 import { SnackbarContainer } from '../SnackbarContainer'
 import { useSnackbar } from '../hooks'
 
@@ -45,6 +47,51 @@ export const Default: Story = {
   render: () => (
     <SnackbarContainer>
       <ChildComponent />
+    </SnackbarContainer>
+  ),
+}
+
+const WithModalComponent: FC = () => {
+  const { addSnackbar } = useSnackbar()
+  const [showModal, setShowModal] = useState(false)
+
+  return (
+    <>
+      <Button primary onClick={() => setShowModal(true)} mr="16px">
+        Open Modal
+      </Button>
+
+      <Modal
+        title="Test Modal"
+        showModal={showModal}
+        handleClick={() => setShowModal(false)}
+      >
+        <Text mb="16px">
+          This is a test modal. Try clicking the "Add Snackbar" button to see
+          how the snackbar appears centered directly over this modal content.
+        </Text>
+        <Button
+          secondary
+          onClick={() => {
+            addSnackbar({
+              leadingIcon: 'warning',
+              message: 'This snackbar appears centered over the modal!',
+              canManuallyClose: true,
+              autoCloseTime: 10,
+            })
+          }}
+        >
+          Add Snackbar
+        </Button>
+      </Modal>
+    </>
+  )
+}
+
+export const WithModal: Story = {
+  render: () => (
+    <SnackbarContainer>
+      <WithModalComponent />
     </SnackbarContainer>
   ),
 }

--- a/src/Snackbar/types.ts
+++ b/src/Snackbar/types.ts
@@ -1,4 +1,5 @@
 import { Icons } from '../Icon/iconsList'
+import { ReactNode } from 'react'
 
 export interface Snackbar {
   id: string
@@ -13,4 +14,9 @@ export type CreateSnack = Omit<Snackbar, 'id'>
 
 export interface SnackbarContextType {
   addSnackbar: (snackbar: CreateSnack) => void
+}
+
+export interface SnackbarContainerProps {
+  children?: ReactNode
+  portalContainer?: Element | DocumentFragment
 }


### PR DESCRIPTION
## What does this do?

- Updated SnackbarContainer to use createPortal for rendering snackbars, allowing them to be displayed over other components.
- Introduced SnackbarContainerProps to define props for the SnackbarContainer, including an optional portalContainer prop.
- Enhanced Snackbar stories to demonstrate snackbar functionality within a modal context.


## Screenshot / Video
<!--
- applicable for UI changes, can be skipped if not relevant. You can drag and drop images/videos to upload them to GitHub.
- Example with image with fixed width 
  - <img src="https://github.com/marshmallow-insurance/uk-auto-signup-www/assets/57456071/3dbf1ec1-2363-4e20-8236-b1f1581b0953" width="300px" />
shortcuts:
 - Screenshot: cmd + shift + 4
 - Screen recording: cmd + shift + 5
-->

https://github.com/user-attachments/assets/e6ad0113-4972-46c9-92fe-0081dc74424c


## Relevant tickets / Documentation
<!--
- Link to any relevant issue tracking software (jira, GitHub etc), documentation (PRDs, engineering plans, Figma designs) or slack threads
- If applicable, list any new documentation that has been created/updated e.g. diagrams/flows etc
-->

https://marshmallow1.atlassian.net/browse/CLM-156

