### PR TITLE
chore(snackbar): update to use theme provider [DES-75]

### DIFF
--- a/src/Snackbar/SnackbarItem.test.tsx
+++ b/src/Snackbar/SnackbarItem.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { noop } from '../utils/noop'
+import { SnackbarItem } from './SnackbarItem'
+import { render, screen } from '../testUtils'
+
+describe('SnackbarItem', () => {
+  it('renders correctly with required props', () => {
+    const { baseElement } = render(
+      <SnackbarItem id="1" message="Test message" deleteSnack={noop} />,
+    )
+
+    expect(baseElement).toMatchSnapshot()
+
+    expect(screen.getByText('Test message')).toBeTruthy()
+  })
+})

--- a/src/Snackbar/SnackbarItem.tsx
+++ b/src/Snackbar/SnackbarItem.tsx
@@ -4,7 +4,6 @@ import { Box } from '../Box'
 import { useTimeout } from '../hooks'
 import { Icon } from '../Icon'
 import { Text } from '../Text'
-import { theme } from '../theme'
 import { Snackbar } from './types'
 
 interface Props extends Snackbar {
@@ -52,7 +51,7 @@ export const SnackbarItem: FC<Props> = ({
 
 const SnackItem = styled(Box)`
   border-radius: 16px;
-  background-color: ${theme.colors.liquorice};
+  background-color: ${({ theme }) => theme.color.surface.base[900]};
 `
 
 const CloseButton = styled.button`

--- a/src/Snackbar/__snapshots__/SnackbarItem.test.tsx.snap
+++ b/src/Snackbar/__snapshots__/SnackbarItem.test.tsx.snap
@@ -1,0 +1,23 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`SnackbarItem > renders correctly with required props 1`] = `
+<body>
+  <div>
+    <div
+      class="sc-bRKDuR iQYNmO sc-jwTyAe btMzyf"
+    >
+      <div
+        class="sc-bRKDuR hUwRKL"
+      >
+        <p
+          class="sc-bRKDuR bHjpxP sc-dTvVRJ iaYRQx"
+          cursor="inherit"
+          title=""
+        >
+          Test message
+        </p>
+      </div>
+    </div>
+  </div>
+</body>
+`;


### PR DESCRIPTION
## What does this do?
- Updates snackbar to use theme provider

## Screenshot / Video
### Left - prod | right - dev
https://github.com/user-attachments/assets/5521fe9d-9aca-4382-b4e8-72015efb04ae

## Relevant tickets / Documentation
N/A

## Testing
- unit tests added
- snapshot tests added