### PR TITLE
fix(SearchInput): reset results scroll position when search query changes

### DIFF
--- a/src/SearchInput/SearchInput.test.tsx
+++ b/src/SearchInput/SearchInput.test.tsx
@@ -1,0 +1,63 @@
+import { beforeEach, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '../testUtils'
+import { noop } from '../utils/noop'
+import { SearchInput } from './SearchInput'
+
+const searchList = Array.from({ length: 30 }, (_, i) => ({
+  label: `Option ${i}`,
+  value: `option-${i}`,
+}))
+
+let scrollIntoViewMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  scrollIntoViewMock = vi.fn()
+  Element.prototype.scrollIntoView =
+    scrollIntoViewMock as unknown as Element['scrollIntoView']
+})
+
+const openResults = (container: HTMLElement) => {
+  const input = container.querySelector('input')!
+  fireEvent.click(input)
+  return input
+}
+
+describe('SearchInput', () => {
+  it('resets the results list scroll position to the top when the search query changes', () => {
+    const { container } = render(
+      <SearchInput searchList={searchList} onFound={noop} />,
+    )
+    const input = openResults(container)
+
+    const resultsList = container.querySelector('ul')!
+    resultsList.scrollTop = 150
+
+    fireEvent.change(input, { target: { value: 'Option 2' } })
+
+    expect(container.querySelector('ul')?.scrollTop).toBe(0)
+  })
+
+  it('still scrolls the highlighted item into view on arrow key navigation', () => {
+    const { container } = render(
+      <SearchInput searchList={searchList} onFound={noop} />,
+    )
+    const input = openResults(container)
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+
+    expect(scrollIntoViewMock).toHaveBeenCalled()
+  })
+
+  it('still closes the results list and selects the option when an item is clicked', () => {
+    const onFound = vi.fn()
+    const { container } = render(
+      <SearchInput searchList={searchList} onFound={onFound} />,
+    )
+    openResults(container)
+
+    fireEvent.click(screen.getByText('Option 0'))
+
+    expect(onFound).toHaveBeenCalledWith('option-0')
+    expect(container.querySelector('ul')).not.toBeInTheDocument()
+  })
+})

--- a/src/SearchInput/components/SearchOptions.tsx
+++ b/src/SearchInput/components/SearchOptions.tsx
@@ -38,6 +38,7 @@ export const SearchOptions: FC<SearchOptionsProps> = ({
   notFoundComponent,
 }) => {
   const itemRefs = useRef<RefObject<HTMLLIElement | null>[]>([])
+  const resultsListRef = useRef<HTMLUListElement>(null)
 
   useEffect(() => {
     itemRefs.current = displayedList.map(
@@ -55,10 +56,21 @@ export const SearchOptions: FC<SearchOptionsProps> = ({
     }
   }, [highlightedIndex])
 
+  useEffect(() => {
+    if (resultsListRef.current) {
+      resultsListRef.current.scrollTop = 0
+    }
+    setHighlightedIndex(-1)
+  }, [searchTerm, setHighlightedIndex])
+
   return (
     <BoxWithPositionRelative>
       <StyledResultsContainer $positionRelative={positionRelative}>
-        <ResultsList $resultsBorder={resultsBorder} onKeyDown={onKeyDown}>
+        <ResultsList
+          ref={resultsListRef}
+          $resultsBorder={resultsBorder}
+          onKeyDown={onKeyDown}
+        >
           {displayedList.length ? (
             displayedList.map((el, i) => {
               const isSelected =


### PR DESCRIPTION
## Summary
- `SearchOptions` (used by `SearchInput`'s searchable dropdowns) kept its previous scroll offset when a new search query produced a different filtered list, so the highest-relevance matches could be hidden below the fold until the user manually scrolled back up.
- Adds a `useEffect` keyed on the search query that resets the results list `scrollTop` to `0` and `highlightedIndex` to `-1` whenever the query changes, without touching the existing keyboard-navigation `scrollIntoView` behavior.

## Test plan
- [x] New test: typing a query while scrolled down resets scroll to top
- [x] Existing behavior verified: arrow-key navigation still scrolls the highlighted item into view
- [x] Existing behavior verified: selecting an option still closes the list and resets state
- [x] Full suite (`npm test`), `check-types`, and `eslint` pass with no regressions