### PR TITLE
feat(Modal): Make modal title sticky

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -83,10 +83,10 @@ export const Modal: FC<ModalProps> = ({
       />
       <Container
         $drawer={drawer}
-        $width={width || '460px'}
+        $width={width ?? '460px'}
         className={containerClass}
       >
-        <Box
+        <HeaderContainer
           flex
           alignItems="flex-start"
           justifyContent="space-between"
@@ -107,7 +107,7 @@ export const Modal: FC<ModalProps> = ({
               />
             )}
           </Box>
-        </Box>
+        </HeaderContainer>
         <Box flex direction="column">
           {children}
         </Box>
@@ -140,12 +140,20 @@ const Overlay = styled.div<{ $closeOnOverlayClick: boolean }>`
   right: 0;
 `
 
+const HeaderContainer = styled(Box)`
+  position: sticky;
+  top: 0;
+  background: ${theme.colors.coconut};
+  padding: 36px 0 8px;
+  z-index: 1;
+`
+
 const Container = styled.div<IModalContainer>(
   ({ $drawer, $width }) => css`
     background: ${theme.colors.coconut};
     box-sizing: border-box;
     border-radius: 16px;
-    padding: 24px;
+    padding: 0 24px 24px 24px;
     width: 100%;
     max-width: ${$width};
     position: fixed;

--- a/src/Modal/storybook/Modal.stories.tsx
+++ b/src/Modal/storybook/Modal.stories.tsx
@@ -5,11 +5,18 @@ import { Box } from '../../Box'
 import { Button } from '../../Button'
 import { Icon } from '../../Icon'
 import { Modal, ModalProps } from '../Modal'
+import { theme } from '../../theme'
 
 const StyledBox = styled(Box)<{ height: string }>`
   width: ${(props) => props.width || '100%'};
   height: ${(props) => props.height};
   transition: height 0.3s ease-in-out;
+`
+
+const SectionBox = styled(Box)`
+  padding: 16px;
+  background-color: ${theme.colors.oatmeal};
+  border-radius: 8px;
 `
 
 const Container: FC<ModalProps> = (props) => {
@@ -99,6 +106,35 @@ export const Interactive: Story = {
           keeps it visible with the modal window as a child window in front of
           it.
         </StyledBox>
+      </Container>
+    )
+  },
+}
+
+export const Scrollable: Story = {
+  args: {
+    title: 'Scrollable Modal',
+    showModal: false,
+    width: '400px',
+  },
+  render: (args) => {
+    return (
+      <Container {...args}>
+        <Box flex direction="column" gap="16px">
+          {Array.from({ length: 20 }).map((_, index) => (
+            <SectionBox key={index}>
+              <Box mb="8px">
+                <strong>Section {index + 1}</strong>
+              </Box>
+              <Box>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                nisi ut aliquip ex ea commodo consequat.
+              </Box>
+            </SectionBox>
+          ))}
+        </Box>
       </Container>
     )
   },


### PR DESCRIPTION
- Add sticky header with solid background to Modal component
- Create new Storybook story demonstrating scrollable content

The sticky header ensures the title remains visible while scrolling through
long content, improving usability for modals with extensive content.

> [!NOTE]
> No visual changes here, padding has only been moved around


### TODO: 
- [ ] Check that modal with no title still has top padding



https://github.com/user-attachments/assets/22200a3d-8fd3-4ae4-a841-801fbe41fe47


