### PR TITLE
feat(text and colours): handle legacy colours

### DIFF
--- a/src/Text/Text.tsx
+++ b/src/Text/Text.tsx
@@ -3,17 +3,21 @@ import styled, { css } from 'styled-components'
 
 import { Box } from '../Box'
 import { linkStyleOverride } from '../Link/Link'
-import { Color, theme } from '../theme'
 import { MarginProps } from '../utils/space'
 import { fontStyleMapping } from './fontMapping'
-
+import {
+  ColorTypes,
+  NewColor,
+  getThemeColor,
+  legacyColorMap,
+} from '../ThemeProvider/utils/colourMap'
 interface IText {
   /** typography class name to apply predefined styles */
   $typo: string
   /** text-align  */
   $align: string
   /** color from the theme  */
-  $color: Color
+  $color: ColorTypes
   $cursor: string
 }
 
@@ -38,7 +42,7 @@ type Props = {
   className?: string
   typo?: Typo
   align?: string
-  color?: Color
+  color?: ColorTypes
   cursor?: string
   title?: string
 } & MarginProps
@@ -53,27 +57,33 @@ export const Text: FC<TextProps> = forwardRef<HTMLElement, TextProps>(
       className = '',
       tag = 'p',
       align = 'left',
-      color = 'liquorice',
+      color = 'color.text.base',
       cursor = 'inherit',
       title = '',
       ...props
     },
     ref,
-  ) => (
-    <Container
-      forwardedAs={tag}
-      className={className}
-      $typo={typo}
-      $align={align}
-      $color={color}
-      cursor={cursor}
-      title={title}
-      {...props}
-      ref={ref}
-    >
-      {children}
-    </Container>
-  ),
+  ) => {
+    const resolvedColor =
+      color in legacyColorMap
+        ? getThemeColor(legacyColorMap[color as keyof typeof legacyColorMap])
+        : getThemeColor(color as NewColor)
+    return (
+      <Container
+        forwardedAs={tag}
+        className={className}
+        $typo={typo}
+        $align={align}
+        $color={resolvedColor}
+        cursor={cursor}
+        title={title}
+        {...props}
+        ref={ref}
+      >
+        {children}
+      </Container>
+    )
+  },
 )
 
 Text.displayName = 'Text'
