### PR TITLE
feat(testing): add snapshot tests to 4 components

### DIFF
--- a/src/Accordion/Accordion.test.tsx
+++ b/src/Accordion/Accordion.test.tsx
@@ -1,0 +1,32 @@
+import { expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+
+import { Accordion } from './Accordion'
+import React from 'react'
+
+describe('Accordion', () => {
+  it('renders correctly when closed', () => {
+    const { container } = render(
+      <Accordion title="How it works">
+        Lots of brilliant information about this beautiful component
+      </Accordion>,
+    )
+    expect(container).toMatchSnapshot()
+  })
+  it('renders correctly when expanded', () => {
+    const { container } = render(
+      <Accordion title="How it works" defaultIsOpen>
+        Lots of brilliant information about this beautiful component
+      </Accordion>,
+    )
+    expect(container).toMatchSnapshot()
+  })
+  it('renders correctly for fullBorder and filledBackground variant', () => {
+    const { container } = render(
+      <Accordion title="How it works" fullBorder filledBackground defaultIsOpen>
+        Lots of brilliant information about this beautiful component
+      </Accordion>,
+    )
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/src/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -1,0 +1,143 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Accordion > renders correctly for fullBorder and filledBackground variant 1`] = `
+<div>
+  <div
+    class="sc-bRKDuR bHjpxP sc-jwTyAe jaJEhk"
+  >
+    <div
+      class="sc-bRKDuR gwwejK sc-jJLAfE iWiHKP"
+    >
+      <div
+        class="sc-hjsuWn hLwqBO"
+      >
+        <h2
+          class="sc-bRKDuR bHjpxP sc-dTvVRJ jMSukC"
+          cursor="inherit"
+          title=""
+        >
+          How it works
+        </h2>
+      </div>
+      <span
+        class="sc-bRKDuR bHjpxP sc-fhHczv cTkdi sc-hwkwBN fqsjph"
+        color="marzipan"
+        data-testid="caret-container"
+        rotate="0"
+        size="24"
+      >
+        <svg
+          fill="none"
+          height="100%"
+          viewBox="0 0 24 24"
+          width="100%"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M19.66 8.248a1 1 0 00-1.412.095L12 15.482l-6.248-7.14a1 1 0 10-1.504 1.317l7 8a.995.995 0 001.504 0l7-8a1 1 0 00-.093-1.411z"
+            fill="currentColor"
+          />
+        </svg>
+      </span>
+    </div>
+    <div
+      class="sc-bRKDuR enIEuK"
+    >
+      Lots of brilliant information about this beautiful component
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Accordion > renders correctly when closed 1`] = `
+<div>
+  <div
+    class="sc-bRKDuR bHjpxP sc-jwTyAe LOspj"
+  >
+    <div
+      class="sc-bRKDuR jGGaUV sc-jJLAfE iWiHKP"
+    >
+      <div
+        class="sc-hjsuWn hLwqBO"
+      >
+        <h2
+          class="sc-bRKDuR bHjpxP sc-dTvVRJ jMSukC"
+          cursor="inherit"
+          title=""
+        >
+          How it works
+        </h2>
+      </div>
+      <span
+        class="sc-bRKDuR bHjpxP sc-fhHczv cTkdi sc-hwkwBN hNMPrg"
+        color="marzipan"
+        data-testid="caret-container"
+        rotate="0"
+        size="24"
+      >
+        <svg
+          fill="none"
+          height="100%"
+          viewBox="0 0 24 24"
+          width="100%"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M19.66 8.248a1 1 0 00-1.412.095L12 15.482l-6.248-7.14a1 1 0 10-1.504 1.317l7 8a.995.995 0 001.504 0l7-8a1 1 0 00-.093-1.411z"
+            fill="currentColor"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Accordion > renders correctly when expanded 1`] = `
+<div>
+  <div
+    class="sc-bRKDuR bHjpxP sc-jwTyAe LOspj"
+  >
+    <div
+      class="sc-bRKDuR jGGaUV sc-jJLAfE iWiHKP"
+    >
+      <div
+        class="sc-hjsuWn hLwqBO"
+      >
+        <h2
+          class="sc-bRKDuR bHjpxP sc-dTvVRJ jMSukC"
+          cursor="inherit"
+          title=""
+        >
+          How it works
+        </h2>
+      </div>
+      <span
+        class="sc-bRKDuR bHjpxP sc-fhHczv cTkdi sc-hwkwBN fqsjph"
+        color="marzipan"
+        data-testid="caret-container"
+        rotate="0"
+        size="24"
+      >
+        <svg
+          fill="none"
+          height="100%"
+          viewBox="0 0 24 24"
+          width="100%"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M19.66 8.248a1 1 0 00-1.412.095L12 15.482l-6.248-7.14a1 1 0 10-1.504 1.317l7 8a.995.995 0 001.504 0l7-8a1 1 0 00-.093-1.411z"
+            fill="currentColor"
+          />
+        </svg>
+      </span>
+    </div>
+    <div
+      class="sc-bRKDuR hANJi"
+    >
+      Lots of brilliant information about this beautiful component
+    </div>
+  </div>
+</div>
+`;

--- a/src/Button/Button.test.tsx
+++ b/src/Button/Button.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+import { Button } from './Button'
+
+describe('Button', () => {
+  it('renders correctly with default props', () => {
+    const { container } = render(<Button>Click Me</Button>)
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders correctly with a custom className', () => {
+    const { container } = render(
+      <Button className="custom-class">Click Me</Button>,
+    )
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders correctly when disabled', () => {
+    const { container } = render(<Button disabled>Click Me</Button>)
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders correctly with a custom type', () => {
+    const { container } = render(<Button type="submit">Submit</Button>)
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders correctly with an icon', () => {
+    const { container } = render(<Button icon="info">With Icon</Button>)
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders correctly when loading', () => {
+    const { container } = render(<Button loading>Loading</Button>)
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders correctly with primary styling', () => {
+    const { container } = render(<Button primary>Primary Button</Button>)
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders correctly with secondary styling', () => {
+    const { container } = render(<Button secondary>Secondary Button</Button>)
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders correctly with text button styling', () => {
+    const { container } = render(<Button textBtn>Text Button</Button>)
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders correctly with small button styling', () => {
+    const { container } = render(<Button smallButton>Small Button</Button>)
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders correctly with trailing icon', () => {
+    const { container } = render(
+      <Button icon="arrow" trailingIcon>
+        Trailing Icon
+      </Button>,
+    )
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders correctly with forced width', () => {
+    const { container } = render(
+      <Button forcedWidth="200px">Forced Width</Button>,
+    )
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/Button/__snapshots__/Button.test.tsx.snap
@@ -1,0 +1,275 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Button > renders correctly when disabled 1`] = `
+<div>
+  <button
+    class="sc-bRKDuR bHjpxP sc-jJLAfE fhgohJ"
+    disabled=""
+  >
+    <div
+      class="sc-kNOymR AyWek"
+    >
+      <div
+        class="sc-lgpSej dtnxRg childrenContainer"
+      >
+        Click Me
+      </div>
+    </div>
+  </button>
+</div>
+`;
+
+exports[`Button > renders correctly when loading 1`] = `
+<div>
+  <button
+    class="sc-bRKDuR bHjpxP sc-jJLAfE fhgohJ"
+    disabled=""
+  >
+    <div
+      class="sc-hwkwBN HRaKY"
+    >
+      <svg
+        class="sc-ggWZvA gpJQRo"
+        color="liquorice"
+        height="16"
+        viewBox="0 0 60 32"
+      >
+        <g
+          transform="translate(30,18.5455) translate(-30,-9)"
+        >
+          <path
+            class="sc-dTvVRJ jLBpiK"
+            d="M73.999,81.9767L73.6592,70.6087C73.6352,69.8071,73.1892,69.0806,72.4916,68.707C71.1747,68.0014,69.0105,67.648,66.0001,67.6467C62.9894,67.648,60.8254,68.0014,59.5084,68.707C58.8109,69.0806,58.3648,69.8071,58.3408,70.6087L58.001,81.9767C57.983,82.5754,58.2138,83.1538,58.6366,83.5705C60.0408,84.9546,62.4906,85.6467,65.986,85.6467C65.9907,85.6467,65.9953,85.6467,66.0001,85.6467C66.0047,85.6467,66.0094,85.6467,66.014,85.6467C69.5095,85.6467,71.9593,84.9546,73.3634,83.5705C73.7863,83.1538,74.0169,82.5754,73.999,81.9767"
+            id="Marshmallow1"
+            transform="translate(-58,-67.6467)"
+          />
+          <path
+            class="sc-jwTyAe kHfTEG"
+            d="M73.999,81.9767L73.6592,70.6087C73.6352,69.8071,73.1892,69.0806,72.4916,68.707C71.1747,68.0014,69.0105,67.648,66.0001,67.6467C62.9894,67.648,60.8254,68.0014,59.5084,68.707C58.8109,69.0806,58.3648,69.8071,58.3408,70.6087L58.001,81.9767C57.983,82.5754,58.2138,83.1538,58.6366,83.5705C60.0408,84.9546,62.4906,85.6467,65.986,85.6467C65.9907,85.6467,65.9953,85.6467,66.0001,85.6467C66.0047,85.6467,66.0094,85.6467,66.014,85.6467C69.5095,85.6467,71.9593,84.9546,73.3634,83.5705C73.7863,83.1538,74.0169,82.5754,73.999,81.9767"
+            id="Marshmallow2"
+            transform="translate(-36,-67.6467)"
+          />
+          <path
+            class="sc-hjsuWn bjPPtv"
+            d="M73.999,81.9767L73.6592,70.6087C73.6352,69.8071,73.1892,69.0806,72.4916,68.707C71.1747,68.0014,69.0105,67.648,66.0001,67.6467C62.9894,67.648,60.8254,68.0014,59.5084,68.707C58.8109,69.0806,58.3648,69.8071,58.3408,70.6087L58.001,81.9767C57.983,82.5754,58.2138,83.1538,58.6366,83.5705C60.0408,84.9546,62.4906,85.6467,65.986,85.6467C65.9907,85.6467,65.9953,85.6467,66.0001,85.6467C66.0047,85.6467,66.0094,85.6467,66.014,85.6467C69.5095,85.6467,71.9593,84.9546,73.3634,83.5705C73.7863,83.1538,74.0169,82.5754,73.999,81.9767"
+            id="Marshmallow3"
+            transform="translate(-14,-67.6467)"
+          />
+        </g>
+      </svg>
+    </div>
+    <div
+      class="sc-kNOymR AyVJp"
+    >
+      <div
+        class="sc-lgpSej dtnxRg childrenContainer"
+      >
+        Loading
+      </div>
+    </div>
+  </button>
+</div>
+`;
+
+exports[`Button > renders correctly with a custom className 1`] = `
+<div>
+  <button
+    class="sc-bRKDuR bHjpxP sc-jJLAfE cRvUpc custom-class"
+  >
+    <div
+      class="sc-kNOymR AyWek"
+    >
+      <div
+        class="sc-lgpSej dtnxRg childrenContainer"
+      >
+        Click Me
+      </div>
+    </div>
+  </button>
+</div>
+`;
+
+exports[`Button > renders correctly with a custom type 1`] = `
+<div>
+  <button
+    class="sc-bRKDuR bHjpxP sc-jJLAfE cRvUpc"
+    type="submit"
+  >
+    <div
+      class="sc-kNOymR AyWek"
+    >
+      <div
+        class="sc-lgpSej dtnxRg childrenContainer"
+      >
+        Submit
+      </div>
+    </div>
+  </button>
+</div>
+`;
+
+exports[`Button > renders correctly with an icon 1`] = `
+<div>
+  <button
+    class="sc-bRKDuR bHjpxP sc-jJLAfE cRvUpc"
+  >
+    <div
+      class="sc-kNOymR cOHRID"
+    >
+      <span
+        class="sc-bRKDuR bHjpxP sc-fhHczv XmxEI sc-dYwGCk ijOES"
+        color="liquorice"
+        data-testid="info-container"
+        rotate="0"
+        size="24"
+      >
+        <svg
+          fill="none"
+          height="100%"
+          viewBox="0 0 24 24"
+          width="100%"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm-1 6.99a1 1 0 112 0c0 .553-.447 1.005-1 1.005-.553 0-1-.442-1-.995v-.01zM11 11a1 1 0 112 0v7a1 1 0 11-2 0v-7zm-9 1c0 5.514 4.486 10 10 10s10-4.486 10-10S17.514 2 12 2 2 6.486 2 12z"
+            fill="currentColor"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+      <div
+        class="sc-lgpSej dtnxRg childrenContainer"
+      >
+        With Icon
+      </div>
+    </div>
+  </button>
+</div>
+`;
+
+exports[`Button > renders correctly with default props 1`] = `
+<div>
+  <button
+    class="sc-bRKDuR bHjpxP sc-jJLAfE cRvUpc"
+  >
+    <div
+      class="sc-kNOymR AyWek"
+    >
+      <div
+        class="sc-lgpSej dtnxRg childrenContainer"
+      >
+        Click Me
+      </div>
+    </div>
+  </button>
+</div>
+`;
+
+exports[`Button > renders correctly with forced width 1`] = `
+<div>
+  <button
+    class="sc-bRKDuR bHjpxP sc-jJLAfE khrGJF"
+  >
+    <div
+      class="sc-kNOymR AyWek"
+    >
+      <div
+        class="sc-lgpSej dtnxRg childrenContainer"
+      >
+        Forced Width
+      </div>
+    </div>
+  </button>
+</div>
+`;
+
+exports[`Button > renders correctly with primary styling 1`] = `
+<div>
+  <button
+    class="sc-bRKDuR bHjpxP sc-jJLAfE hFWsoJ"
+  >
+    <div
+      class="sc-kNOymR AyWek"
+    >
+      <div
+        class="sc-lgpSej dtnxRg childrenContainer"
+      >
+        Primary Button
+      </div>
+    </div>
+  </button>
+</div>
+`;
+
+exports[`Button > renders correctly with secondary styling 1`] = `
+<div>
+  <button
+    class="sc-bRKDuR bHjpxP sc-jJLAfE emWyIm"
+  >
+    <div
+      class="sc-kNOymR AyWek"
+    >
+      <div
+        class="sc-lgpSej dtnxRg childrenContainer"
+      >
+        Secondary Button
+      </div>
+    </div>
+  </button>
+</div>
+`;
+
+exports[`Button > renders correctly with small button styling 1`] = `
+<div>
+  <button
+    class="sc-bRKDuR bHjpxP sc-jJLAfE eyvxmm"
+  >
+    <div
+      class="sc-kNOymR AyWek"
+    >
+      <div
+        class="sc-lgpSej dtnxRg childrenContainer"
+      >
+        Small Button
+      </div>
+    </div>
+  </button>
+</div>
+`;
+
+exports[`Button > renders correctly with text button styling 1`] = `
+<div>
+  <button
+    class="sc-bRKDuR bHjpxP sc-jJLAfE hJEFtC"
+  >
+    <div
+      class="sc-kNOymR AyWek"
+    >
+      <div
+        class="sc-lgpSej dtnxRg childrenContainer"
+      >
+        Text Button
+      </div>
+    </div>
+  </button>
+</div>
+`;
+
+exports[`Button > renders correctly with trailing icon 1`] = `
+<div>
+  <button
+    class="sc-bRKDuR bHjpxP sc-jJLAfE cRvUpc"
+  >
+    <div
+      class="sc-kNOymR cOHRID"
+    >
+      <div
+        class="sc-lgpSej dtnxRg childrenContainer"
+      >
+        Trailing Icon
+      </div>
+    </div>
+  </button>
+</div>
+`;

--- a/src/Card/Card.test.tsx
+++ b/src/Card/Card.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+import { Card } from './Card'
+import placeHolderSvg from './storybook/placeHolderImage.svg'
+import { Button } from '../Button'
+
+describe('Card', () => {
+  it('renders correctly with title and body', () => {
+    const { container } = render(
+      <Card title="Card Title" body="This is the card body." />,
+    )
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders correctly with a leading icon', () => {
+    const { container } = render(<Card title="Card Title" leadingIcon="info" />)
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders correctly with a visual', () => {
+    const { container } = render(
+      <Card title="Card Title" visual={placeHolderSvg} />,
+    )
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders correctly with action button', () => {
+    const { container } = render(
+      <Card
+        title="Card Title"
+        buttonAction={<Button primary>Action</Button>}
+      />,
+    )
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders correctly with fallback style', () => {
+    const { container } = render(<Card title="Card Title" fallbackStyle />)
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/src/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/Card/__snapshots__/Card.test.tsx.snap
@@ -1,0 +1,229 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Card > renders correctly with a leading icon 1`] = `
+<div>
+  <div
+    class="sc-bRKDuR bHjpxP sc-jwTyAe hjnNOi"
+  >
+    <div
+      class="sc-bRKDuR cRGbbj"
+    >
+      <div
+        class="sc-bRKDuR pJiNb"
+      >
+        <div
+          class="sc-bRKDuR hUwRKL"
+        >
+          <span
+            class="sc-bRKDuR cNXuge sc-fhHczv XmxEI"
+            color="liquorice"
+            data-testid="info-container"
+            rotate="0"
+            size="24"
+          >
+            <svg
+              fill="none"
+              height="100%"
+              viewBox="0 0 24 24"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm-1 6.99a1 1 0 112 0c0 .553-.447 1.005-1 1.005-.553 0-1-.442-1-.995v-.01zM11 11a1 1 0 112 0v7a1 1 0 11-2 0v-7zm-9 1c0 5.514 4.486 10 10 10s10-4.486 10-10S17.514 2 12 2 2 6.486 2 12z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="sc-bRKDuR bHjpxP"
+          >
+            <p
+              class="sc-bRKDuR bHjpxP sc-dTvVRJ jMSukC"
+              cursor="inherit"
+              title=""
+            >
+              Card Title
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="sc-bRKDuR drfqDG"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Card > renders correctly with a visual 1`] = `
+<div>
+  <div
+    class="sc-bRKDuR bHjpxP sc-jwTyAe hzFEh"
+  >
+    <div
+      class="sc-bRKDuR bHjpxP sc-jJLAfE ixsXVo"
+    >
+      <div
+        class="sc-bRKDuR bHjpxP sc-hwkwBN kdnwPq"
+      />
+    </div>
+    <div
+      class="sc-bRKDuR gHyHhE"
+    >
+      <div
+        class="sc-bRKDuR pJiNb"
+      >
+        <div
+          class="sc-bRKDuR hUwRKL"
+        >
+          <div
+            class="sc-bRKDuR bHjpxP"
+          >
+            <p
+              class="sc-bRKDuR bHjpxP sc-dTvVRJ jMSukC"
+              cursor="inherit"
+              title=""
+            >
+              Card Title
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="sc-bRKDuR drfqDG"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Card > renders correctly with action button 1`] = `
+<div>
+  <div
+    class="sc-bRKDuR bHjpxP sc-jwTyAe hjnNOi"
+  >
+    <div
+      class="sc-bRKDuR cRGbbj"
+    >
+      <div
+        class="sc-bRKDuR pJiNb"
+      >
+        <div
+          class="sc-bRKDuR hUwRKL"
+        >
+          <div
+            class="sc-bRKDuR bHjpxP"
+          >
+            <p
+              class="sc-bRKDuR bHjpxP sc-dTvVRJ jMSukC"
+              cursor="inherit"
+              title=""
+            >
+              Card Title
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="sc-bRKDuR drfqDG"
+      />
+      <div
+        class="sc-bRKDuR bozFCt"
+      >
+        <button
+          class="sc-bRKDuR bHjpxP sc-kcLKEh ftunAF"
+        >
+          <div
+            class="sc-kvnevz bNTvaC"
+          >
+            <div
+              class="sc-kCuUfV eQEbcv childrenContainer"
+            >
+              Action
+            </div>
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Card > renders correctly with fallback style 1`] = `
+<div>
+  <div
+    class="sc-bRKDuR bHjpxP sc-jwTyAe KWyJy"
+  >
+    <div
+      class="sc-bRKDuR cRGbbj"
+    >
+      <div
+        class="sc-bRKDuR pJiNb"
+      >
+        <div
+          class="sc-bRKDuR hUwRKL"
+        >
+          <div
+            class="sc-bRKDuR bHjpxP"
+          >
+            <p
+              class="sc-bRKDuR bHjpxP sc-dTvVRJ jMSukC"
+              cursor="inherit"
+              title=""
+            >
+              Card Title
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="sc-bRKDuR drfqDG"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Card > renders correctly with title and body 1`] = `
+<div>
+  <div
+    class="sc-bRKDuR bHjpxP sc-jwTyAe hjnNOi"
+  >
+    <div
+      class="sc-bRKDuR cRGbbj"
+    >
+      <div
+        class="sc-bRKDuR pJiNb"
+      >
+        <div
+          class="sc-bRKDuR hUwRKL"
+        >
+          <div
+            class="sc-bRKDuR bHjpxP"
+          >
+            <p
+              class="sc-bRKDuR bHjpxP sc-dTvVRJ jMSukC"
+              cursor="inherit"
+              title=""
+            >
+              Card Title
+            </p>
+            <p
+              class="sc-bRKDuR bHjpxP sc-dTvVRJ cXtlSP"
+              cursor="inherit"
+              title=""
+            >
+              This is the card body.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="sc-bRKDuR drfqDG"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/CheckBox/CheckBox.test.tsx
+++ b/src/CheckBox/CheckBox.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+import { CheckBox } from './CheckBox'
+
+describe('CheckBox', () => {
+  it('renders correctly when unchecked', () => {
+    const { container } = render(
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      <CheckBox checked={false} toggle={() => {}}>
+        Accept Terms
+      </CheckBox>,
+    )
+    expect(container).toMatchSnapshot()
+  })
+  it('renders correctly when checked', () => {
+    const { container } = render(
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      <CheckBox checked={true} toggle={() => {}}>
+        Accept Terms
+      </CheckBox>,
+    )
+    expect(container).toMatchSnapshot()
+  })
+  it('renders correctly with an error state', () => {
+    const { container } = render(
+      <CheckBox
+        checked={false}
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        toggle={() => {}}
+        error={true}
+        errorMsg="You must accept the terms"
+      >
+        Accept Terms
+      </CheckBox>,
+    )
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/src/CheckBox/__snapshots__/CheckBox.test.tsx.snap
+++ b/src/CheckBox/__snapshots__/CheckBox.test.tsx.snap
@@ -1,0 +1,76 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CheckBox > renders correctly when checked 1`] = `
+<div>
+  <label
+    class="sc-hjsuWn degeIE"
+    id="MM_SMORES_1"
+  >
+    <span
+      class="sc-bRKDuR bHjpxP sc-dTvVRJ JyLYT"
+      cursor="inherit"
+      title=""
+    >
+      Accept Terms
+    </span>
+    <input
+      checked=""
+      type="checkbox"
+    />
+    <span
+      class="sc-jwTyAe jUFwTC"
+    />
+  </label>
+</div>
+`;
+
+exports[`CheckBox > renders correctly when unchecked 1`] = `
+<div>
+  <label
+    class="sc-hjsuWn degeIE"
+    id="MM_SMORES_0"
+  >
+    <span
+      class="sc-bRKDuR bHjpxP sc-dTvVRJ JyLYT"
+      cursor="inherit"
+      title=""
+    >
+      Accept Terms
+    </span>
+    <input
+      type="checkbox"
+    />
+    <span
+      class="sc-jwTyAe jUFwTC"
+    />
+  </label>
+</div>
+`;
+
+exports[`CheckBox > renders correctly with an error state 1`] = `
+<div>
+  <label
+    class="sc-hjsuWn degeIE"
+    id="MM_SMORES_2"
+  >
+    <span
+      class="sc-bRKDuR bHjpxP sc-dTvVRJ fWKoGb"
+      cursor="inherit"
+      title=""
+    >
+      Accept Terms
+    </span>
+    <input
+      type="checkbox"
+    />
+    <span
+      class="sc-jwTyAe gQvhra"
+    />
+  </label>
+  <div
+    class="sc-jJLAfE dDPnEi"
+  >
+    You must accept the terms
+  </div>
+</div>
+`;


### PR DESCRIPTION
## What does this do?
<!-- 
- A short description of what the PR changes and why it's necessary
- Give the reviewers context
- Is the impact global or localised?
- Any tech debt created or discovered?
-->

Adds snapshot tests to the following components as part of gradual snapshot testing implementation to key components/variants:
- Accordion
- Button
- Card
- Checkbox

## Screenshot / Video
<!--
- applicable for UI changes, can be skipped if not relevant. You can drag and drop images/videos to upload them to GitHub.
- Example with image with fixed width 
  - <img src="https://github.com/marshmallow-insurance/uk-auto-signup-www/assets/57456071/3dbf1ec1-2363-4e20-8236-b1f1581b0953" width="300px" />
shortcuts:
 - Screenshot: cmd + shift + 4
 - Screen recording: cmd + shift + 5
-->
N/A

## Relevant tickets / Documentation
<!--
- Link to any relevant issue tracking software (jira, GitHub etc), documentation (PRDs, engineering plans, Figma designs) or slack threads
- If applicable, list any new documentation that has been created/updated e.g. diagrams/flows etc
-->
Prerequisite of the ongoing Design System tokenisation work

## Testing
<!--
- Tests should have been updated/created to cover the changes made in this PR, if not please explain why
-->
✅ Snapshot tests added to four components 