### PR TITLE
chore(deps): group more related dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,20 +41,21 @@ updates:
         patterns:
           - "@typescript-eslint*"
           - "@typescript-eslint/*"
+          - "typescript-eslint"
         update-types:
           - "minor"
           - "patch"
-      storybook-dependencies:
+      eslint:
         patterns:
-          - "storybook*"
-          - "@storybook/*"
-        update-types:
-          - "minor"
-          - "patch"
-      semantic-release-dependencies:
+          - "eslint"
+          - "eslint-plugin-*"
+          - "eslint-config-*"
+        exclude-patterns:
+          - "eslint-plugin-storybook"
+      testing-library:
         patterns:
-          - "@semantic-release*"
-          - "@semantic-release/*"
-        update-types:
-          - "minor"
-          - "patch"
+          - "@testing-library/*"
+      vite:
+        patterns:
+          - "vite"
+          - "vitest"


### PR DESCRIPTION
closes RET-2281

## Context

Several coupled packages were bumping in separate dependabot PRs instead of one, and the `ts-eslint` group's patterns missed the bare `typescript-eslint` package entirely — visible right now as two open branches, `ts-eslint-*` and `typescript-eslint-*`, for what should be one bump.

## Changes

- `ts-eslint` group: add `typescript-eslint` pattern (previously only matched `@typescript-eslint/*`)
- New `eslint` group: `eslint`, `eslint-plugin-*`, `eslint-config-*` (excludes `eslint-plugin-storybook`, already in the `storybook` group)
- New `testing-library` group: `@testing-library/*`
- New `vite` group: `vite`, `vitest`
- Removed `storybook-dependencies` (fully shadowed by the existing `storybook` group) and `semantic-release-dependencies` (matches no manifest package — semantic-release only runs via `npx` in workflows)