### PR TITLE
ci: speed up pull request workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -52,3 +52,17 @@ jobs:
           npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
             "npx http-server storybook-static --port 6006 --silent" \
             "npx wait-on tcp:6006 && npm run test-storybook:ci"
+
+  # Branch protection requires a status check named "pull-request" (the old single-job
+  # name). This aggregates the split jobs back into that name so protection still works.
+  pull-request:
+    needs: [check-types, test, storybook-test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all jobs succeeded
+        run: |
+          if [[ "${{ needs.check-types.result }}" != "success" || "${{ needs.test.result }}" != "success" || "${{ needs.storybook-test.result }}" != "success" ]]; then
+            echo "One or more required jobs failed"
+            exit 1
+          fi

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,8 +2,12 @@ name: Pull Request
 on:
   pull_request:
 
+concurrency:
+  group: pull-request-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
-  pull-request:
+  check-types:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -15,13 +19,34 @@ jobs:
           FONT_AWESOME_AUTH_TOKEN: ${{ secrets.FONT_AWESOME_AUTH_TOKEN }}
       - name: Run Check Types
         run: npm run check-types
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: marshmallow-insurance/campfire/.github/actions/setup-node-project@main
+        env:
+          FONT_AWESOME_AUTH_TOKEN: ${{ secrets.FONT_AWESOME_AUTH_TOKEN }}
       - name: Run Tests
         run: npm run test
+
+  storybook-test:
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/playwright:v1.61.1-jammy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: marshmallow-insurance/campfire/.github/actions/setup-node-project@main
+        env:
+          FONT_AWESOME_AUTH_TOKEN: ${{ secrets.FONT_AWESOME_AUTH_TOKEN }}
       - name: Run Build Storybook
         run: |
           npm run build-storybook --quiet
-      - name: Install Playwright
-        run: npx playwright install --with-deps
       - name: Serve Storybook and test
         run: |
           npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \


### PR DESCRIPTION
## What does this do?

The PR workflow ran everything as one sequential job with no cancellation for superseded runs, and reinstalled Playwright browsers from scratch on every run. This splits it into three parallel jobs (`check-types`, `test`, `storybook-test`), adds a `concurrency` group so pushing a new commit cancels the in-flight run for that PR, and runs `storybook-test` in the official Playwright container image (`mcr.microsoft.com/playwright:v1.61.1-jammy`, matching the pinned `playwright` version in `package-lock.json`) so browsers are already present and the install step is removed entirely.

Impact is CI-only, no runtime code touched. Filed [RET-2280](https://linear.app/marshmallow/issue/RET-2280/smores-react-ci-speedup-follow-up-for-pull-requestyml) to track further follow-up ideas (node_modules caching, Storybook build cache) not done in this pass.

## Relevant tickets / Documentation

Related: [RET-2280](https://linear.app/marshmallow/issue/RET-2280/smores-react-ci-speedup-follow-up-for-pull-requestyml)

## Testing

No test suite for CI config. Validated the YAML parses correctly and cross-checked the container tag against the exact `playwright` version resolved in `package-lock.json`.