### PR TITLE
chore(npm-dep): bump @mrshmllw/campfire to 6.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       },
       "devDependencies": {
         "@commitlint/cli": "^20.5.3",
-        "@mrshmllw/campfire": "^6.1.2",
+        "@mrshmllw/campfire": "^6.1.3",
         "@snyk/protect": "^1.1306.0",
         "@storybook/addon-a11y": "^10.5.0",
         "@storybook/addon-coverage": "^3.0.2",
@@ -3530,9 +3530,9 @@
       }
     },
     "node_modules/@mrshmllw/campfire": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@mrshmllw/campfire/-/campfire-6.1.2.tgz",
-      "integrity": "sha512-+B0G4pId31yLVeKvs9XyEPAlIcvTNI3l0eff/HLaInPWTZZDin7RnSZH1atVRBwxIXfm8nMHL2D8and02mMzoQ==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@mrshmllw/campfire/-/campfire-6.1.3.tgz",
+      "integrity": "sha512-188h9vFfVRLl7tC6+D+HAJ+6Go4vK7l0ewx4UjNElJvfV3aZlWf1yxLtHf1t/+WHhuZztOo12jMniG22nipsVA==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^20.5.3",
-    "@mrshmllw/campfire": "^6.1.2",
+    "@mrshmllw/campfire": "^6.1.3",
     "@snyk/protect": "^1.1306.0",
     "@storybook/addon-a11y": "^10.5.0",
     "@storybook/addon-coverage": "^3.0.2",


### PR DESCRIPTION
## What does this do?

Bumps `@mrshmllw/campfire` `6.1.2 → 6.1.3`, which carries the fix to the shared semantic-release pipeline.

The `Bump and Publish` job has failed on **every** `main` merge since ~2026-05-08 (`Cannot find module '@semantic-release/changelog'` — the shared workflow ran `npx semantic-release` without its non-bundled plugins). As a result smores' last published `latest` is stuck at **16.0.3**, so recently-merged work — the `sideEffects: false` tree-shaking fix (#5070) and the code-shiki migration (#5072) — hasn't reached consumers.

**Impact:** global — unblocks NPM publishing. Once this merges, the release job should succeed and cut the first new version since May.

## Testing

- [x] `npm install` resolves `@mrshmllw/campfire@6.1.3`; diff is limited to `package.json` + `package-lock.json`
- [ ] Confirm the post-merge `Bump and Publish` job goes green and a new version is published to NPM (the real end-to-end signal)