### PR TITLE
feat(accordion): resolve border and background to theme colours [DES-42]

### DIFF
--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -6,16 +6,29 @@ import { Box } from '../Box'
 import { Icon } from '../Icon'
 import { Text } from '../Text'
 import { MarginProps } from '../utils/space'
-import { resolveToThemeColor } from '../ThemeProvider/utils/colourMap'
+import { NewColor, resolveToThemeColor } from '../ThemeProvider/utils/colourMap'
+
+type UsableNewColors = Extract<
+  NewColor,
+  | 'color.surface.base.000'
+  | 'color.surface.base.100'
+  | 'color.surface.base.300'
+  | 'color.illustration.neutral.300'
+>
 
 export type AccordionProps = {
   title: string
   subTitle?: string
   filledBackground?: boolean
   borderTop?: boolean
-  borderColor?: 'oatmeal' | 'custard' | 'cream' | 'coconut'
+  borderColor?: 'oatmeal' | 'custard' | 'cream' | 'coconut' | UsableNewColors
   fullBorder?: boolean
-  backgroundColor?: 'oatmeal' | 'custard' | 'cream' | 'coconut'
+  backgroundColor?:
+    | 'oatmeal'
+    | 'custard'
+    | 'cream'
+    | 'coconut'
+    | UsableNewColors
   onToggle?: (isOpen: boolean) => void
   children: ReactNode
   defaultIsOpen?: boolean
@@ -28,8 +41,8 @@ export const Accordion: FC<AccordionProps> = ({
   filledBackground,
   defaultIsOpen = false,
   borderTop = false,
-  borderColor = 'oatmeal',
-  backgroundColor = 'custard',
+  borderColor = 'color.illustration.neutral.300',
+  backgroundColor = 'color.surface.base.300',
   subTitle,
   fullBorder = false,
   ...marginProps

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -5,8 +5,8 @@ import { TransientProps } from 'utils/utilTypes'
 import { Box } from '../Box'
 import { Icon } from '../Icon'
 import { Text } from '../Text'
-import { theme } from '../theme'
 import { MarginProps } from '../utils/space'
+import { resolveToThemeColor } from '../ThemeProvider/utils/colourMap'
 
 export type AccordionProps = {
   title: string
@@ -37,6 +37,10 @@ export const Accordion: FC<AccordionProps> = ({
   const [isOpen, setIsOpen] = useState(defaultIsOpen)
   const px = fullBorder ? '16px' : '0'
 
+  const resolvedBorderColor = resolveToThemeColor(borderColor)
+
+  const resolvedBackgroundColour = resolveToThemeColor(backgroundColor)
+
   const handleToggle = () => {
     const nextOpenState = !isOpen
     onToggle?.(nextOpenState)
@@ -48,8 +52,8 @@ export const Accordion: FC<AccordionProps> = ({
       $borderTop={borderTop}
       $fullBorder={fullBorder}
       $filledBackground={filledBackground}
-      $borderColor={borderColor}
-      $backgroundColor={backgroundColor}
+      $borderColor={resolvedBorderColor}
+      $backgroundColor={resolvedBackgroundColour}
       {...marginProps}
     >
       <TopContainer
@@ -91,15 +95,8 @@ export const Accordion: FC<AccordionProps> = ({
 
 const Wrapper = styled(Box)<
   TransientProps<
-    Pick<
-      AccordionProps,
-      | 'borderTop'
-      | 'fullBorder'
-      | 'filledBackground'
-      | 'borderColor'
-      | 'backgroundColor'
-    >
-  >
+    Pick<AccordionProps, 'borderTop' | 'fullBorder' | 'filledBackground'>
+  > & { $borderColor: string; $backgroundColor: string }
 >(
   ({
     $borderTop,
@@ -108,18 +105,18 @@ const Wrapper = styled(Box)<
     $borderColor = 'oatmeal',
     $backgroundColor = 'custard',
   }) => css`
-    border-bottom: 1px solid ${theme.colors[$borderColor]};
-    ${$borderTop && `border-top: 1px solid ${theme.colors[$borderColor]};`}
+    border-bottom: 1px solid ${$borderColor};
+    ${$borderTop && `border-top: 1px solid ${$backgroundColor};`}
 
     ${$fullBorder &&
     css`
-      border: 1px solid ${theme.colors[$borderColor]};
+      border: 1px solid ${$borderColor};
       border-radius: 16px;
     `}
 
     ${$filledBackground &&
     css`
-      background-color: ${theme.colors[$backgroundColor]};
+      background-color: ${$backgroundColor};
     `}
   `,
 )

--- a/src/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Accordion > renders correctly for fullBorder and filledBackground variant 1`] = `
 <div>
   <div
-    class="sc-bRKDuR bHjpxP sc-jwTyAe jaJEhk"
+    class="sc-bRKDuR bHjpxP sc-jwTyAe emHXsE"
   >
     <div
       class="sc-bRKDuR gwwejK sc-jJLAfE iWiHKP"
@@ -52,7 +52,7 @@ exports[`Accordion > renders correctly for fullBorder and filledBackground varia
 exports[`Accordion > renders correctly when closed 1`] = `
 <div>
   <div
-    class="sc-bRKDuR bHjpxP sc-jwTyAe LOspj"
+    class="sc-bRKDuR bHjpxP sc-jwTyAe dRsXQD"
   >
     <div
       class="sc-bRKDuR jGGaUV sc-jJLAfE iWiHKP"
@@ -96,7 +96,7 @@ exports[`Accordion > renders correctly when closed 1`] = `
 exports[`Accordion > renders correctly when expanded 1`] = `
 <div>
   <div
-    class="sc-bRKDuR bHjpxP sc-jwTyAe LOspj"
+    class="sc-bRKDuR bHjpxP sc-jwTyAe dRsXQD"
   >
     <div
       class="sc-bRKDuR jGGaUV sc-jJLAfE iWiHKP"

--- a/src/Accordion/storybook/Accordion.stories.tsx
+++ b/src/Accordion/storybook/Accordion.stories.tsx
@@ -3,12 +3,29 @@ import React from 'react'
 import { Box } from '../../Box'
 import { Accordion } from '../Accordion'
 
+const colourOptions = [
+  'color.surface.base.000',
+  'color.surface.base.100',
+  'color.surface.base.300',
+  'color.illustration.neutral.300',
+]
+
 const meta: Meta<typeof Accordion> = {
   title: 'Accordion',
   component: Accordion,
   args: {
     title: 'How it works',
     children: 'Lots of brilliant information about this beautiful component',
+  },
+  argTypes: {
+    backgroundColor: {
+      control: 'select',
+      options: colourOptions,
+    },
+    borderColor: {
+      control: 'select',
+      options: colourOptions,
+    },
   },
 }
 

--- a/src/ThemeProvider/utils/colourMap.ts
+++ b/src/ThemeProvider/utils/colourMap.ts
@@ -18,9 +18,7 @@ export type NewColor = Prettify<
 export type ColorTypes = Color | NewColor
 
 export const getThemeColor = (path: NewColor): string => {
-  return path
-    .split('.')
-    .reduce((acc, key) => acc?.[key], designTokens as any) as string
+  return path.split('.').reduce((acc, key) => acc?.[key], designTokens as any)
 }
 
 export const resolveToThemeColor = (color: NewColor | Color): string => {

--- a/src/ThemeProvider/utils/colourMap.ts
+++ b/src/ThemeProvider/utils/colourMap.ts
@@ -17,11 +17,16 @@ export type NewColor = Prettify<
 
 export type ColorTypes = Color | NewColor
 
-// we currently access numerical colours like `theme.color.neutral[100]` or in the case of 000 colours, `theme.color.neutral['000']`
 export const getThemeColor = (path: NewColor): string => {
   return path
     .split('.')
     .reduce((acc, key) => acc?.[key], designTokens as any) as string
+}
+
+export const resolveToThemeColor = (color: NewColor | Color): string => {
+  return color in legacyColorMap
+    ? getThemeColor(legacyColorMap[color as keyof typeof legacyColorMap])
+    : getThemeColor(color as NewColor)
 }
 
 // a function that returns a flattened dot notation string path to access the color value


### PR DESCRIPTION
## What does this do?
- Updates the `Accordion` component to resolve the border & background colours to the theme colours provided.
- Adds and uses a `resolveToThemeColor` to help resolve colours easier

> [!NOTE]
> The Accordion component will be deprecated and replace/updated with a new variant soon so I have chosen to still use the old colour values but resolve to the correct theme color.    

## Screenshot / Video
### Left - Prod | right - dev

https://github.com/user-attachments/assets/a495f195-f020-4345-9f12-2d7e43c77ccf


## Relevant tickets / Documentation
N/A

## Testing
- Snapshot tests updated