### PR TITLE
chore(checkbox): use theme provider [DES-50]

### DIFF
--- a/src/CheckBox/CheckBox.tsx
+++ b/src/CheckBox/CheckBox.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import { focusOutline } from '../utils/focusOutline'
 
 import { Text } from '../Text'
-import { theme } from '../theme'
 import { useUniqueId } from '../utils/id'
 
 export type CheckBoxProps = {
@@ -51,10 +50,10 @@ const Checkmark = styled.span<{ $error?: boolean }>`
   left: 0;
   width: 24px;
   height: 24px;
-  border: ${({ $error }) =>
+  border: ${({ $error, theme }) =>
     $error
-      ? `solid 2px ${theme.colors.strawberry}`
-      : `solid 2px ${theme.colors.liquorice}`};
+      ? `solid 2px ${theme.color.feedback.negative[200]}`
+      : `solid 2px ${theme.color.border.contrast}`};
   box-sizing: border-box;
   border-radius: 1px;
 
@@ -67,7 +66,7 @@ const Checkmark = styled.span<{ $error?: boolean }>`
     width: 3px;
     height: 8px;
     border-radius: 4px;
-    background-color: ${theme.colors.cream};
+    background-color: ${({ theme }) => theme.color.surface.base['000']};
     -webkit-transform: rotate(316deg);
     -ms-transform: rotate(316deg);
     transform: rotate(316deg);
@@ -82,7 +81,7 @@ const Checkmark = styled.span<{ $error?: boolean }>`
     width: 3px;
     height: 15px;
     border-radius: 4px;
-    background-color: ${theme.colors.cream};
+    background-color: ${({ theme }) => theme.color.surface.base['000']};
     -webkit-transform: rotate(43deg);
     -ms-transform: rotate(43deg);
     transform: rotate(43deg);
@@ -102,11 +101,11 @@ const BoxContainer = styled.label`
     position: absolute;
     opacity: 0;
     cursor: pointer;
-    background-color: ${theme.colors.cream};
+    background-color: ${({ theme }) => theme.color.surface.base['000']};
 
     &:checked ~ ${Checkmark} {
-      background-color: ${theme.colors.liquorice};
-      border: solid 2px ${theme.colors.liquorice};
+      background-color: ${({ theme }) => theme.color.icon.base};
+      border: solid 2px ${({ theme }) => theme.color.icon.base};
     }
 
     &:checked ~ ${Checkmark}:before {
@@ -122,8 +121,8 @@ const BoxContainer = styled.label`
 
   &:hover {
     ${Checkmark} {
-      background-color: ${theme.colors.coconut};
-      border: solid 2px ${theme.colors.liquorice};
+      background-color: ${({ theme }) =>
+        theme.color.interactive.tertiary.hover};
     }
   }
 
@@ -140,5 +139,5 @@ const BoxContainer = styled.label`
 const ErrorBox = styled.div`
   margin-top: 4px;
   font-size: 12px;
-  color: ${theme.colors.strawberry};
+  color: ${({ theme }) => theme.color.feedback.negative[200]};
 `

--- a/src/CheckBox/__snapshots__/CheckBox.test.tsx.snap
+++ b/src/CheckBox/__snapshots__/CheckBox.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CheckBox > renders correctly when checked 1`] = `
 <div>
   <label
-    class="sc-hjsuWn jdOYzT"
+    class="sc-hjsuWn iyKZva"
     id="MM_SMORES_1"
   >
     <span
@@ -18,7 +18,7 @@ exports[`CheckBox > renders correctly when checked 1`] = `
       type="checkbox"
     />
     <span
-      class="sc-jwTyAe jUFwTC"
+      class="sc-jwTyAe kYeyOg"
     />
   </label>
 </div>
@@ -27,7 +27,7 @@ exports[`CheckBox > renders correctly when checked 1`] = `
 exports[`CheckBox > renders correctly when unchecked 1`] = `
 <div>
   <label
-    class="sc-hjsuWn jdOYzT"
+    class="sc-hjsuWn iyKZva"
     id="MM_SMORES_0"
   >
     <span
@@ -41,7 +41,7 @@ exports[`CheckBox > renders correctly when unchecked 1`] = `
       type="checkbox"
     />
     <span
-      class="sc-jwTyAe jUFwTC"
+      class="sc-jwTyAe kYeyOg"
     />
   </label>
 </div>
@@ -50,7 +50,7 @@ exports[`CheckBox > renders correctly when unchecked 1`] = `
 exports[`CheckBox > renders correctly with an error state 1`] = `
 <div>
   <label
-    class="sc-hjsuWn jdOYzT"
+    class="sc-hjsuWn iyKZva"
     id="MM_SMORES_2"
   >
     <span
@@ -64,11 +64,11 @@ exports[`CheckBox > renders correctly with an error state 1`] = `
       type="checkbox"
     />
     <span
-      class="sc-jwTyAe gQvhra"
+      class="sc-jwTyAe iuKYMp"
     />
   </label>
   <div
-    class="sc-jJLAfE dDPnEi"
+    class="sc-jJLAfE llFNkS"
   >
     You must accept the terms
   </div>


### PR DESCRIPTION
## What does this do?
- Update checkbox to use theme provider
- fixes an issue where `border` turned black if the error boolean is true

## Screenshot / Video
### Left - Prod | Right - Dev

https://github.com/user-attachments/assets/f63889ce-757c-42c5-a289-1fe100c94c26


## Relevant tickets / Documentation
N/A

## Testing
- unit tests still pass
- snapshots updated