@@ -90,7 +100,7 @@ const Container = styled(Box)<IText>(
 
     text-align: ${$align};
     cursor: ${$cursor};
-    color: ${theme.colors[$color]};
-    ${linkStyleOverride({ color: theme.colors[$color] })}
+    color: ${$color};
+    ${linkStyleOverride({ color: $color })}
   `,
 )

--- a/src/Text/storybook/Text.stories.tsx
+++ b/src/Text/storybook/Text.stories.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { Box } from '../../Box'
 import { Text, Typo } from '../Text'
 import { fontStyleMapping } from '../fontMapping'
+import { formatDesignTokenColor } from '../../ThemeProvider/utils/colourMap'
 
 const Grid = styled(Box)`
   display: grid;
@@ -11,6 +12,8 @@ const Grid = styled(Box)`
   margin-bottom: 24px;
   gap: 10px;
 `
+
+const colourOptions = Array.from(new Set(formatDesignTokenColor().split(', ')))
 
 const TypoCollection = ({
   typos,
@@ -32,16 +35,16 @@ const TypoCollection = ({
       </Grid>
       {typos.map((typo) => (
         <Grid key={typo}>
-          <Text tag="p" typo="body-regular" color="sesame">
+          <Text tag="p" typo="body-regular" color="color.text.subtle">
             {typo}
           </Text>
-          <Text tag="p" typo="body-regular" color="liquorice">
+          <Text tag="p" typo="body-regular" color="color.text.base">
             They waited patiently for what seemed a very long time.
           </Text>
           {!['hero-alternate', 'hero', 'heading-alternate', 'label'].includes(
             typo,
           ) && (
-            <Text tag="p" typo="body-regular" color="liquorice">
+            <Text tag="p" typo="body-regular" color="color.text.base">
               They waited patiently for what seemed a very long time. They
               waited patiently for what seemed a very long time.
             </Text>
@@ -55,6 +58,12 @@ const TypoCollection = ({
 const meta: Meta<typeof Text> = {
   title: 'Text',
   component: Text,
+  argTypes: {
+    color: {
+      control: 'select',
+      options: colourOptions,
+    },
+  },
   decorators: [
     (Story) => (
       <div style={{ margin: '64px' }}>
@@ -83,7 +92,7 @@ export const Label: Story = {
   args: {
     tag: 'label',
     typo: 'label',
-    color: 'liquorice',
+    color: 'color.text.base',
   },
   render: (args) => (
     <Text {...args}>The quick brown fox jumps over the lazy dog</Text>

--- a/src/ThemeProvider/utils/colourMap.ts
+++ b/src/ThemeProvider/utils/colourMap.ts
@@ -1,4 +1,5 @@
 import * as designTokens from '@mrshmllw/smores-foundations/build/web/variables.json'
+import { Color } from 'theme'
 
 type Flatten<T, Prefix extends string = ''> = {
   [K in keyof T & string]: T[K] extends Record<string, any>
@@ -6,18 +7,106 @@ type Flatten<T, Prefix extends string = ''> = {
     : `${Prefix}${K}`
 }[keyof T & string]
 
-export type NewColor = Flatten<(typeof designTokens)['color']>
+export type NewColor = Flatten<
+  Pick<typeof designTokens, 'color' | 'extended1' | 'thirdParty'>
+>
+
+export type ColorTypes = Color | NewColor
 
 // TODO: Test how well this works
 // we currently access numerical colours like `theme.color.neutral[100]` or in the case of 000 colours, `theme.color.neutral['000']`
 export const getThemeColor = (path: NewColor): string => {
   return path
     .split('.')
-    .reduce((acc, key) => acc?.[key], designTokens.color as any) as string
+    .reduce((acc, key) => acc?.[key], designTokens as any) as string
 }
 
-export const legacyColorMap = {
-  marshmallowPink: 'interactive.primary.base', // old → new
+// a function that extracts the color objects from the design tokens
+const getColourObjectsFromDesignTokens = () => {
+  const { color, extended1, thirdParty } = designTokens
+  return { color, extended1, thirdParty }
+}
+
+// a function that returns a flattened dot notation string path to access the color value
+export const formatDesignTokenColor = (): string => {
+  const colors = getColourObjectsFromDesignTokens()
+
+  if (typeof colors !== 'object' || colors === null) {
+    return ''
+  }
+
+  const result: string[] = []
+  const destructureNestedObject = (obj: any, currentPath: string) => {
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        const value = obj[key]
+        const newPath = currentPath ? `${currentPath}.${key}` : key
+        if (typeof value === 'object' && value !== null) {
+          destructureNestedObject(value, newPath)
+        } else {
+          result.push(newPath)
+        }
+      }
+    }
+  }
+  destructureNestedObject(colors, '')
+  return result.join(', ')
+}
+
+// old colour name → new colour path // base token value
+export const legacyColorMap: Record<Color, NewColor> = {
+  fairyFloss: 'color.surface.brand.100', // palette.primary.040
+  bubblegum: 'color.surface.brand.200', // palette.primary.060
+  marshmallowPink: 'color.surface.brand.300', // palette.primary.100
+  lollipop: 'color.surface.brand.400', // palatte.primary.120
+
+  // Core Secondary
+  chia: 'color.feedback.inactive.100', // palette.secondary.040
+  sesame: 'color.text.subtle', // palette.secondary.060
+  liquorice: 'color.text.base', // palette.secondary.100
+  boba: 'color.text.contrast', // palette.secondary.120
+
+  // Core Tertiary
+  cream: `color.surface.base.000`, // palette.neutral.000
+  coconut: 'color.surface.base.100', // palette.neutral.010
+  mascarpone: 'color.surface.base.200', // palette.neutral.020
+  custard: 'color.surface.base.300', // palette.neutral.040
+
+  // Brand Secondary
+  feijoa: 'color.illustration.accent1.100', // palette.brand1.060
+  spearmint: 'color.illustration.accent1.200', // palette.brand1.100
+  macaroon: 'color.illustration.accent2.100', // palette.brand2.060
+  blueberry: 'color.illustration.accent2.200', // palette.brand2.100
+  pistachio: 'color.illustration.accent3.200', // palette.brand3.100
+  matcha: 'color.illustration.accent3.100', // palette.brand3.060
+  caramel: 'color.illustration.accent4.200', // palette.brand4.100
+  peanut: 'color.illustration.accent4.100', // palette.brand4.060
+  marzipan: 'color.illustration.neutral.400', // palette.neutral.100
+  oatmeal: 'color.illustration.neutral.300', // palette.neutral.060
+  satsuma: 'extended1.20', // extended1.020
+
+  // Traffic light
+  watermelon: 'color.feedback.negative.100', // palette.negative.020
+  strawberry: 'color.feedback.negative.200', // palette.negative.100
+  apple: 'color.feedback.positive.200', // palette.positive.100
+  mint: 'color.feedback.positive.100', // palette.positive.020
+  lemon: 'color.feedback.notice.200', // palette.notice.100
+  sherbert: 'color.feedback.notice.100', // palette.notice.020
+  tangerine: 'extended1.100', // extended1.100
+
+  // Third-party brand colours
+  compareTheMarket: 'thirdParty.compareTheMarket',
+  confused: 'thirdParty.confusedCom',
+  onfido: 'thirdParty.onfido',
+  x: 'thirdParty.twitter', // x rebrand not yet reflected in foundations
+  premfina: 'thirdParty.premfina',
+  checkout: 'thirdParty.checkout',
+  meta: 'thirdParty.facebook', // Meta rebrand not yet reflected in foundations
+  stripe: 'thirdParty.stripe',
+  intercom: 'thirdParty.intercom',
+  ravelin: 'thirdParty.ravelin',
+  rac: 'thirdParty.rac',
+  hometree: 'thirdParty.hometree',
 } as const
 
 /* usage example */


### PR DESCRIPTION
## What does this do?
<!-- 
- A short description of what the PR changes and why it's necessary
- Give the reviewers context
- Is the impact global or localised?
- Any tech debt created or discovered?
-->
- Updates the Text component to use new colour names
- Updates the Text Story to accept new colour names as dropdown options
- Adds legacyColorMap object
- Adds function to format design token colours into dot notation string

## Screenshot / Video
<!--
- applicable for UI changes, can be skipped if not relevant. You can drag and drop images/videos to upload them to GitHub.
- Example with image with fixed width 
  - <img src="https://github.com/marshmallow-insurance/uk-auto-signup-www/assets/57456071/3dbf1ec1-2363-4e20-8236-b1f1581b0953" width="300px" />
shortcuts:
 - Screenshot: cmd + shift + 4
 - Screen recording: cmd + shift + 5
-->

**(Left is Prod, Right is Local)**

https://github.com/user-attachments/assets/e32b2157-d071-4c94-ab19-c95848274f30

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/79da9c08-2d8c-4d9c-babf-c7ef03f776bb" />




## Relevant tickets / Documentation
<!--
- Link to any relevant issue tracking software (jira, GitHub etc), documentation (PRDs, engineering plans, Figma designs) or slack threads
- If applicable, list any new documentation that has been created/updated e.g. diagrams/flows etc
-->

N/A

## Testing
<!--
- Tests should have been updated/created to cover the changes made in this PR, if not please explain why
-->
TODO: update snapshot tests