### PR TITLE
feat(Modal): sticky header/footer, accessibility & scroll-lock fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 logs
 *.log
 npm-debug.log*
+
+.superpowers/

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from '@storybook/react-vite'
 
 const config: StorybookConfig = {
-  stories: ['../src/**/*.stories.tsx'],
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.tsx'],
 
   addons: [
     '@storybook/addon-a11y',

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -16,6 +16,14 @@ const config: StorybookConfig = {
     name: '@storybook/react-vite',
     options: {},
   },
+
+  typescript: {
+    // The default 'react-docgen' (babel-based) parser can't resolve
+    // union/generic prop types like Modal's `title?: string | TitleProps`,
+    // silently producing an empty props table. react-docgen-typescript
+    // uses the real TS compiler and handles this correctly.
+    reactDocgen: 'react-docgen-typescript',
+  },
 }
 
 export default config

--- a/docs/superpowers/plans/2026-08-10-modal-sticky-header-footer.md
+++ b/docs/superpowers/plans/2026-08-10-modal-sticky-header-footer.md
@@ -1,0 +1,997 @@
+# Modal Sticky Header/Footer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add opt-in `stickyHeader`/`stickyFooter`/`footer` props to `Modal`, and bring its Storybook documentation up to parity with (and beyond) the Figma design guideline page.
+
+**Architecture:** `Modal`'s `Container` (`src/Modal/Modal.tsx`) currently owns all padding and wraps both the header row and `children` in one `overflow: auto` box. We move that padding onto new `Header`/`ContentArea`/`Footer` styled children so `position: sticky` can be applied directly to `Header`/`Footer` without introducing a nested scroll container. `footer` is a new, fully optional `ReactNode` slot. Documentation moves from pure Storybook autodocs to a hand-authored MDX page with live, embedded Story examples.
+
+**Tech Stack:** React, styled-components, Storybook 10 (`@storybook/addon-docs/blocks` for the MDX page), Vitest + Testing Library + jest-styled-components (snapshot tests).
+
+**Before you start:** This workspace's `node_modules` is not installed. Run `npm install` once before Task 1.
+
+**Reference:** Design spec at `docs/superpowers/specs/2026-08-10-modal-sticky-header-footer-design.md`.
+
+---
+
+### Task 1: Restructure `Container` padding + add `stickyHeader`
+
+**Goal:** Move `Container`'s padding onto new `Header`/`ContentArea` children (no visual change), then make the header row stickable via a new `stickyHeader` prop (default `false`, fully opt-in).
+
+**Files:**
+- Modify: `src/Modal/Modal.tsx`
+- Modify: `src/Modal/Modal.test.tsx`
+- Modify (regenerated): `src/Modal/__snapshots__/Modal.test.tsx.snap`
+
+**Acceptance Criteria:**
+- [ ] `Modal` renders identically (visually) with default props — only the snapshot's DOM structure changes (extra wrapper), not the computed padding/spacing.
+- [ ] `stickyHeader` defaults to `false`; passing `true` applies `position: sticky; top: 0` to the header row.
+- [ ] All existing and new tests pass.
+
+**Verify:** `npx vitest run src/Modal/Modal.test.tsx` → all tests pass (after snapshots are regenerated in Step 4).
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing test for `stickyHeader`**
+
+Add this test inside the existing `describe('Modal', ...)` block in `src/Modal/Modal.test.tsx`, right after the `'renders correctly with default props'` test:
+
+```tsx
+  it('renders correctly with sticky header', () => {
+    const { baseElement } = render(
+      <Modal
+        showModal={true}
+        handleClick={noop}
+        width={'600px'}
+        title={'Modal Title'}
+        stickyHeader
+      >
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+
+    expect(baseElement).toMatchSnapshot()
+  })
+```
+
+- [ ] **Step 2: Run the test to confirm it currently fails**
+
+Run: `npx vitest run src/Modal/Modal.test.tsx`
+Expected: FAIL — `Property 'stickyHeader' does not exist on type 'IntrinsicAttributes & ModalProps'` (TypeScript) or the test runs but produces a snapshot with no sticky styling (since the prop is silently ignored by React on an unknown prop passed to a function component — either way, this confirms the prop doesn't do anything yet).
+
+- [ ] **Step 3: Rewrite `src/Modal/Modal.tsx`**
+
+Replace the entire file with:
+
+```tsx
+import { FC, ReactNode, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import styled, { css, useTheme } from 'styled-components'
+
+import { Box } from '../Box'
+import { Text, type TextProps } from '../Text'
+import { useBodyScrollLock } from '../hooks/useBodyScrollLock'
+import { IconContainer } from '../sharedStyles/shared.styles'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faXmark } from '@awesome.me/kit-46ca99185c/icons/classic/regular'
+
+interface IModalContainer {
+  // drawer state
+  $drawer: boolean
+  // modal width
+  $width: string
+}
+
+export type ModalProps = {
+  /**
+   * Title of the modal
+   * @default "" (empty string)
+   *
+   * @example
+   * ```tsx
+   * <Modal title="MultiCar Account" />
+   * ```
+   *
+   * @example
+   * ```tsx
+   * <Modal title={{ typo: 'hero', children: 'MultiCar Account' }} />
+   * ```
+   */
+  title?: string | TitleProps
+  icon?: string
+  children?: ReactNode
+  rightPanel?: ReactNode
+  showModal?: boolean
+  handleClick: () => void
+  drawer?: boolean
+  cross?: boolean
+  width?: string
+  containerClass?: string
+  portalContainer?: Element | DocumentFragment
+  closeOnOverlayClick?: boolean
+  /**
+   * Pins the title/close row so it stays visible while the content
+   * scrolls. Recommended whenever content might overflow, especially on
+   * mobile where there's little room to tap outside the modal to dismiss
+   * it.
+   * @default false
+   */
+  stickyHeader?: boolean
+}
+
+export type TitleProps = TextProps
+
+const getDefaultTitleProps = (title: string): TitleProps => ({
+  children: title,
+  tag: 'h2',
+  typo: 'heading-small',
+  align: 'left',
+})
+
+export const Modal: FC<ModalProps> = ({
+  title = '',
+  children,
+  rightPanel,
+  showModal = false,
+  handleClick,
+  drawer = true,
+  cross = true,
+  width,
+  containerClass,
+  portalContainer = document.body,
+  closeOnOverlayClick = true,
+  stickyHeader = false,
+}) => {
+  const modalRef = useRef<HTMLDivElement>(null)
+  const theme = useTheme()
+
+  useBodyScrollLock({ node: modalRef.current, showModal })
+
+  const isTitleString = typeof title === 'string'
+  const titleProps = isTitleString ? getDefaultTitleProps(title) : title
+
+  if (!showModal) return null
+
+  return createPortal(
+    <Wrapper ref={modalRef}>
+      <Overlay
+        onClick={() => closeOnOverlayClick && handleClick()}
+        $closeOnOverlayClick={closeOnOverlayClick}
+      />
+      <Container
+        $drawer={drawer}
+        $width={width || '460px'}
+        className={containerClass}
+      >
+        <Header
+          flex
+          alignItems="flex-start"
+          justifyContent="space-between"
+          $sticky={stickyHeader}
+          $drawer={drawer}
+        >
+          <TitleElements flex direction="column">
+            <Text {...titleProps} />
+          </TitleElements>
+          <Box flex alignItems="center" gap={'space.100'}>
+            {rightPanel}
+            {cross && (
+              <IconContainer
+                as="button"
+                onClick={handleClick}
+                role="button"
+                title="Close modal"
+                $size={32}
+                style={{
+                  background: theme.color.illustration.neutral[300],
+                  borderRadius: '100%',
+                  padding: '6px',
+                  border: 'none',
+                  cursor: 'pointer',
+                }}
+              >
+                <FontAwesomeIcon icon={faXmark} color={theme.color.icon.base} />
+              </IconContainer>
+            )}
+          </Box>
+        </Header>
+        <ContentArea flex direction="column" $drawer={drawer}>
+          {children}
+        </ContentArea>
+      </Container>
+    </Wrapper>,
+    portalContainer,
+  )
+}
+
+const Wrapper = styled(Box)`
+  display: flex;
+  position: absolute;
+  z-index: 999;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+`
+
+const Overlay = styled.div<{ $closeOnOverlayClick: boolean }>`
+  position: fixed;
+  background: ${({ theme }) => theme.color.surface.base[900]};
+  cursor: ${(props) => (props.$closeOnOverlayClick ? 'pointer' : 'default')};
+  opacity: 0.4;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+`
+
+const Container = styled.div<IModalContainer>(
+  ({ $drawer, $width }) => css`
+    background: ${({ theme }) => theme.color.background[100]};
+    box-sizing: border-box;
+    border-radius: 16px;
+    width: 100%;
+    max-width: ${$width};
+    position: fixed;
+    max-height: calc(100vh - 64px);
+    overflow: auto;
+    transition: all 0.3s ease-in-out;
+
+    ${$drawer === true &&
+    css`
+      @media (max-width: 768px) {
+        max-width: none;
+        border-radius: 16px 16px 0px 0px;
+        max-height: 90vh;
+
+        position: fixed;
+        right: 0;
+        left: 0;
+        bottom: 0;
+      }
+    `}
+  `,
+)
+
+const Header = styled(Box)<{ $sticky: boolean; $drawer: boolean }>(
+  ({ $sticky, $drawer, theme }) => css`
+    padding: ${theme.space[300]} ${theme.space[300]} ${theme.space[100]};
+    background: ${theme.color.background[100]};
+
+    ${$sticky &&
+    css`
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    `}
+
+    ${$drawer &&
+    css`
+      @media (max-width: 768px) {
+        padding: 10% ${theme.space[300]} ${theme.space[100]};
+      }
+    `}
+  `,
+)
+
+const ContentArea = styled(Box)<{ $drawer: boolean }>(
+  ({ $drawer, theme }) => css`
+    padding: 0 ${theme.space[300]} ${theme.space[300]};
+
+    ${$drawer &&
+    css`
+      @media (max-width: 768px) {
+        padding: 0 ${theme.space[300]} 10%;
+      }
+    `}
+  `,
+)
+
+const TitleElements = styled(Box)`
+  align-self: center;
+`
+```
+
+Note on the `10%` values: CSS resolves percentage `padding-top`/`padding-bottom` against the containing block's **width**, not height (this is a common misconception — see CSS2.1 §8.4). Since `Header` and `ContentArea` share the same containing block (`Container`) as the original single padded box did, splitting the `10% 24px` rule across them produces byte-for-byte the same computed padding as before.
+
+- [ ] **Step 4: Regenerate snapshots and confirm the diff is purely structural**
+
+Run: `npx vitest run src/Modal/Modal.test.tsx -u`
+Expected: Both tests pass and update `src/Modal/__snapshots__/Modal.test.tsx.snap`.
+
+Open the diff (`git diff src/Modal/__snapshots__/Modal.test.tsx.snap`) and confirm:
+- The `'renders correctly with default props'` snapshot shows the header/content now sit in separate padded boxes instead of one, but no `position`, `padding`, or `margin` computed value on the rendered elements actually changes in visual effect (padding is now split between two adjacent boxes instead of living on their shared parent).
+- The new `'renders correctly with sticky header'` snapshot shows `position: sticky; top: 0;` on the header element.
+
+- [ ] **Step 5: Run the full test file to confirm everything passes**
+
+Run: `npx vitest run src/Modal/Modal.test.tsx`
+Expected: PASS (2 tests)
+
+- [ ] **Step 6: Type-check and lint**
+
+Run: `npm run check-types && npm run lint`
+Expected: Both exit 0 with no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Modal/Modal.tsx src/Modal/Modal.test.tsx src/Modal/__snapshots__/Modal.test.tsx.snap
+git commit -m "feat(Modal): add stickyHeader prop"
+```
+
+---
+
+### Task 2: Add `footer` + `stickyFooter`
+
+**Goal:** Add an optional `footer` slot rendered below the scrollable content, with an opt-in `stickyFooter` prop and a default flex layout matching the Figma reference (1 child fills the row, 2 children split it 50/50).
+
+**Files:**
+- Modify: `src/Modal/Modal.tsx`
+- Modify: `src/Modal/Modal.test.tsx`
+- Modify (regenerated): `src/Modal/__snapshots__/Modal.test.tsx.snap`
+
+**Acceptance Criteria:**
+- [ ] Omitting `footer` renders nothing extra — no empty footer element in the DOM.
+- [ ] `footer` renders in a flex row with a `theme.space[100]` gap, each direct child at `flex: 1`, and a `1px solid theme.color.border.subtle` top border.
+- [ ] `stickyFooter` defaults to `false`; passing `true` (with `footer` present) applies `position: sticky; bottom: 0`.
+- [ ] All existing and new tests pass.
+
+**Verify:** `npx vitest run src/Modal/Modal.test.tsx` → all tests pass (after snapshots are regenerated in Step 4).
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these two tests to `src/Modal/Modal.test.tsx`, after the `'renders correctly with sticky header'` test, and add `import { Button } from '../Button'` to the top of the file (alongside the other imports):
+
+```tsx
+  it('renders correctly with a footer', () => {
+    const { baseElement } = render(
+      <Modal
+        showModal={true}
+        handleClick={noop}
+        width={'600px'}
+        title={'Modal Title'}
+        footer={
+          <>
+            <Button secondary handleClick={noop}>
+              Find out more
+            </Button>
+            <Button primary handleClick={noop}>
+              Got it
+            </Button>
+          </>
+        }
+      >
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+
+    expect(baseElement).toMatchSnapshot()
+  })
+
+  it('renders correctly with a sticky footer', () => {
+    const { baseElement } = render(
+      <Modal
+        showModal={true}
+        handleClick={noop}
+        width={'600px'}
+        title={'Modal Title'}
+        footer={
+          <Button primary handleClick={noop}>
+            Got it
+          </Button>
+        }
+        stickyFooter
+      >
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+
+    expect(baseElement).toMatchSnapshot()
+  })
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+Run: `npx vitest run src/Modal/Modal.test.tsx`
+Expected: FAIL — TypeScript errors on `footer`/`stickyFooter` not existing on `ModalProps`.
+
+- [ ] **Step 3: Add `footer`/`stickyFooter` to `src/Modal/Modal.tsx`**
+
+In `ModalProps`, add these two fields after `stickyHeader?: boolean`:
+
+```tsx
+  /**
+   * Optional footer content rendered below the scrollable body, outside
+   * `children` — e.g. one or two action buttons. When there are 1–2
+   * direct children, they're laid out as equal-width flex items with a
+   * gap. The confirming/primary action should be the last child, closest
+   * to the trailing edge.
+   * @default undefined (no footer rendered)
+   */
+  footer?: ReactNode
+  /**
+   * Pins `footer` so it stays visible while the content scrolls. Has no
+   * effect if `footer` isn't passed.
+   * @default false
+   */
+  stickyFooter?: boolean
+```
+
+In the `Modal` component's destructured props, add `footer` and `stickyFooter = false` after `stickyHeader = false,`:
+
+```tsx
+  stickyHeader = false,
+  footer,
+  stickyFooter = false,
+}) => {
+```
+
+In the JSX, add the footer render right after the closing `</ContentArea>` tag (still inside `<Container>`):
+
+```tsx
+        </ContentArea>
+        {footer && <Footer $sticky={stickyFooter}>{footer}</Footer>}
+      </Container>
+```
+
+Add the `Footer` styled component after `ContentArea`'s definition:
+
+```tsx
+const Footer = styled.div<{ $sticky: boolean }>(
+  ({ $sticky, theme }) => css`
+    display: flex;
+    gap: ${theme.space[100]};
+    padding: ${theme.space[200]} ${theme.space[300]} ${theme.space[300]};
+    background: ${theme.color.background[100]};
+    border-top: 1px solid ${theme.color.border.subtle};
+
+    & > * {
+      flex: 1;
+    }
+
+    ${$sticky &&
+    css`
+      position: sticky;
+      bottom: 0;
+      z-index: 1;
+    `}
+  `,
+)
+```
+
+- [ ] **Step 4: Regenerate snapshots and confirm the diff**
+
+Run: `npx vitest run src/Modal/Modal.test.tsx -u`
+Expected: All 4 tests pass. New snapshots for `'renders correctly with a footer'` and `'renders correctly with a sticky footer'` appear; the two existing snapshots are unchanged (footer is additive — no footer means no `Footer` element renders at all).
+
+- [ ] **Step 5: Run the full test file to confirm everything passes**
+
+Run: `npx vitest run src/Modal/Modal.test.tsx`
+Expected: PASS (4 tests)
+
+- [ ] **Step 6: Type-check and lint**
+
+Run: `npm run check-types && npm run lint`
+Expected: Both exit 0 with no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Modal/Modal.tsx src/Modal/Modal.test.tsx src/Modal/__snapshots__/Modal.test.tsx.snap
+git commit -m "feat(Modal): add footer and stickyFooter props"
+```
+
+---
+
+### Task 3: Add Storybook story variants
+
+**Goal:** Add Story exports covering every documented variant (basic vs. custom content, single/two-button footer, sticky combinations, mobile drawer) so Task 4's MDX page has live examples to embed.
+
+**Files:**
+- Modify: `src/Modal/storybook/Modal.stories.tsx`
+
+**Acceptance Criteria:**
+- [ ] `Default` and `Interactive` stories are unchanged in behavior.
+- [ ] 8 new named story exports exist: `BasicContentModal`, `CustomContentModal`, `SingleButtonFooter`, `TwoButtonFooter`, `StickyHeader`, `StickyFooter`, `StickyHeaderAndFooter`, `MobileDrawer`.
+- [ ] `meta.tags` includes `'!autodocs'` (autodocs generation is disabled for Modal now that Task 4 will add a hand-authored docs page).
+- [ ] Storybook builds without errors.
+
+**Verify:** `npm run build-storybook` → exits 0, no errors referencing `Modal.stories.tsx`.
+
+**Steps:**
+
+- [ ] **Step 1: Replace `src/Modal/storybook/Modal.stories.tsx`**
+
+Replace the entire file with:
+
+```tsx
+import { Meta, StoryObj } from '@storybook/react-vite'
+import { FC, useState } from 'react'
+import styled from 'styled-components'
+import { Box } from '../../Box'
+import { Button } from '../../Button'
+import { Text } from '../../Text'
+import { Modal, ModalProps } from '../Modal'
+import { noop } from '../../utils/noop'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faArrowsMaximize } from '@awesome.me/kit-46ca99185c/icons/classic/regular'
+
+const StyledBox = styled(Box)<{ height: string }>`
+  width: ${(props) => props.width || '100%'};
+  height: ${(props) => props.height};
+  transition: height 0.3s ease-in-out;
+`
+
+const Container: FC<ModalProps> = (props) => {
+  const [showModal, setShowModal] = useState(false)
+  const handleClick = () => {
+    setShowModal(!showModal)
+  }
+
+  return (
+    <>
+      <Modal {...props} showModal={showModal} handleClick={handleClick}>
+        {props.children}
+      </Modal>
+      <Button primary onClick={handleClick}>
+        Show modal
+      </Button>
+    </>
+  )
+}
+
+const LongContent = () => (
+  <Box flex direction="column" gap="space.200">
+    {Array.from({ length: 12 }).map((_, index) => (
+      <Text key={index}>
+        Paragraph {index + 1}: No Claims Discount (NCD) is the UK system
+        that recognises claim-free drivers by giving them a discount. So
+        the more years you drive without making a claim, the bigger your
+        discount will be.
+      </Text>
+    ))}
+  </Box>
+)
+
+const TwoButtonFooterContent = (
+  <>
+    <Button secondary handleClick={noop}>
+      Find out more
+    </Button>
+    <Button primary handleClick={noop}>
+      Got it
+    </Button>
+  </>
+)
+
+const meta: Meta<typeof Modal> = {
+  title: 'Modal',
+  component: Modal,
+  tags: ['!autodocs'],
+  argTypes: {
+    rightPanel: {
+      description:
+        'Pass react nodes to display on the right side of the modal before the close button',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: '20px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export default meta
+
+type Story = StoryObj<typeof Modal>
+
+export const Default: Story = {
+  args: {
+    title: 'Generic modal',
+    showModal: false,
+  },
+  render: (args) => {
+    return (
+      <Container {...args}>
+        <Box>
+          [A modal window] creates a mode that disables the main window, but
+          keeps it visible with the modal window as a child window in front of
+          it.
+        </Box>
+      </Container>
+    )
+  },
+}
+
+export const Interactive: Story = {
+  args: {
+    icon: 'calendar',
+    title: "Hello world i'm a beautiful modal",
+    showModal: false,
+    drawer: true,
+    cross: true,
+    closeOnOverlayClick: false,
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [expanded, setExpanded] = useState(false)
+    const rightPanel = (
+      <Box onClick={() => setExpanded((current) => !current)}>
+        <FontAwesomeIcon icon={faArrowsMaximize} />
+      </Box>
+    )
+
+    return (
+      <Container
+        rightPanel={rightPanel}
+        width={expanded ? '500px' : '300px'}
+        {...args}
+      >
+        <StyledBox height={expanded ? '500px' : '200px'}>
+          [A modal window] creates a mode that disables the main window, but
+          keeps it visible with the modal window as a child window in front of
+          it.
+        </StyledBox>
+      </Container>
+    )
+  },
+}
+
+export const BasicContentModal: Story = {
+  args: {
+    title: 'Title of content',
+    showModal: false,
+  },
+  render: (args) => (
+    <Container {...args}>
+      <Text>
+        No Claims Discount (NCD) is the UK system that recognises
+        claim-free drivers by giving them a discount. So the more years
+        you drive without making a claim, the bigger your discount will
+        be.
+      </Text>
+    </Container>
+  ),
+}
+
+export const CustomContentModal: Story = {
+  args: {
+    title: 'Title of content',
+    showModal: false,
+  },
+  render: (args) => (
+    <Container {...args}>
+      <Box flex direction="column" gap="space.200">
+        <Box
+          style={{
+            height: '160px',
+            borderRadius: '12px',
+            background: '#EDE7DE',
+          }}
+        />
+        <Text>
+          No Claims Discount (NCD) is the UK system that recognises
+          claim-free drivers by giving them a discount. Outside the UK,
+          this system is often called Bonus Malus. And we accept them
+          all!
+        </Text>
+      </Box>
+    </Container>
+  ),
+}
+
+export const SingleButtonFooter: Story = {
+  args: {
+    title: 'Title of content',
+    showModal: false,
+    footer: (
+      <Button primary handleClick={noop}>
+        Got it
+      </Button>
+    ),
+  },
+  render: (args) => (
+    <Container {...args}>
+      <Text>
+        No Claims Discount (NCD) is the UK system that recognises
+        claim-free drivers by giving them a discount.
+      </Text>
+    </Container>
+  ),
+}
+
+export const TwoButtonFooter: Story = {
+  args: {
+    title: 'Title of content',
+    showModal: false,
+    footer: TwoButtonFooterContent,
+  },
+  render: (args) => (
+    <Container {...args}>
+      <Text>
+        No Claims Discount (NCD) is the UK system that recognises
+        claim-free drivers by giving them a discount.
+      </Text>
+    </Container>
+  ),
+}
+
+export const StickyHeader: Story = {
+  args: {
+    title: 'Title of content',
+    showModal: false,
+    stickyHeader: true,
+  },
+  render: (args) => (
+    <Container {...args}>
+      <LongContent />
+    </Container>
+  ),
+}
+
+export const StickyFooter: Story = {
+  args: {
+    title: 'Title of content',
+    showModal: false,
+    stickyFooter: true,
+    footer: TwoButtonFooterContent,
+  },
+  render: (args) => (
+    <Container {...args}>
+      <LongContent />
+    </Container>
+  ),
+}
+
+export const StickyHeaderAndFooter: Story = {
+  args: {
+    title: 'Title of content',
+    showModal: false,
+    stickyHeader: true,
+    stickyFooter: true,
+    footer: TwoButtonFooterContent,
+  },
+  render: (args) => (
+    <Container {...args}>
+      <LongContent />
+    </Container>
+  ),
+}
+
+export const MobileDrawer: Story = {
+  args: {
+    title: 'Title of content',
+    showModal: false,
+    drawer: true,
+    stickyHeader: true,
+    stickyFooter: true,
+    footer: TwoButtonFooterContent,
+  },
+  render: (args) => (
+    <Container {...args}>
+      <LongContent />
+    </Container>
+  ),
+}
+```
+
+- [ ] **Step 2: Type-check and lint**
+
+Run: `npm run check-types && npm run lint`
+Expected: Both exit 0 with no errors.
+
+- [ ] **Step 3: Build Storybook to confirm the stories compile**
+
+Run: `npm run build-storybook`
+Expected: Exits 0. (The docs page will look empty/default at this point — Task 4 attaches the real MDX content. `tags: ['!autodocs']` means Modal currently has *no* docs tab until Task 4 lands; that's expected and temporary.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Modal/storybook/Modal.stories.tsx
+git commit -m "feat(Modal): add story variants for sticky header/footer and content types"
+```
+
+---
+
+### Task 4: Add the Modal MDX documentation page
+
+**Goal:** Replace Modal's autodocs page with a hand-authored MDX page matching (and exceeding) the Figma guideline's structure, using live Story embeds instead of static images.
+
+**Files:**
+- Create: `src/Modal/storybook/Modal.mdx`
+- Modify: `.storybook/main.ts`
+
+**Acceptance Criteria:**
+- [ ] `.storybook/main.ts`'s `stories` glob includes `.mdx` files.
+- [ ] Visiting Modal's docs page in Storybook shows: Overview, When to use/not to use, Types, Behaviour & interaction, Anatomy, Content guidelines, and a full props table — each example section embeds a live Story, not a static image.
+- [ ] Storybook builds without errors.
+
+**Verify:** `npm run build-storybook` → exits 0, no errors referencing `Modal.mdx`.
+
+**Steps:**
+
+- [ ] **Step 1: Update `.storybook/main.ts`**
+
+Change the `stories` field:
+
+```ts
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.tsx'],
+```
+
+- [ ] **Step 2: Create `src/Modal/storybook/Modal.mdx`**
+
+```mdx
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks'
+import * as ModalStories from './Modal.stories'
+
+<Meta of={ModalStories} />
+
+# Modal
+
+Modals are purposefully interruptive. A modal appears in front of content
+to provide critical information or ask for a decision. Modals disable all
+other functionality when they appear, and remain on screen until
+confirmed, dismissed, or a required action has been taken.
+
+<Canvas of={ModalStories.Default} />
+
+## When to use
+
+Use a modal:
+
+- If you want to interrupt the customer's flow.
+- If you want to confirm high-risk actions, like deleting progress.
+- If you want to gather more information and/or additional actions that
+  are relevant to the current task.
+
+Don't use a modal:
+
+- If you can display the content in a less intrusive way within a
+  screen, as part of the main flow.
+- If you want users to interact with the content beneath the modal.
+- For low or medium priority information.
+
+## Types
+
+### Basic content modal
+
+Plain text content, with or without a footer.
+
+<Canvas of={ModalStories.BasicContentModal} />
+
+### Custom content modal
+
+Any React content — images, illustrations, forms, or other components.
+
+<Canvas of={ModalStories.CustomContentModal} />
+
+## Behaviour & interaction
+
+Most modals should avoid scrolling. Even when scrolling is required, the
+title should stay pinned at the top and the buttons pinned at the bottom
+— via the `stickyHeader` and `stickyFooter` props — so the title and
+actions remain visible alongside the content, even upon scroll. Never
+scroll content outside of the modal, such as the page behind it —
+`Modal` already locks background scroll for you.
+
+### Sticky header
+
+<Canvas of={ModalStories.StickyHeader} />
+
+### Sticky footer
+
+<Canvas of={ModalStories.StickyFooter} />
+
+### Sticky header and footer
+
+The recommended combination for any modal with scrollable content.
+
+<Canvas of={ModalStories.StickyHeaderAndFooter} />
+
+### Mobile (drawer)
+
+On narrow viewports, `drawer` (on by default) turns the modal into a
+bottom sheet. Combine it with `stickyHeader`/`stickyFooter` so the title
+and actions stay reachable even though there's little room to tap
+outside the modal to dismiss it.
+
+<Canvas of={ModalStories.MobileDrawer} />
+
+## Anatomy
+
+1. **Title** — a single, short sentence or question. It can wrap to a
+   second line if necessary. Avoid apologies ("Sorry for the
+   interruption"), extra alarm ("Warning!"), or ambiguity ("Are you
+   sure?").
+2. **Close icon** — optional; used when there's no primary button in the
+   footer (pass `cross={false}` to hide it).
+3. **Content** — can be plain text (basic) or any custom React content.
+4. **Buttons** — one, two, or none. The confirming/primary action is
+   always closest to the edge (the last child of `footer`).
+
+<Canvas of={ModalStories.TwoButtonFooter} />
+
+## Content guidelines
+
+**Title**
+- Should be a single, short sentence or question.
+- Can wrap to a second line if necessary.
+- Avoid apologies, extra alarm, or ambiguity.
+
+**Buttons**
+- Describe the action in as few words as possible — ideally one or two.
+- Should summarise the purpose of the modal — if a user skips the title
+  and content, the button copy alone should tell them what they're
+  about to do.
+- Start with a strong, imperative verb, like "Pay", "Send", or "Log in".
+
+## Props
+
+<Controls />
+```
+
+- [ ] **Step 3: Build Storybook and manually verify the docs page**
+
+Run: `npm run build-storybook`
+Expected: Exits 0.
+
+Then run `npm run storybook` locally, navigate to Modal's Docs tab, and confirm:
+- Every `<Canvas>` renders its story inline and is interactive (you can click "Show modal" and open each one).
+- No duplicate "Modal" docs entries appear in the sidebar (confirms `tags: ['!autodocs']` from Task 3 successfully suppressed the auto-generated page in favor of this one).
+- The props table at the bottom lists `footer`, `stickyHeader`, and `stickyFooter` with the JSDoc descriptions from Task 1/2.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .storybook/main.ts src/Modal/storybook/Modal.mdx
+git commit -m "docs(Modal): add MDX documentation page"
+```
+
+---
+
+### Task 5: Final verification pass
+
+**Goal:** Confirm the whole change set is consistent end-to-end.
+
+**Files:** None (verification only).
+
+**Acceptance Criteria:**
+- [ ] Full test suite passes.
+- [ ] Type-check and lint pass repo-wide.
+- [ ] Storybook builds cleanly.
+
+**Verify:** see steps below.
+
+**Steps:**
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm test`
+Expected: All tests pass, including the 4 `Modal` tests from Tasks 1–2.
+
+- [ ] **Step 2: Run type-check and lint repo-wide**
+
+Run: `npm run check-types && npm run lint`
+Expected: Both exit 0 with no errors.
+
+- [ ] **Step 3: Build Storybook**
+
+Run: `npm run build-storybook`
+Expected: Exits 0.
+
+- [ ] **Step 4: Manual permutation check (per your earlier request to verify locally)**
+
+Run `npm run storybook` and, for each of `BasicContentModal`, `CustomContentModal`, `SingleButtonFooter`, `TwoButtonFooter`, `StickyHeader`, `StickyFooter`, `StickyHeaderAndFooter`, `MobileDrawer`:
+- Open the modal, resize the browser to a narrow (mobile) width, and scroll the content.
+- Confirm the header/footer stick exactly where expected for that story, with no shadow on the header and a single top divider line (no shadow) on the footer.
+- Confirm `Default`/`Interactive` (no sticky props) still scroll away entirely, matching pre-change behavior.
+
+This step has no automated command — it's the manual sign-off before merging.

--- a/docs/superpowers/plans/2026-08-10-modal-sticky-header-footer.md.tasks.json
+++ b/docs/superpowers/plans/2026-08-10-modal-sticky-header-footer.md.tasks.json
@@ -31,10 +31,10 @@
     {
       "id": 5,
       "subject": "Task 5: Final verification pass",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [4],
       "description": "**Goal:** Confirm the whole change set is consistent end-to-end.\n\n**Files:** None (verification only).\n\n**Acceptance Criteria:**\n- [ ] Full test suite passes (npm test)\n- [ ] check-types and lint pass repo-wide\n- [ ] build-storybook passes\n- [ ] Manual permutation check across all new stories confirms sticky behavior, divider/shadow rules, and mobile drawer\n\n```json:metadata\n{\"files\": [], \"verifyCommand\": \"npm test && npm run check-types && npm run lint && npm run build-storybook\", \"acceptanceCriteria\": [\"npm test passes fully\", \"check-types and lint pass repo-wide\", \"build-storybook exits 0\", \"manual permutation check done in local Storybook\"]}\n```"
     }
   ],
-  "lastUpdated": "2026-08-10T19:10:00Z"
+  "lastUpdated": "2026-08-10T20:20:00Z"
 }

--- a/docs/superpowers/plans/2026-08-10-modal-sticky-header-footer.md.tasks.json
+++ b/docs/superpowers/plans/2026-08-10-modal-sticky-header-footer.md.tasks.json
@@ -1,0 +1,40 @@
+{
+  "planPath": "docs/superpowers/plans/2026-08-10-modal-sticky-header-footer.md",
+  "tasks": [
+    {
+      "id": 1,
+      "subject": "Task 1: Restructure Container padding + add stickyHeader",
+      "status": "pending",
+      "description": "**Goal:** Move Container's padding onto new Header/ContentArea children (no visual change), then make the header row stickable via a new `stickyHeader` prop (default false).\n\n**Files:**\n- Modify: src/Modal/Modal.tsx\n- Modify: src/Modal/Modal.test.tsx\n- Modify (regenerated): src/Modal/__snapshots__/Modal.test.tsx.snap\n\n**Acceptance Criteria:**\n- [ ] Modal renders identically (visually) with default props\n- [ ] stickyHeader defaults to false; true applies position:sticky;top:0 to header\n- [ ] All tests pass\n\n**Verify:** npx vitest run src/Modal/Modal.test.tsx\n\n```json:metadata\n{\"files\": [\"src/Modal/Modal.tsx\", \"src/Modal/Modal.test.tsx\", \"src/Modal/__snapshots__/Modal.test.tsx.snap\"], \"verifyCommand\": \"npx vitest run src/Modal/Modal.test.tsx\", \"acceptanceCriteria\": [\"Modal renders identically with default props (structural snapshot diff only)\", \"stickyHeader defaults to false\", \"stickyHeader=true applies position:sticky;top:0 to header\", \"check-types and lint pass\"]}\n```"
+    },
+    {
+      "id": 2,
+      "subject": "Task 2: Add footer + stickyFooter",
+      "status": "pending",
+      "blockedBy": [1],
+      "description": "**Goal:** Add an optional `footer` slot rendered below the scrollable content, with opt-in `stickyFooter`, and a default flex layout (1 child fills row, 2 children split 50/50) matching the Figma reference.\n\n**Files:**\n- Modify: src/Modal/Modal.tsx\n- Modify: src/Modal/Modal.test.tsx\n- Modify (regenerated): src/Modal/__snapshots__/Modal.test.tsx.snap\n\n**Acceptance Criteria:**\n- [ ] Omitting footer renders nothing extra\n- [ ] footer renders flex row, gap theme.space[100], children flex:1, border-top 1px solid theme.color.border.subtle\n- [ ] stickyFooter defaults false; true applies position:sticky;bottom:0\n- [ ] All tests pass\n\n**Verify:** npx vitest run src/Modal/Modal.test.tsx\n\n```json:metadata\n{\"files\": [\"src/Modal/Modal.tsx\", \"src/Modal/Modal.test.tsx\", \"src/Modal/__snapshots__/Modal.test.tsx.snap\"], \"verifyCommand\": \"npx vitest run src/Modal/Modal.test.tsx\", \"acceptanceCriteria\": [\"footer omitted renders nothing extra\", \"footer flex layout with gap and flex:1 children plus divider border-top\", \"stickyFooter defaults false, true sticks footer to bottom\", \"check-types and lint pass\"]}\n```"
+    },
+    {
+      "id": 3,
+      "subject": "Task 3: Add Storybook story variants",
+      "status": "pending",
+      "blockedBy": [2],
+      "description": "**Goal:** Add Story exports covering every documented variant so Task 4's MDX page has live examples to embed.\n\n**Files:**\n- Modify: src/Modal/storybook/Modal.stories.tsx\n\n**Acceptance Criteria:**\n- [ ] Default and Interactive stories unchanged in behavior\n- [ ] New exports: BasicContentModal, CustomContentModal, SingleButtonFooter, TwoButtonFooter, StickyHeader, StickyFooter, StickyHeaderAndFooter, MobileDrawer\n- [ ] meta.tags includes '!autodocs'\n- [ ] Storybook builds without errors\n\n**Verify:** npm run build-storybook\n\n```json:metadata\n{\"files\": [\"src/Modal/storybook/Modal.stories.tsx\"], \"verifyCommand\": \"npm run build-storybook\", \"acceptanceCriteria\": [\"8 new story exports added\", \"meta.tags includes '!autodocs'\", \"check-types and lint pass\", \"build-storybook exits 0\"]}\n```"
+    },
+    {
+      "id": 4,
+      "subject": "Task 4: Add Modal MDX documentation page",
+      "status": "pending",
+      "blockedBy": [3],
+      "description": "**Goal:** Replace Modal's autodocs page with a hand-authored MDX page matching (and exceeding) the Figma guideline's structure, using live Story embeds instead of static images.\n\n**Files:**\n- Create: src/Modal/storybook/Modal.mdx\n- Modify: .storybook/main.ts\n\n**Acceptance Criteria:**\n- [ ] main.ts stories glob includes .mdx files\n- [ ] Docs page shows Overview, When to use/not, Types, Behaviour & interaction, Anatomy, Content guidelines, props table — all with live Canvas embeds\n- [ ] No duplicate docs entries for Modal\n- [ ] Storybook builds without errors\n\n**Verify:** npm run build-storybook\n\n```json:metadata\n{\"files\": [\".storybook/main.ts\", \"src/Modal/storybook/Modal.mdx\"], \"verifyCommand\": \"npm run build-storybook\", \"acceptanceCriteria\": [\"stories glob includes mdx\", \"MDX page renders all guideline sections with live Canvas embeds\", \"no duplicate Modal docs entries in sidebar\", \"build-storybook exits 0\"]}\n```"
+    },
+    {
+      "id": 5,
+      "subject": "Task 5: Final verification pass",
+      "status": "pending",
+      "blockedBy": [4],
+      "description": "**Goal:** Confirm the whole change set is consistent end-to-end.\n\n**Files:** None (verification only).\n\n**Acceptance Criteria:**\n- [ ] Full test suite passes (npm test)\n- [ ] check-types and lint pass repo-wide\n- [ ] build-storybook passes\n- [ ] Manual permutation check across all new stories confirms sticky behavior, divider/shadow rules, and mobile drawer\n\n```json:metadata\n{\"files\": [], \"verifyCommand\": \"npm test && npm run check-types && npm run lint && npm run build-storybook\", \"acceptanceCriteria\": [\"npm test passes fully\", \"check-types and lint pass repo-wide\", \"build-storybook exits 0\", \"manual permutation check done in local Storybook\"]}\n```"
+    }
+  ],
+  "lastUpdated": "2026-08-10T00:00:00Z"
+}

--- a/docs/superpowers/plans/2026-08-10-modal-sticky-header-footer.md.tasks.json
+++ b/docs/superpowers/plans/2026-08-10-modal-sticky-header-footer.md.tasks.json
@@ -4,7 +4,7 @@
     {
       "id": 1,
       "subject": "Task 1: Restructure Container padding + add stickyHeader",
-      "status": "pending",
+      "status": "completed",
       "description": "**Goal:** Move Container's padding onto new Header/ContentArea children (no visual change), then make the header row stickable via a new `stickyHeader` prop (default false).\n\n**Files:**\n- Modify: src/Modal/Modal.tsx\n- Modify: src/Modal/Modal.test.tsx\n- Modify (regenerated): src/Modal/__snapshots__/Modal.test.tsx.snap\n\n**Acceptance Criteria:**\n- [ ] Modal renders identically (visually) with default props\n- [ ] stickyHeader defaults to false; true applies position:sticky;top:0 to header\n- [ ] All tests pass\n\n**Verify:** npx vitest run src/Modal/Modal.test.tsx\n\n```json:metadata\n{\"files\": [\"src/Modal/Modal.tsx\", \"src/Modal/Modal.test.tsx\", \"src/Modal/__snapshots__/Modal.test.tsx.snap\"], \"verifyCommand\": \"npx vitest run src/Modal/Modal.test.tsx\", \"acceptanceCriteria\": [\"Modal renders identically with default props (structural snapshot diff only)\", \"stickyHeader defaults to false\", \"stickyHeader=true applies position:sticky;top:0 to header\", \"check-types and lint pass\"]}\n```"
     },
     {
@@ -36,5 +36,5 @@
       "description": "**Goal:** Confirm the whole change set is consistent end-to-end.\n\n**Files:** None (verification only).\n\n**Acceptance Criteria:**\n- [ ] Full test suite passes (npm test)\n- [ ] check-types and lint pass repo-wide\n- [ ] build-storybook passes\n- [ ] Manual permutation check across all new stories confirms sticky behavior, divider/shadow rules, and mobile drawer\n\n```json:metadata\n{\"files\": [], \"verifyCommand\": \"npm test && npm run check-types && npm run lint && npm run build-storybook\", \"acceptanceCriteria\": [\"npm test passes fully\", \"check-types and lint pass repo-wide\", \"build-storybook exits 0\", \"manual permutation check done in local Storybook\"]}\n```"
     }
   ],
-  "lastUpdated": "2026-08-10T00:00:00Z"
+  "lastUpdated": "2026-08-10T17:00:00Z"
 }

--- a/docs/superpowers/plans/2026-08-10-modal-sticky-header-footer.md.tasks.json
+++ b/docs/superpowers/plans/2026-08-10-modal-sticky-header-footer.md.tasks.json
@@ -24,7 +24,7 @@
     {
       "id": 4,
       "subject": "Task 4: Add Modal MDX documentation page",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [3],
       "description": "**Goal:** Replace Modal's autodocs page with a hand-authored MDX page matching (and exceeding) the Figma guideline's structure, using live Story embeds instead of static images.\n\n**Files:**\n- Create: src/Modal/storybook/Modal.mdx\n- Modify: .storybook/main.ts\n\n**Acceptance Criteria:**\n- [ ] main.ts stories glob includes .mdx files\n- [ ] Docs page shows Overview, When to use/not, Types, Behaviour & interaction, Anatomy, Content guidelines, props table — all with live Canvas embeds\n- [ ] No duplicate docs entries for Modal\n- [ ] Storybook builds without errors\n\n**Verify:** npm run build-storybook\n\n```json:metadata\n{\"files\": [\".storybook/main.ts\", \"src/Modal/storybook/Modal.mdx\"], \"verifyCommand\": \"npm run build-storybook\", \"acceptanceCriteria\": [\"stories glob includes mdx\", \"MDX page renders all guideline sections with live Canvas embeds\", \"no duplicate Modal docs entries in sidebar\", \"build-storybook exits 0\"]}\n```"
     },
@@ -36,5 +36,5 @@
       "description": "**Goal:** Confirm the whole change set is consistent end-to-end.\n\n**Files:** None (verification only).\n\n**Acceptance Criteria:**\n- [ ] Full test suite passes (npm test)\n- [ ] check-types and lint pass repo-wide\n- [ ] build-storybook passes\n- [ ] Manual permutation check across all new stories confirms sticky behavior, divider/shadow rules, and mobile drawer\n\n```json:metadata\n{\"files\": [], \"verifyCommand\": \"npm test && npm run check-types && npm run lint && npm run build-storybook\", \"acceptanceCriteria\": [\"npm test passes fully\", \"check-types and lint pass repo-wide\", \"build-storybook exits 0\", \"manual permutation check done in local Storybook\"]}\n```"
     }
   ],
-  "lastUpdated": "2026-08-10T18:30:00Z"
+  "lastUpdated": "2026-08-10T19:10:00Z"
 }

--- a/docs/superpowers/plans/2026-08-10-modal-sticky-header-footer.md.tasks.json
+++ b/docs/superpowers/plans/2026-08-10-modal-sticky-header-footer.md.tasks.json
@@ -17,7 +17,7 @@
     {
       "id": 3,
       "subject": "Task 3: Add Storybook story variants",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [2],
       "description": "**Goal:** Add Story exports covering every documented variant so Task 4's MDX page has live examples to embed.\n\n**Files:**\n- Modify: src/Modal/storybook/Modal.stories.tsx\n\n**Acceptance Criteria:**\n- [ ] Default and Interactive stories unchanged in behavior\n- [ ] New exports: BasicContentModal, CustomContentModal, SingleButtonFooter, TwoButtonFooter, StickyHeader, StickyFooter, StickyHeaderAndFooter, MobileDrawer\n- [ ] meta.tags includes '!autodocs'\n- [ ] Storybook builds without errors\n\n**Verify:** npm run build-storybook\n\n```json:metadata\n{\"files\": [\"src/Modal/storybook/Modal.stories.tsx\"], \"verifyCommand\": \"npm run build-storybook\", \"acceptanceCriteria\": [\"8 new story exports added\", \"meta.tags includes '!autodocs'\", \"check-types and lint pass\", \"build-storybook exits 0\"]}\n```"
     },
@@ -36,5 +36,5 @@
       "description": "**Goal:** Confirm the whole change set is consistent end-to-end.\n\n**Files:** None (verification only).\n\n**Acceptance Criteria:**\n- [ ] Full test suite passes (npm test)\n- [ ] check-types and lint pass repo-wide\n- [ ] build-storybook passes\n- [ ] Manual permutation check across all new stories confirms sticky behavior, divider/shadow rules, and mobile drawer\n\n```json:metadata\n{\"files\": [], \"verifyCommand\": \"npm test && npm run check-types && npm run lint && npm run build-storybook\", \"acceptanceCriteria\": [\"npm test passes fully\", \"check-types and lint pass repo-wide\", \"build-storybook exits 0\", \"manual permutation check done in local Storybook\"]}\n```"
     }
   ],
-  "lastUpdated": "2026-08-10T18:15:00Z"
+  "lastUpdated": "2026-08-10T18:30:00Z"
 }

--- a/docs/superpowers/plans/2026-08-10-modal-sticky-header-footer.md.tasks.json
+++ b/docs/superpowers/plans/2026-08-10-modal-sticky-header-footer.md.tasks.json
@@ -10,7 +10,7 @@
     {
       "id": 2,
       "subject": "Task 2: Add footer + stickyFooter",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [1],
       "description": "**Goal:** Add an optional `footer` slot rendered below the scrollable content, with opt-in `stickyFooter`, and a default flex layout (1 child fills row, 2 children split 50/50) matching the Figma reference.\n\n**Files:**\n- Modify: src/Modal/Modal.tsx\n- Modify: src/Modal/Modal.test.tsx\n- Modify (regenerated): src/Modal/__snapshots__/Modal.test.tsx.snap\n\n**Acceptance Criteria:**\n- [ ] Omitting footer renders nothing extra\n- [ ] footer renders flex row, gap theme.space[100], children flex:1, border-top 1px solid theme.color.border.subtle\n- [ ] stickyFooter defaults false; true applies position:sticky;bottom:0\n- [ ] All tests pass\n\n**Verify:** npx vitest run src/Modal/Modal.test.tsx\n\n```json:metadata\n{\"files\": [\"src/Modal/Modal.tsx\", \"src/Modal/Modal.test.tsx\", \"src/Modal/__snapshots__/Modal.test.tsx.snap\"], \"verifyCommand\": \"npx vitest run src/Modal/Modal.test.tsx\", \"acceptanceCriteria\": [\"footer omitted renders nothing extra\", \"footer flex layout with gap and flex:1 children plus divider border-top\", \"stickyFooter defaults false, true sticks footer to bottom\", \"check-types and lint pass\"]}\n```"
     },
@@ -36,5 +36,5 @@
       "description": "**Goal:** Confirm the whole change set is consistent end-to-end.\n\n**Files:** None (verification only).\n\n**Acceptance Criteria:**\n- [ ] Full test suite passes (npm test)\n- [ ] check-types and lint pass repo-wide\n- [ ] build-storybook passes\n- [ ] Manual permutation check across all new stories confirms sticky behavior, divider/shadow rules, and mobile drawer\n\n```json:metadata\n{\"files\": [], \"verifyCommand\": \"npm test && npm run check-types && npm run lint && npm run build-storybook\", \"acceptanceCriteria\": [\"npm test passes fully\", \"check-types and lint pass repo-wide\", \"build-storybook exits 0\", \"manual permutation check done in local Storybook\"]}\n```"
     }
   ],
-  "lastUpdated": "2026-08-10T17:00:00Z"
+  "lastUpdated": "2026-08-10T18:15:00Z"
 }

--- a/docs/superpowers/specs/2026-08-10-modal-sticky-header-footer-design.md
+++ b/docs/superpowers/specs/2026-08-10-modal-sticky-header-footer-design.md
@@ -1,0 +1,65 @@
+# Modal: sticky header/footer + documentation overhaul
+
+## Problem
+
+`Modal` (`src/Modal/Modal.tsx`) currently renders its title/close row and `children` inside a single `overflow: auto` container. When content overflows, the header scrolls away with everything else. On mobile especially, where there's little room around the modal to tap-outside-to-dismiss, losing the close button on scroll is a usability problem. There's also no dedicated footer slot — action buttons, if any, just live at the end of `children` and scroll away too.
+
+The Marshmallow design system's Figma guidelines for Modal are explicit on this: *"Even when scrolling is required, the dialog title is pinned at the top, with buttons pinned at the bottom... Do not scroll items outside of the modal, such as the background."*
+
+Separately, `Modal`'s Storybook documentation today is minimal — it's 100% autodocs-generated (props table + two live examples), with no prose guidance. The Figma file has a full guideline page (overview, when to use, anatomy, content rules, behaviour). This work also brings the coded docs up to parity with, and beyond, that Figma page.
+
+## Non-goals
+
+- No visual/behavioral change for any existing `Modal` consumer who doesn't opt in to the new props. This ships as a non-breaking minor version.
+- Not reworking `drawer` (mobile bottom-sheet) behavior, overlay behavior, or anything else already working.
+
+## Props API
+
+```ts
+footer?: ReactNode        // new — optional slot rendered below the scrollable content
+stickyHeader?: boolean    // default: false
+stickyFooter?: boolean    // default: false
+```
+
+- `footer` is additive. Omitting it changes nothing — `children` renders exactly as it does today.
+- `stickyHeader` pins the title/close row so it doesn't scroll away. Defaults to `false` — despite this being the better default per the design guidelines, this is a shared package consumed by multiple apps, and defaulting it to `true` would silently change the visual behavior of every existing modal in production on the next version bump. It's opt-in; recommended for new usage in the docs.
+- `stickyFooter` only has an effect when `footer` is passed; also defaults to `false` for the same reason.
+- Passing `stickyFooter={true}` with no `footer` is a documented no-op, not a warning.
+
+## Structure & styling
+
+Current `Container` (`src/Modal/Modal.tsx:154`) has `overflow: auto` and padding applied to itself, wrapping both the header `Box` and the `children` `Box`.
+
+Changes:
+
+- `position: sticky` works fine on a direct child of a scrolling ancestor — no need to introduce a nested scroll container. `Container` keeps `overflow: auto`.
+- Move `Container`'s padding onto a new inner `ContentArea` wrapper around `children` only, so `Container` spans edge-to-edge and sticky children can span full width with no side gaps.
+- Header `Box` gets horizontal padding matching the old `Container` padding. When `stickyHeader` is true: `position: sticky; top: 0` + `z-index`. Background: `theme.color.background[100]` (same token `Container` already uses) — **no shadow, no border**, so the header blends with content scrolling underneath it (confirmed against the Figma reference, which shows the previous section's heading fading out behind the pinned header).
+- New `Footer` styled component, sibling to `ContentArea`: horizontal padding matching the header, `display: flex; gap: theme.space[100]` with `& > * { flex: 1 }` on direct children (so 1 button fills the row, 2 buttons split it 50/50 — matches measurements taken directly from the Figma reference file, which showed two equal 366px-wide buttons with a gap, not an auto-width + fill-remaining split). `border-top: 1px solid theme.color.illustration.neutral[300]` (same token `Divider` defaults to) whenever `footer` is rendered, sticky or not. `position: sticky; bottom: 0` + `z-index` when `stickyFooter` is true. No shadow.
+- Button ordering inside `footer` is the consumer's responsibility; docs call out the design rule: the confirming/primary action goes closest to the trailing edge (i.e. last).
+
+## Documentation
+
+New `src/Modal/storybook/Modal.mdx`, attached via `<Meta of={ModalStories} />` — this supersedes the autodocs page Storybook currently generates for Modal via the global `tags: ['autodocs']` in `.storybook/preview.tsx`. `.storybook/main.ts`'s `stories` glob needs to include `.mdx` files (currently only matches `*.stories.tsx`).
+
+Sections, modeled on the Figma guideline page but with every example a **live, interactive Story embed** (`<Canvas of={ModalStories.X} />`) rather than a static image:
+
+1. **Overview** — purposefully interruptive, disables surrounding content until dismissed/confirmed.
+2. **When to use / when not to** — from the guideline's bullet points (interrupt flow, confirm high-risk actions, gather additional info / vs. low-priority info that fits inline).
+3. **Types** — Basic content modal vs. Custom content modal, each with a live example.
+4. **Behaviour & interaction** — the scrolling rule ("title pinned top, buttons pinned bottom, don't scroll the background") tied directly to live `stickyHeader`/`stickyFooter` examples.
+5. **Anatomy** — title, close icon (optional, used when there's no primary button), content, buttons — annotated against a live example.
+6. **Content guidelines** — title: single short sentence/question, can wrap to a second line, avoid apologies/alarm/ambiguity. Buttons: 1-2 words, imperative verb ("Pay", "Send"), confirm button closest to the edge.
+7. **Full props table** (`<Controls />` / `<ArgTypes />`).
+
+New Story exports in `Modal.stories.tsx` to support the above: `BasicContentModal`, `CustomContentModal`, `NoFooter`, `SingleButtonFooter`, `TwoButtonFooter`, `StickyHeader`, `StickyFooter`, `StickyHeaderAndFooter`, `MobileDrawer`.
+
+## Testing
+
+- Extend `Modal.test.tsx` with cases for: `footer` rendering, `stickyHeader`/`stickyFooter` default-off behavior (snapshot unchanged from today), and sticky props applying the expected styles when on.
+- Existing snapshot in `__snapshots__` must remain unchanged for default props (proves non-breaking).
+- Manual verification across permutations (no footer / 1 button / 2 buttons, sticky combinations, `drawer` mobile mode) — user will verify locally.
+
+## Open implementation details (not blocking, resolved during implementation)
+
+- Exact MDX block imports for Storybook 10 (`@storybook/addon-docs/blocks`) to be confirmed against the installed version during implementation.

--- a/src/Modal/Modal.test.tsx
+++ b/src/Modal/Modal.test.tsx
@@ -81,4 +81,32 @@ describe('Modal', () => {
 
     expect(baseElement).toMatchSnapshot()
   })
+
+  it('ignores stickyFooter when no footer is passed', () => {
+    const withoutStickyFooter = render(
+      <Modal
+        showModal={true}
+        handleClick={noop}
+        width={'600px'}
+        title={'Modal Title'}
+      >
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+    const withStickyFooter = render(
+      <Modal
+        showModal={true}
+        handleClick={noop}
+        width={'600px'}
+        title={'Modal Title'}
+        stickyFooter
+      >
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+
+    expect(withStickyFooter.baseElement.innerHTML).toBe(
+      withoutStickyFooter.baseElement.innerHTML,
+    )
+  })
 })

--- a/src/Modal/Modal.test.tsx
+++ b/src/Modal/Modal.test.tsx
@@ -1,6 +1,7 @@
 import { expect, it } from 'vitest'
 import { render } from '../testUtils'
 import { Modal } from './Modal'
+import { Button } from '../Button'
 import { noop } from '../utils/noop'
 
 describe('Modal', () => {
@@ -27,6 +28,52 @@ describe('Modal', () => {
         width={'600px'}
         title={'Modal Title'}
         stickyHeader
+      >
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+
+    expect(baseElement).toMatchSnapshot()
+  })
+
+  it('renders correctly with a footer', () => {
+    const { baseElement } = render(
+      <Modal
+        showModal={true}
+        handleClick={noop}
+        width={'600px'}
+        title={'Modal Title'}
+        footer={
+          <>
+            <Button secondary handleClick={noop}>
+              Find out more
+            </Button>
+            <Button primary handleClick={noop}>
+              Got it
+            </Button>
+          </>
+        }
+      >
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+
+    expect(baseElement).toMatchSnapshot()
+  })
+
+  it('renders correctly with a sticky footer', () => {
+    const { baseElement } = render(
+      <Modal
+        showModal={true}
+        handleClick={noop}
+        width={'600px'}
+        title={'Modal Title'}
+        footer={
+          <Button primary handleClick={noop}>
+            Got it
+          </Button>
+        }
+        stickyFooter
       >
         <div>Modal Content ...</div>
       </Modal>,

--- a/src/Modal/Modal.test.tsx
+++ b/src/Modal/Modal.test.tsx
@@ -1,5 +1,5 @@
-import { expect, it } from 'vitest'
-import { render } from '../testUtils'
+import { expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '../testUtils'
 import { Modal } from './Modal'
 import { Button } from '../Button'
 import { noop } from '../utils/noop'
@@ -108,5 +108,109 @@ describe('Modal', () => {
     expect(withStickyFooter.baseElement.innerHTML).toBe(
       withoutStickyFooter.baseElement.innerHTML,
     )
+  })
+
+  it('exposes an accessible dialog labelled by the title', () => {
+    render(
+      <Modal showModal={true} handleClick={noop} title={'Modal Title'}>
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toHaveAccessibleName('Modal Title')
+  })
+
+  it('moves focus into the dialog when it opens', () => {
+    render(
+      <Modal showModal={true} handleClick={noop} title={'Modal Title'}>
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+
+    expect(screen.getByRole('dialog')).toHaveFocus()
+  })
+
+  it('restores focus to the previously focused element on close', () => {
+    const trigger = document.createElement('button')
+    document.body.appendChild(trigger)
+    trigger.focus()
+
+    const { rerender } = render(
+      <Modal showModal={true} handleClick={noop} title={'Modal Title'}>
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+    expect(screen.getByRole('dialog')).toHaveFocus()
+
+    rerender(
+      <Modal showModal={false} handleClick={noop} title={'Modal Title'}>
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+
+    expect(trigger).toHaveFocus()
+    trigger.remove()
+  })
+
+  it('calls handleClick on Escape when closeOnOverlayClick is true', () => {
+    const handleClick = vi.fn()
+    render(
+      <Modal showModal={true} handleClick={handleClick} title={'Modal Title'}>
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(handleClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores Escape when closeOnOverlayClick is false', () => {
+    const handleClick = vi.fn()
+    render(
+      <Modal
+        showModal={true}
+        handleClick={handleClick}
+        title={'Modal Title'}
+        closeOnOverlayClick={false}
+      >
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(handleClick).not.toHaveBeenCalled()
+  })
+
+  it('wraps Tab focus between the first and last focusable elements', () => {
+    render(
+      <Modal
+        showModal={true}
+        handleClick={noop}
+        title={'Modal Title'}
+        footer={
+          <Button primary handleClick={noop}>
+            Got it
+          </Button>
+        }
+      >
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+
+    const closeButton = screen.getByRole('button', { name: 'Close modal' })
+    const gotItButton = screen.getByRole('button', { name: 'Got it' })
+
+    gotItButton.focus()
+    expect(gotItButton).toHaveFocus()
+
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(closeButton).toHaveFocus()
+
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+    expect(gotItButton).toHaveFocus()
   })
 })

--- a/src/Modal/Modal.test.tsx
+++ b/src/Modal/Modal.test.tsx
@@ -18,4 +18,20 @@ describe('Modal', () => {
 
     expect(baseElement).toMatchSnapshot()
   })
+
+  it('renders correctly with sticky header', () => {
+    const { baseElement } = render(
+      <Modal
+        showModal={true}
+        handleClick={noop}
+        width={'600px'}
+        title={'Modal Title'}
+        stickyHeader
+      >
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+
+    expect(baseElement).toMatchSnapshot()
+  })
 })

--- a/src/Modal/Modal.test.tsx
+++ b/src/Modal/Modal.test.tsx
@@ -213,4 +213,50 @@ describe('Modal', () => {
     fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
     expect(gotItButton).toHaveFocus()
   })
+
+  it('locks body scroll while open and restores it on close', () => {
+    const { rerender } = render(
+      <Modal showModal={false} handleClick={noop} title={'Modal Title'}>
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+    expect(document.body.style.overflow).not.toBe('hidden')
+
+    rerender(
+      <Modal showModal={true} handleClick={noop} title={'Modal Title'}>
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+    expect(document.body.style.overflow).toBe('hidden')
+
+    rerender(
+      <Modal showModal={false} handleClick={noop} title={'Modal Title'}>
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+    expect(document.body.style.overflow).not.toBe('hidden')
+  })
+
+  it('locks body scroll when showModal is true on first mount', () => {
+    render(
+      <Modal showModal={true} handleClick={noop} title={'Modal Title'}>
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+
+    expect(document.body.style.overflow).toBe('hidden')
+  })
+
+  it('unlocks body scroll on unmount', () => {
+    const { unmount } = render(
+      <Modal showModal={true} handleClick={noop} title={'Modal Title'}>
+        <div>Modal Content ...</div>
+      </Modal>,
+    )
+    expect(document.body.style.overflow).toBe('hidden')
+
+    unmount()
+
+    expect(document.body.style.overflow).not.toBe('hidden')
+  })
 })

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -89,10 +89,11 @@ export const Modal: FC<ModalProps> = ({
   stickyFooter = false,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null)
+  const scrollAreaRef = useRef<HTMLDivElement>(null)
   const titleId = useId()
   const theme = useTheme()
 
-  useBodyScrollLock({ ref: containerRef, showModal })
+  useBodyScrollLock({ ref: scrollAreaRef, showModal })
 
   const latestRef = useRef({ handleClick, closeOnOverlayClick })
   latestRef.current = { handleClick, closeOnOverlayClick }
@@ -158,41 +159,46 @@ export const Modal: FC<ModalProps> = ({
         $width={width || '460px'}
         className={containerClass}
       >
-        <Header
-          flex
-          alignItems="flex-start"
-          justifyContent="space-between"
-          $sticky={stickyHeader}
-        >
-          <TitleElements flex direction="column">
-            <Text {...titleProps} id={titleId} />
-          </TitleElements>
-          <Box flex alignItems="center" gap={'space.100'}>
-            {rightPanel}
-            {cross && (
-              <IconContainer
-                as="button"
-                onClick={handleClick}
-                role="button"
-                title="Close modal"
-                $size={32}
-                style={{
-                  background: theme.color.illustration.neutral[300],
-                  borderRadius: '100%',
-                  padding: '6px',
-                  border: 'none',
-                  cursor: 'pointer',
-                }}
-              >
-                <FontAwesomeIcon icon={faXmark} color={theme.color.icon.base} />
-              </IconContainer>
-            )}
-          </Box>
-        </Header>
-        <ContentArea flex direction="column" $hasFooter={!!footer}>
-          {children}
-        </ContentArea>
-        {footer ? <Footer $sticky={stickyFooter}>{footer}</Footer> : null}
+        <ScrollArea ref={scrollAreaRef}>
+          <Header
+            flex
+            alignItems="flex-start"
+            justifyContent="space-between"
+            $sticky={stickyHeader}
+          >
+            <TitleElements flex direction="column">
+              <Text {...titleProps} id={titleId} />
+            </TitleElements>
+            <Box flex alignItems="center" gap={'space.100'}>
+              {rightPanel}
+              {cross && (
+                <IconContainer
+                  as="button"
+                  onClick={handleClick}
+                  role="button"
+                  title="Close modal"
+                  $size={32}
+                  style={{
+                    background: theme.color.illustration.neutral[300],
+                    borderRadius: '100%',
+                    padding: '6px',
+                    border: 'none',
+                    cursor: 'pointer',
+                  }}
+                >
+                  <FontAwesomeIcon
+                    icon={faXmark}
+                    color={theme.color.icon.base}
+                  />
+                </IconContainer>
+              )}
+            </Box>
+          </Header>
+          <ContentArea flex direction="column" $hasFooter={!!footer}>
+            {children}
+          </ContentArea>
+          {footer ? <Footer $sticky={stickyFooter}>{footer}</Footer> : null}
+        </ScrollArea>
       </Container>
     </Wrapper>,
     portalContainer,
@@ -224,6 +230,8 @@ const Overlay = styled.div<{ $closeOnOverlayClick: boolean }>`
 
 const Container = styled.div<{ $drawer: boolean; $width: string }>(
   ({ $drawer, $width }) => css`
+    display: flex;
+    flex-direction: column;
     background: ${({ theme }) => theme.color.background[100]};
     box-sizing: border-box;
     border-radius: 16px;
@@ -231,8 +239,7 @@ const Container = styled.div<{ $drawer: boolean; $width: string }>(
     max-width: ${$width};
     position: fixed;
     max-height: calc(100vh - 64px);
-    overflow: auto;
-    overscroll-behavior-y: none;
+    overflow: hidden;
     outline: none;
     transition: all 0.3s ease-in-out;
 
@@ -253,6 +260,17 @@ const Container = styled.div<{ $drawer: boolean; $width: string }>(
     }
   `,
 )
+
+// Container clips to the border-radius; ScrollArea is where the native
+// scrollbar actually lives. Without this split, the scrollbar's straight
+// edge cuts across the rounded corner (native scrollbars aren't clipped
+// to border-radius on their own scrolling element in any browser).
+const ScrollArea = styled.div`
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior-y: none;
+`
 
 // Header's bottom padding and ContentArea's top padding are a paired
 // invariant: their sum must equal the gap between title and content.

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -276,7 +276,7 @@ const ScrollArea = styled.div`
 // invariant: their sum must equal the gap between title and content.
 const Header = styled(Box)<{ $sticky: boolean }>(
   ({ $sticky, theme }) => css`
-    padding: ${theme.space[300]} ${theme.space[200]} ${theme.space[100]};
+    padding: ${theme.space[300]} ${theme.space[200]} ${theme.space[300]};
     background: ${theme.color.background[100]};
 
     ${

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -10,9 +10,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faXmark } from '@awesome.me/kit-46ca99185c/icons/classic/regular'
 
 interface IModalContainer {
-  // drawer state
   $drawer: boolean
-  // modal width
   $width: string
 }
 
@@ -209,14 +207,8 @@ const Container = styled.div<IModalContainer>(
   `,
 )
 
-// NOTE: Header's bottom padding and ContentArea's top padding are a paired
-// invariant — their sum must equal the original pre-refactor gap between
-// title and content. If you change one, change the other (and re-check
-// snapshots).
-//
-// Header's top/left/right and Footer's bottom/left/right are the modal's
-// outer edge padding (24px top/bottom, 16px left/right) and are constant
-// across all viewports/drawer modes — no media-query overrides here.
+// Header's bottom padding and ContentArea's top padding are a paired
+// invariant: their sum must equal the gap between title and content.
 const Header = styled(Box)<{ $sticky: boolean }>(
   ({ $sticky, theme }) => css`
     padding: ${theme.space[300]} ${theme.space[200]} ${theme.space[100]};

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -9,11 +9,6 @@ import { IconContainer } from '../sharedStyles/shared.styles'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faXmark } from '@awesome.me/kit-46ca99185c/icons/classic/regular'
 
-interface IModalContainer {
-  $drawer: boolean
-  $width: string
-}
-
 export type ModalProps = {
   /**
    * Title of the modal
@@ -30,7 +25,6 @@ export type ModalProps = {
    * ```
    */
   title?: string | TitleProps
-  icon?: string
   children?: ReactNode
   rightPanel?: ReactNode
   showModal?: boolean
@@ -176,7 +170,7 @@ const Overlay = styled.div<{ $closeOnOverlayClick: boolean }>`
   right: 0;
 `
 
-const Container = styled.div<IModalContainer>(
+const Container = styled.div<{ $drawer: boolean; $width: string }>(
   ({ $drawer, $width }) => css`
     background: ${({ theme }) => theme.color.background[100]};
     box-sizing: border-box;

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -145,7 +145,7 @@ export const Modal: FC<ModalProps> = ({
             )}
           </Box>
         </Header>
-        <ContentArea flex direction="column">
+        <ContentArea flex direction="column" $hasFooter={!!footer}>
           {children}
         </ContentArea>
         {footer ? <Footer $sticky={stickyFooter}>{footer}</Footer> : null}
@@ -233,10 +233,11 @@ const Header = styled(Box)<{ $sticky: boolean }>(
   `,
 )
 
-const ContentArea = styled(Box)`
-  padding: 0 ${({ theme }) => theme.space[200]}
-    ${({ theme }) => theme.space[300]};
-`
+const ContentArea = styled(Box)<{ $hasFooter: boolean }>(
+  ({ $hasFooter, theme }) => css`
+    padding: 0 ${theme.space[200]} ${$hasFooter ? '0' : theme.space[300]};
+  `,
+)
 
 const Footer = styled.div<{ $sticky: boolean }>(
   ({ $sticky, theme }) => css`
@@ -244,7 +245,6 @@ const Footer = styled.div<{ $sticky: boolean }>(
     gap: ${theme.space[100]};
     padding: ${theme.space[200]} ${theme.space[200]} ${theme.space[300]};
     background: ${theme.color.background[100]};
-    border-top: 1px solid ${theme.color.border.subtle};
 
     & > * {
       flex: 1;

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -198,7 +198,7 @@ const Container = styled.div<IModalContainer>(
     position: fixed;
     max-height: calc(100vh - 64px);
     overflow: auto;
-    overscroll-behavior-y: contain;
+    overscroll-behavior-y: none;
     transition: all 0.3s ease-in-out;
 
     ${

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -295,7 +295,7 @@ const Footer = styled.div<{ $sticky: boolean; $drawer: boolean }>(
       $drawer &&
       css`
         @media (max-width: 768px) {
-          padding: ${theme.space[200]} ${theme.space[300]} ${theme.space[200]};
+          padding: ${theme.space[200]} ${theme.space[300]} ${theme.space[300]};
         }
       `
     }

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useRef } from 'react'
+import { FC, ReactNode, useEffect, useId, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import styled, { css, useTheme } from 'styled-components'
 
@@ -69,6 +69,9 @@ const getDefaultTitleProps = (title: string): TitleProps => ({
   align: 'left',
 })
 
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
 export const Modal: FC<ModalProps> = ({
   title = '',
   children,
@@ -85,10 +88,54 @@ export const Modal: FC<ModalProps> = ({
   footer,
   stickyFooter = false,
 }) => {
-  const modalRef = useRef<HTMLDivElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const titleId = useId()
   const theme = useTheme()
 
-  useBodyScrollLock({ node: modalRef.current, showModal })
+  useBodyScrollLock({ node: containerRef.current, showModal })
+
+  const latestRef = useRef({ handleClick, closeOnOverlayClick })
+  latestRef.current = { handleClick, closeOnOverlayClick }
+
+  useEffect(() => {
+    if (!showModal) return
+
+    const previouslyFocused = document.activeElement as HTMLElement | null
+    containerRef.current?.focus()
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        if (latestRef.current.closeOnOverlayClick) {
+          latestRef.current.handleClick()
+        }
+        return
+      }
+
+      if (event.key !== 'Tab' || !containerRef.current) return
+
+      const focusable =
+        containerRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      if (focusable.length === 0) return
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      previouslyFocused?.focus()
+    }
+  }, [showModal])
 
   const isTitleString = typeof title === 'string'
   const titleProps = isTitleString ? getDefaultTitleProps(title) : title
@@ -96,12 +143,17 @@ export const Modal: FC<ModalProps> = ({
   if (!showModal) return null
 
   return createPortal(
-    <Wrapper ref={modalRef}>
+    <Wrapper>
       <Overlay
         onClick={() => closeOnOverlayClick && handleClick()}
         $closeOnOverlayClick={closeOnOverlayClick}
       />
       <Container
+        ref={containerRef}
+        tabIndex={-1}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
         $drawer={drawer}
         $width={width || '460px'}
         className={containerClass}
@@ -113,7 +165,7 @@ export const Modal: FC<ModalProps> = ({
           $sticky={stickyHeader}
         >
           <TitleElements flex direction="column">
-            <Text {...titleProps} />
+            <Text {...titleProps} id={titleId} />
           </TitleElements>
           <Box flex alignItems="center" gap={'space.100'}>
             {rightPanel}
@@ -181,6 +233,7 @@ const Container = styled.div<{ $drawer: boolean; $width: string }>(
     max-height: calc(100vh - 64px);
     overflow: auto;
     overscroll-behavior-y: none;
+    outline: none;
     transition: all 0.3s ease-in-out;
 
     ${

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -149,7 +149,7 @@ export const Modal: FC<ModalProps> = ({
         <ContentArea flex direction="column" $drawer={drawer}>
           {children}
         </ContentArea>
-        {footer && <Footer $sticky={stickyFooter}>{footer}</Footer>}
+        {footer ? <Footer $sticky={stickyFooter}>{footer}</Footer> : null}
       </Container>
     </Wrapper>,
     portalContainer,

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -146,10 +146,19 @@ export const Modal: FC<ModalProps> = ({
             )}
           </Box>
         </Header>
-        <ContentArea flex direction="column" $drawer={drawer}>
+        <ContentArea
+          flex
+          direction="column"
+          $drawer={drawer}
+          $hasFooter={!!footer}
+        >
           {children}
         </ContentArea>
-        {footer ? <Footer $sticky={stickyFooter}>{footer}</Footer> : null}
+        {footer ? (
+          <Footer $sticky={stickyFooter} $drawer={drawer}>
+            {footer}
+          </Footer>
+        ) : null}
       </Container>
     </Wrapper>,
     portalContainer,
@@ -214,6 +223,12 @@ const Container = styled.div<IModalContainer>(
 // invariant — in both drawer and non-drawer modes their sum must equal the
 // original pre-refactor gap between title and content. If you change one,
 // change the other (and re-check snapshots).
+//
+// The drawer mode's 10% bottom inset belongs on whichever element is
+// actually last inside Container: ContentArea when there's no footer,
+// Footer when there is. ContentArea's $hasFooter prop switches that inset
+// off so it isn't wasted on an internal gap once Footer owns the true
+// bottom edge.
 const Header = styled(Box)<{ $sticky: boolean; $drawer: boolean }>(
   ({ $sticky, $drawer, theme }) => css`
     padding: ${theme.space[300]} ${theme.space[300]} ${theme.space[100]};
@@ -239,12 +254,13 @@ const Header = styled(Box)<{ $sticky: boolean; $drawer: boolean }>(
   `,
 )
 
-const ContentArea = styled(Box)<{ $drawer: boolean }>(
-  ({ $drawer, theme }) => css`
+const ContentArea = styled(Box)<{ $drawer: boolean; $hasFooter: boolean }>(
+  ({ $drawer, $hasFooter, theme }) => css`
     padding: 0 ${theme.space[300]} ${theme.space[300]};
 
     ${
       $drawer &&
+      !$hasFooter &&
       css`
         @media (max-width: 768px) {
           padding: 0 ${theme.space[300]} 10%;
@@ -254,8 +270,8 @@ const ContentArea = styled(Box)<{ $drawer: boolean }>(
   `,
 )
 
-const Footer = styled.div<{ $sticky: boolean }>(
-  ({ $sticky, theme }) => css`
+const Footer = styled.div<{ $sticky: boolean; $drawer: boolean }>(
+  ({ $sticky, $drawer, theme }) => css`
     display: flex;
     gap: ${theme.space[100]};
     padding: ${theme.space[200]} ${theme.space[300]} ${theme.space[300]};
@@ -272,6 +288,15 @@ const Footer = styled.div<{ $sticky: boolean }>(
         position: sticky;
         bottom: 0;
         z-index: 1;
+      `
+    }
+
+    ${
+      $drawer &&
+      css`
+        @media (max-width: 768px) {
+          padding: ${theme.space[200]} ${theme.space[300]} 10%;
+        }
       `
     }
   `,

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -51,6 +51,21 @@ export type ModalProps = {
    * @default false
    */
   stickyHeader?: boolean
+  /**
+   * Optional footer content rendered below the scrollable body, outside
+   * `children` — e.g. one or two action buttons. When there are 1–2
+   * direct children, they're laid out as equal-width flex items with a
+   * gap. The confirming/primary action should be the last child, closest
+   * to the trailing edge.
+   * @default undefined (no footer rendered)
+   */
+  footer?: ReactNode
+  /**
+   * Pins `footer` so it stays visible while the content scrolls. Has no
+   * effect if `footer` isn't passed.
+   * @default false
+   */
+  stickyFooter?: boolean
 }
 
 export type TitleProps = TextProps
@@ -75,6 +90,8 @@ export const Modal: FC<ModalProps> = ({
   portalContainer = document.body,
   closeOnOverlayClick = true,
   stickyHeader = false,
+  footer,
+  stickyFooter = false,
 }) => {
   const modalRef = useRef<HTMLDivElement>(null)
   const theme = useTheme()
@@ -132,6 +149,7 @@ export const Modal: FC<ModalProps> = ({
         <ContentArea flex direction="column" $drawer={drawer}>
           {children}
         </ContentArea>
+        {footer && <Footer $sticky={stickyFooter}>{footer}</Footer>}
       </Container>
     </Wrapper>,
     portalContainer,
@@ -191,6 +209,10 @@ const Container = styled.div<IModalContainer>(
   `,
 )
 
+// NOTE: Header's bottom padding and ContentArea's top padding are a paired
+// invariant — in both drawer and non-drawer modes their sum must equal the
+// original pre-refactor gap between title and content. If you change one,
+// change the other (and re-check snapshots).
 const Header = styled(Box)<{ $sticky: boolean; $drawer: boolean }>(
   ({ $sticky, $drawer, theme }) => css`
     padding: ${theme.space[300]} ${theme.space[300]} ${theme.space[100]};
@@ -226,6 +248,29 @@ const ContentArea = styled(Box)<{ $drawer: boolean }>(
         @media (max-width: 768px) {
           padding: 0 ${theme.space[300]} 10%;
         }
+      `
+    }
+  `,
+)
+
+const Footer = styled.div<{ $sticky: boolean }>(
+  ({ $sticky, theme }) => css`
+    display: flex;
+    gap: ${theme.space[100]};
+    padding: ${theme.space[200]} ${theme.space[300]} ${theme.space[300]};
+    background: ${theme.color.background[100]};
+    border-top: 1px solid ${theme.color.border.subtle};
+
+    & > * {
+      flex: 1;
+    }
+
+    ${
+      $sticky &&
+      css`
+        position: sticky;
+        bottom: 0;
+        z-index: 1;
       `
     }
   `,

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -300,7 +300,7 @@ const Footer = styled.div<{ $sticky: boolean }>(
   ({ $sticky, theme }) => css`
     display: flex;
     gap: ${theme.space[100]};
-    padding: ${theme.space[200]} ${theme.space[200]} ${theme.space[300]};
+    padding: ${theme.space[300]} ${theme.space[200]} ${theme.space[300]};
     background: ${theme.color.background[100]};
 
     & > * {

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -119,7 +119,6 @@ export const Modal: FC<ModalProps> = ({
           alignItems="flex-start"
           justifyContent="space-between"
           $sticky={stickyHeader}
-          $drawer={drawer}
         >
           <TitleElements flex direction="column">
             <Text {...titleProps} />
@@ -146,19 +145,10 @@ export const Modal: FC<ModalProps> = ({
             )}
           </Box>
         </Header>
-        <ContentArea
-          flex
-          direction="column"
-          $drawer={drawer}
-          $hasFooter={!!footer}
-        >
+        <ContentArea flex direction="column">
           {children}
         </ContentArea>
-        {footer ? (
-          <Footer $sticky={stickyFooter} $drawer={drawer}>
-            {footer}
-          </Footer>
-        ) : null}
+        {footer ? <Footer $sticky={stickyFooter}>{footer}</Footer> : null}
       </Container>
     </Wrapper>,
     portalContainer,
@@ -220,18 +210,16 @@ const Container = styled.div<IModalContainer>(
 )
 
 // NOTE: Header's bottom padding and ContentArea's top padding are a paired
-// invariant — in both drawer and non-drawer modes their sum must equal the
-// original pre-refactor gap between title and content. If you change one,
-// change the other (and re-check snapshots).
+// invariant — their sum must equal the original pre-refactor gap between
+// title and content. If you change one, change the other (and re-check
+// snapshots).
 //
-// The drawer mode's 10% bottom inset belongs on whichever element is
-// actually last inside Container: ContentArea when there's no footer,
-// Footer when there is. ContentArea's $hasFooter prop switches that inset
-// off so it isn't wasted on an internal gap once Footer owns the true
-// bottom edge.
-const Header = styled(Box)<{ $sticky: boolean; $drawer: boolean }>(
-  ({ $sticky, $drawer, theme }) => css`
-    padding: ${theme.space[300]} ${theme.space[300]} ${theme.space[100]};
+// Header's top/left/right and Footer's bottom/left/right are the modal's
+// outer edge padding (24px top/bottom, 16px left/right) and are constant
+// across all viewports/drawer modes — no media-query overrides here.
+const Header = styled(Box)<{ $sticky: boolean }>(
+  ({ $sticky, theme }) => css`
+    padding: ${theme.space[300]} ${theme.space[200]} ${theme.space[100]};
     background: ${theme.color.background[100]};
 
     ${
@@ -242,39 +230,19 @@ const Header = styled(Box)<{ $sticky: boolean; $drawer: boolean }>(
         z-index: 1;
       `
     }
-
-    ${
-      $drawer &&
-      css`
-        @media (max-width: 768px) {
-          padding: 10% ${theme.space[300]} ${theme.space[100]};
-        }
-      `
-    }
   `,
 )
 
-const ContentArea = styled(Box)<{ $drawer: boolean; $hasFooter: boolean }>(
-  ({ $drawer, $hasFooter, theme }) => css`
-    padding: 0 ${theme.space[300]} ${theme.space[300]};
+const ContentArea = styled(Box)`
+  padding: 0 ${({ theme }) => theme.space[200]}
+    ${({ theme }) => theme.space[300]};
+`
 
-    ${
-      $drawer &&
-      !$hasFooter &&
-      css`
-        @media (max-width: 768px) {
-          padding: 0 ${theme.space[300]} 10%;
-        }
-      `
-    }
-  `,
-)
-
-const Footer = styled.div<{ $sticky: boolean; $drawer: boolean }>(
-  ({ $sticky, $drawer, theme }) => css`
+const Footer = styled.div<{ $sticky: boolean }>(
+  ({ $sticky, theme }) => css`
     display: flex;
     gap: ${theme.space[100]};
-    padding: ${theme.space[200]} ${theme.space[300]} ${theme.space[300]};
+    padding: ${theme.space[200]} ${theme.space[200]} ${theme.space[300]};
     background: ${theme.color.background[100]};
     border-top: 1px solid ${theme.color.border.subtle};
 
@@ -288,15 +256,6 @@ const Footer = styled.div<{ $sticky: boolean; $drawer: boolean }>(
         position: sticky;
         bottom: 0;
         z-index: 1;
-      `
-    }
-
-    ${
-      $drawer &&
-      css`
-        @media (max-width: 768px) {
-          padding: ${theme.space[200]} ${theme.space[300]} ${theme.space[300]};
-        }
       `
     }
   `,

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -43,6 +43,14 @@ export type ModalProps = {
   containerClass?: string
   portalContainer?: Element | DocumentFragment
   closeOnOverlayClick?: boolean
+  /**
+   * Pins the title/close row so it stays visible while the content
+   * scrolls. Recommended whenever content might overflow, especially on
+   * mobile where there's little room to tap outside the modal to dismiss
+   * it.
+   * @default false
+   */
+  stickyHeader?: boolean
 }
 
 export type TitleProps = TextProps
@@ -66,6 +74,7 @@ export const Modal: FC<ModalProps> = ({
   containerClass,
   portalContainer = document.body,
   closeOnOverlayClick = true,
+  stickyHeader = false,
 }) => {
   const modalRef = useRef<HTMLDivElement>(null)
   const theme = useTheme()
@@ -88,11 +97,12 @@ export const Modal: FC<ModalProps> = ({
         $width={width || '460px'}
         className={containerClass}
       >
-        <Box
+        <Header
           flex
           alignItems="flex-start"
           justifyContent="space-between"
-          mb="space.100"
+          $sticky={stickyHeader}
+          $drawer={drawer}
         >
           <TitleElements flex direction="column">
             <Text {...titleProps} />
@@ -118,10 +128,10 @@ export const Modal: FC<ModalProps> = ({
               </IconContainer>
             )}
           </Box>
-        </Box>
-        <Box flex direction="column">
+        </Header>
+        <ContentArea flex direction="column" $drawer={drawer}>
           {children}
-        </Box>
+        </ContentArea>
       </Container>
     </Wrapper>,
     portalContainer,
@@ -156,7 +166,6 @@ const Container = styled.div<IModalContainer>(
     background: ${({ theme }) => theme.color.background[100]};
     box-sizing: border-box;
     border-radius: 16px;
-    padding: ${({ theme }) => theme.space[300]};
     width: 100%;
     max-width: ${$width};
     position: fixed;
@@ -164,20 +173,61 @@ const Container = styled.div<IModalContainer>(
     overflow: auto;
     transition: all 0.3s ease-in-out;
 
-    ${$drawer === true &&
-    css`
-      @media (max-width: 768px) {
-        max-width: none;
-        border-radius: 16px 16px 0px 0px;
-        padding: 10% 24px;
-        max-height: 90vh;
+    ${
+      $drawer === true &&
+      css`
+        @media (max-width: 768px) {
+          max-width: none;
+          border-radius: 16px 16px 0px 0px;
+          max-height: 90vh;
 
-        position: fixed;
-        right: 0;
-        left: 0;
-        bottom: 0;
-      }
-    `}
+          position: fixed;
+          right: 0;
+          left: 0;
+          bottom: 0;
+        }
+      `
+    }
+  `,
+)
+
+const Header = styled(Box)<{ $sticky: boolean; $drawer: boolean }>(
+  ({ $sticky, $drawer, theme }) => css`
+    padding: ${theme.space[300]} ${theme.space[300]} ${theme.space[100]};
+    background: ${theme.color.background[100]};
+
+    ${
+      $sticky &&
+      css`
+        position: sticky;
+        top: 0;
+        z-index: 1;
+      `
+    }
+
+    ${
+      $drawer &&
+      css`
+        @media (max-width: 768px) {
+          padding: 10% ${theme.space[300]} ${theme.space[100]};
+        }
+      `
+    }
+  `,
+)
+
+const ContentArea = styled(Box)<{ $drawer: boolean }>(
+  ({ $drawer, theme }) => css`
+    padding: 0 ${theme.space[300]} ${theme.space[300]};
+
+    ${
+      $drawer &&
+      css`
+        @media (max-width: 768px) {
+          padding: 0 ${theme.space[300]} 10%;
+        }
+      `
+    }
   `,
 )
 

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -92,7 +92,7 @@ export const Modal: FC<ModalProps> = ({
   const titleId = useId()
   const theme = useTheme()
 
-  useBodyScrollLock({ node: containerRef.current, showModal })
+  useBodyScrollLock({ ref: containerRef, showModal })
 
   const latestRef = useRef({ handleClick, closeOnOverlayClick })
   latestRef.current = { handleClick, closeOnOverlayClick }

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -276,7 +276,7 @@ const ScrollArea = styled.div`
 // invariant: their sum must equal the gap between title and content.
 const Header = styled(Box)<{ $sticky: boolean }>(
   ({ $sticky, theme }) => css`
-    padding: ${theme.space[300]} ${theme.space[200]} ${theme.space[300]};
+    padding: ${theme.space[300]} ${theme.space[200]} ${theme.space[200]};
     background: ${theme.color.background[100]};
 
     ${

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -189,6 +189,7 @@ const Container = styled.div<IModalContainer>(
     position: fixed;
     max-height: calc(100vh - 64px);
     overflow: auto;
+    overscroll-behavior-y: contain;
     transition: all 0.3s ease-in-out;
 
     ${

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -295,7 +295,7 @@ const Footer = styled.div<{ $sticky: boolean; $drawer: boolean }>(
       $drawer &&
       css`
         @media (max-width: 768px) {
-          padding: ${theme.space[200]} ${theme.space[300]} 10%;
+          padding: ${theme.space[200]} ${theme.space[300]} ${theme.space[200]};
         }
       `
     }

--- a/src/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Modal/__snapshots__/Modal.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`Modal > renders correctly with a footer 1`] = `
   position: fixed;
   max-height: calc(100vh - 64px);
   overflow: auto;
-  overscroll-behavior-y: contain;
+  overscroll-behavior-y: none;
   transition: all 0.3s ease-in-out;
 }
 
@@ -379,7 +379,7 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
   position: fixed;
   max-height: calc(100vh - 64px);
   overflow: auto;
-  overscroll-behavior-y: contain;
+  overscroll-behavior-y: none;
   transition: all 0.3s ease-in-out;
 }
 
@@ -652,7 +652,7 @@ exports[`Modal > renders correctly with default props 1`] = `
   position: fixed;
   max-height: calc(100vh - 64px);
   overflow: auto;
-  overscroll-behavior-y: contain;
+  overscroll-behavior-y: none;
   transition: all 0.3s ease-in-out;
 }
 
@@ -852,7 +852,7 @@ exports[`Modal > renders correctly with sticky header 1`] = `
   position: fixed;
   max-height: calc(100vh - 64px);
   overflow: auto;
-  overscroll-behavior-y: contain;
+  overscroll-behavior-y: none;
   transition: all 0.3s ease-in-out;
 }
 

--- a/src/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Modal/__snapshots__/Modal.test.tsx.snap
@@ -215,8 +215,8 @@ exports[`Modal > renders correctly with a footer 1`] = `
 }
 
 @media (max-width: 768px) {
-  .c10 {
-    padding: 0 24px 10%;
+  .c11 {
+    padding: 16px 24px 10%;
   }
 }
 
@@ -501,8 +501,8 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
 }
 
 @media (max-width: 768px) {
-  .c10 {
-    padding: 0 24px 10%;
+  .c11 {
+    padding: 16px 24px 10%;
   }
 }
 

--- a/src/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Modal/__snapshots__/Modal.test.tsx.snap
@@ -216,7 +216,7 @@ exports[`Modal > renders correctly with a footer 1`] = `
 
 @media (max-width: 768px) {
   .c11 {
-    padding: 16px 24px 16px;
+    padding: 16px 24px 24px;
   }
 }
 
@@ -502,7 +502,7 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
 
 @media (max-width: 768px) {
   .c11 {
-    padding: 16px 24px 16px;
+    padding: 16px 24px 24px;
   }
 }
 

--- a/src/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Modal/__snapshots__/Modal.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`Modal > renders correctly with a footer 1`] = `
 }
 
 .c5 {
-  padding: 24px 16px 8px;
+  padding: 24px 16px 24px;
   background: #fbf8f5;
 }
 
@@ -400,7 +400,7 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
 }
 
 .c5 {
-  padding: 24px 16px 8px;
+  padding: 24px 16px 24px;
   background: #fbf8f5;
 }
 
@@ -680,7 +680,7 @@ exports[`Modal > renders correctly with default props 1`] = `
 }
 
 .c5 {
-  padding: 24px 16px 8px;
+  padding: 24px 16px 24px;
   background: #fbf8f5;
 }
 
@@ -888,7 +888,7 @@ exports[`Modal > renders correctly with sticky header 1`] = `
 }
 
 .c5 {
-  padding: 24px 16px 8px;
+  padding: 24px 16px 24px;
   background: #fbf8f5;
   position: sticky;
   top: 0;

--- a/src/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Modal/__snapshots__/Modal.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`Modal > renders correctly with a footer 1`] = `
   position: fixed;
   max-height: calc(100vh - 64px);
   overflow: auto;
+  overscroll-behavior-y: contain;
   transition: all 0.3s ease-in-out;
 }
 
@@ -378,6 +379,7 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
   position: fixed;
   max-height: calc(100vh - 64px);
   overflow: auto;
+  overscroll-behavior-y: contain;
   transition: all 0.3s ease-in-out;
 }
 
@@ -650,6 +652,7 @@ exports[`Modal > renders correctly with default props 1`] = `
   position: fixed;
   max-height: calc(100vh - 64px);
   overflow: auto;
+  overscroll-behavior-y: contain;
   transition: all 0.3s ease-in-out;
 }
 
@@ -849,6 +852,7 @@ exports[`Modal > renders correctly with sticky header 1`] = `
   position: fixed;
   max-height: calc(100vh - 64px);
   overflow: auto;
+  overscroll-behavior-y: contain;
   transition: all 0.3s ease-in-out;
 }
 

--- a/src/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Modal/__snapshots__/Modal.test.tsx.snap
@@ -1,5 +1,589 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Modal > renders correctly with a footer 1`] = `
+.c3 {
+  display: flex;
+}
+
+.c5 {
+  display: flex;
+}
+
+.c8 {
+  display: flex;
+}
+
+.c9 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+}
+
+.c9 svg {
+  width: 100%;
+  height: 100%;
+}
+
+.c7 {
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 28px;
+  text-align: left;
+  color: #292924;
+}
+
+.c0 {
+  display: flex;
+  position: absolute;
+  z-index: 999;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+}
+
+.c1 {
+  position: fixed;
+  background: #292924;
+  cursor: pointer;
+  opacity: 0.4;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.c2 {
+  background: #fbf8f5;
+  box-sizing: border-box;
+  border-radius: 16px;
+  width: 100%;
+  max-width: 600px;
+  position: fixed;
+  max-height: calc(100vh - 64px);
+  overflow: auto;
+  transition: all 0.3s ease-in-out;
+}
+
+.c4 {
+  padding: 24px 24px 8px;
+  background: #fbf8f5;
+}
+
+.c10 {
+  padding: 0 24px 24px;
+}
+
+.c11 {
+  display: flex;
+  gap: 8px;
+  padding: 16px 24px 24px;
+  background: #fbf8f5;
+  border-top: 1px solid #dad2c4;
+}
+
+.c11>* {
+  flex: 1;
+}
+
+.c6 {
+  align-self: center;
+}
+
+.c12 {
+  position: relative;
+  background-color: #ff88c8;
+  box-shadow: none;
+  color: #292924;
+  padding: 0 20px;
+  outline: none;
+  border-radius: 10000px;
+  font-weight: 500;
+  cursor: pointer;
+  line-height: 100%;
+  font-size: 16px;
+  opacity: 1;
+  width: auto;
+  background-color: #dad2c4;
+}
+
+.c12:focus-visible {
+  outline: 2px solid #292924;
+  outline-offset: 2px;
+}
+
+.c12:hover {
+  background-color: #beb4a0;
+}
+
+.c12:active {
+  background-color: #9d927b;
+}
+
+.c15 {
+  position: relative;
+  background-color: #ff88c8;
+  box-shadow: none;
+  color: #292924;
+  padding: 0 20px;
+  outline: none;
+  border-radius: 10000px;
+  font-weight: 500;
+  cursor: pointer;
+  line-height: 100%;
+  font-size: 16px;
+  opacity: 1;
+  width: auto;
+}
+
+.c15:focus-visible {
+  outline: 2px solid #292924;
+  outline-offset: 2px;
+}
+
+.c15:hover {
+  background-color: #f759a9;
+}
+
+.c15:active {
+  background-color: #e43e93;
+}
+
+.c13 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 1;
+}
+
+.c14 {
+  padding: 16px 0;
+  flex-grow: 1;
+}
+
+@media (min-width: 0px) {
+  .c3 {
+    justify-content: space-between;
+  }
+}
+
+@media (min-width: 0px) {
+  .c3 {
+    align-items: flex-start;
+  }
+}
+
+@media (min-width: 0px) {
+  .c5 {
+    flex-direction: column;
+  }
+}
+
+@media (min-width: 0px) {
+  .c8 {
+    align-items: center;
+  }
+}
+
+@media (min-width: 0px) {
+  .c8 {
+    gap: 8px;
+  }
+}
+
+@media (max-width: 768px) {
+  .c2 {
+    max-width: none;
+    border-radius: 16px 16px 0px 0px;
+    max-height: 90vh;
+    position: fixed;
+    right: 0;
+    left: 0;
+    bottom: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .c4 {
+    padding: 10% 24px 8px;
+  }
+}
+
+@media (max-width: 768px) {
+  .c10 {
+    padding: 0 24px 10%;
+  }
+}
+
+<body>
+  <div />
+  <div
+    class="c0"
+  >
+    <div
+      class="c1"
+    />
+    <div
+      class="c2"
+    >
+      <div
+        class="c3 c4"
+      >
+        <div
+          class="c5 c6"
+        >
+          <h2
+            class="c7"
+            cursor="inherit"
+            title=""
+          >
+            Modal Title
+          </h2>
+        </div>
+        <div
+          class="c8"
+        >
+          <button
+            class="c9"
+            role="button"
+            style="background: rgb(218, 210, 196); border-radius: 100%; padding: 6px; border: medium; cursor: pointer;"
+            title="Close modal"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-xmark"
+              color="#292924"
+              data-icon="xmark"
+              data-prefix="far"
+              role="img"
+              viewBox="0 0 384 512"
+            >
+              <path
+                d="M7.5 105c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l151 151 151-151c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9l-151 151 151 151c9.4 9.4 9.4 24.6 0 33.9s-24.6 9.4-33.9 0l-151-151-151 151c-9.4 9.4-24.6 9.4-33.9 0s-9.4-24.6 0-33.9l151-151-151-151z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div
+        class="c5 c10"
+      >
+        <div>
+          Modal Content ...
+        </div>
+      </div>
+      <div
+        class="c11"
+      >
+        <button
+          class="c12"
+        >
+          <div
+            class="c13"
+          >
+            <div
+              class="c14 childrenContainer"
+            >
+              Find out more
+            </div>
+          </div>
+        </button>
+        <button
+          class="c15"
+        >
+          <div
+            class="c13"
+          >
+            <div
+              class="c14 childrenContainer"
+            >
+              Got it
+            </div>
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Modal > renders correctly with a sticky footer 1`] = `
+.c3 {
+  display: flex;
+}
+
+.c5 {
+  display: flex;
+}
+
+.c8 {
+  display: flex;
+}
+
+.c9 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+}
+
+.c9 svg {
+  width: 100%;
+  height: 100%;
+}
+
+.c7 {
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 28px;
+  text-align: left;
+  color: #292924;
+}
+
+.c0 {
+  display: flex;
+  position: absolute;
+  z-index: 999;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+}
+
+.c1 {
+  position: fixed;
+  background: #292924;
+  cursor: pointer;
+  opacity: 0.4;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.c2 {
+  background: #fbf8f5;
+  box-sizing: border-box;
+  border-radius: 16px;
+  width: 100%;
+  max-width: 600px;
+  position: fixed;
+  max-height: calc(100vh - 64px);
+  overflow: auto;
+  transition: all 0.3s ease-in-out;
+}
+
+.c4 {
+  padding: 24px 24px 8px;
+  background: #fbf8f5;
+}
+
+.c10 {
+  padding: 0 24px 24px;
+}
+
+.c11 {
+  display: flex;
+  gap: 8px;
+  padding: 16px 24px 24px;
+  background: #fbf8f5;
+  border-top: 1px solid #dad2c4;
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+}
+
+.c11>* {
+  flex: 1;
+}
+
+.c6 {
+  align-self: center;
+}
+
+.c12 {
+  position: relative;
+  background-color: #ff88c8;
+  box-shadow: none;
+  color: #292924;
+  padding: 0 20px;
+  outline: none;
+  border-radius: 10000px;
+  font-weight: 500;
+  cursor: pointer;
+  line-height: 100%;
+  font-size: 16px;
+  opacity: 1;
+  width: auto;
+}
+
+.c12:focus-visible {
+  outline: 2px solid #292924;
+  outline-offset: 2px;
+}
+
+.c12:hover {
+  background-color: #f759a9;
+}
+
+.c12:active {
+  background-color: #e43e93;
+}
+
+.c13 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 1;
+}
+
+.c14 {
+  padding: 16px 0;
+  flex-grow: 1;
+}
+
+@media (min-width: 0px) {
+  .c3 {
+    justify-content: space-between;
+  }
+}
+
+@media (min-width: 0px) {
+  .c3 {
+    align-items: flex-start;
+  }
+}
+
+@media (min-width: 0px) {
+  .c5 {
+    flex-direction: column;
+  }
+}
+
+@media (min-width: 0px) {
+  .c8 {
+    align-items: center;
+  }
+}
+
+@media (min-width: 0px) {
+  .c8 {
+    gap: 8px;
+  }
+}
+
+@media (max-width: 768px) {
+  .c2 {
+    max-width: none;
+    border-radius: 16px 16px 0px 0px;
+    max-height: 90vh;
+    position: fixed;
+    right: 0;
+    left: 0;
+    bottom: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .c4 {
+    padding: 10% 24px 8px;
+  }
+}
+
+@media (max-width: 768px) {
+  .c10 {
+    padding: 0 24px 10%;
+  }
+}
+
+<body>
+  <div />
+  <div
+    class="c0"
+  >
+    <div
+      class="c1"
+    />
+    <div
+      class="c2"
+    >
+      <div
+        class="c3 c4"
+      >
+        <div
+          class="c5 c6"
+        >
+          <h2
+            class="c7"
+            cursor="inherit"
+            title=""
+          >
+            Modal Title
+          </h2>
+        </div>
+        <div
+          class="c8"
+        >
+          <button
+            class="c9"
+            role="button"
+            style="background: rgb(218, 210, 196); border-radius: 100%; padding: 6px; border: medium; cursor: pointer;"
+            title="Close modal"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-xmark"
+              color="#292924"
+              data-icon="xmark"
+              data-prefix="far"
+              role="img"
+              viewBox="0 0 384 512"
+            >
+              <path
+                d="M7.5 105c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l151 151 151-151c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9l-151 151 151 151c9.4 9.4 9.4 24.6 0 33.9s-24.6 9.4-33.9 0l-151-151-151 151c-9.4 9.4-24.6 9.4-33.9 0s-9.4-24.6 0-33.9l151-151-151-151z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div
+        class="c5 c10"
+      >
+        <div>
+          Modal Content ...
+        </div>
+      </div>
+      <div
+        class="c11"
+      >
+        <button
+          class="c12"
+        >
+          <div
+            class="c13"
+          >
+            <div
+              class="c14 childrenContainer"
+            >
+              Got it
+            </div>
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
 exports[`Modal > renders correctly with default props 1`] = `
 .c3 {
   display: flex;

--- a/src/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Modal/__snapshots__/Modal.test.tsx.snap
@@ -67,6 +67,7 @@ exports[`Modal > renders correctly with a footer 1`] = `
   max-height: calc(100vh - 64px);
   overflow: auto;
   overscroll-behavior-y: none;
+  outline: none;
   transition: all 0.3s ease-in-out;
 }
 
@@ -216,7 +217,11 @@ exports[`Modal > renders correctly with a footer 1`] = `
       class="c1"
     />
     <div
+      aria-labelledby="_r_6_"
+      aria-modal="true"
       class="c2"
+      role="dialog"
+      tabindex="-1"
     >
       <div
         class="c3 c4"
@@ -227,6 +232,7 @@ exports[`Modal > renders correctly with a footer 1`] = `
           <h2
             class="c7"
             cursor="inherit"
+            id="_r_6_"
             title=""
           >
             Modal Title
@@ -367,6 +373,7 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
   max-height: calc(100vh - 64px);
   overflow: auto;
   overscroll-behavior-y: none;
+  outline: none;
   transition: all 0.3s ease-in-out;
 }
 
@@ -489,7 +496,11 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
       class="c1"
     />
     <div
+      aria-labelledby="_r_9_"
+      aria-modal="true"
       class="c2"
+      role="dialog"
+      tabindex="-1"
     >
       <div
         class="c3 c4"
@@ -500,6 +511,7 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
           <h2
             class="c7"
             cursor="inherit"
+            id="_r_9_"
             title=""
           >
             Modal Title
@@ -627,6 +639,7 @@ exports[`Modal > renders correctly with default props 1`] = `
   max-height: calc(100vh - 64px);
   overflow: auto;
   overscroll-behavior-y: none;
+  outline: none;
   transition: all 0.3s ease-in-out;
 }
 
@@ -694,7 +707,11 @@ exports[`Modal > renders correctly with default props 1`] = `
       class="c1"
     />
     <div
+      aria-labelledby="_r_0_"
+      aria-modal="true"
       class="c2"
+      role="dialog"
+      tabindex="-1"
     >
       <div
         class="c3 c4"
@@ -705,6 +722,7 @@ exports[`Modal > renders correctly with default props 1`] = `
           <h2
             class="c7"
             cursor="inherit"
+            id="_r_0_"
             title=""
           >
             Modal Title
@@ -815,6 +833,7 @@ exports[`Modal > renders correctly with sticky header 1`] = `
   max-height: calc(100vh - 64px);
   overflow: auto;
   overscroll-behavior-y: none;
+  outline: none;
   transition: all 0.3s ease-in-out;
 }
 
@@ -885,7 +904,11 @@ exports[`Modal > renders correctly with sticky header 1`] = `
       class="c1"
     />
     <div
+      aria-labelledby="_r_3_"
+      aria-modal="true"
       class="c2"
+      role="dialog"
+      tabindex="-1"
     >
       <div
         class="c3 c4"
@@ -896,6 +919,7 @@ exports[`Modal > renders correctly with sticky header 1`] = `
           <h2
             class="c7"
             cursor="inherit"
+            id="_r_3_"
             title=""
           >
             Modal Title

--- a/src/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Modal/__snapshots__/Modal.test.tsx.snap
@@ -71,18 +71,18 @@ exports[`Modal > renders correctly with a footer 1`] = `
 }
 
 .c4 {
-  padding: 24px 24px 8px;
+  padding: 24px 16px 8px;
   background: #fbf8f5;
 }
 
 .c10 {
-  padding: 0 24px 24px;
+  padding: 0 16px 24px;
 }
 
 .c11 {
   display: flex;
   gap: 8px;
-  padding: 16px 24px 24px;
+  padding: 16px 16px 24px;
   background: #fbf8f5;
   border-top: 1px solid #dad2c4;
 }
@@ -205,18 +205,6 @@ exports[`Modal > renders correctly with a footer 1`] = `
     right: 0;
     left: 0;
     bottom: 0;
-  }
-}
-
-@media (max-width: 768px) {
-  .c4 {
-    padding: 10% 24px 8px;
-  }
-}
-
-@media (max-width: 768px) {
-  .c11 {
-    padding: 16px 24px 24px;
   }
 }
 
@@ -384,18 +372,18 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
 }
 
 .c4 {
-  padding: 24px 24px 8px;
+  padding: 24px 16px 8px;
   background: #fbf8f5;
 }
 
 .c10 {
-  padding: 0 24px 24px;
+  padding: 0 16px 24px;
 }
 
 .c11 {
   display: flex;
   gap: 8px;
-  padding: 16px 24px 24px;
+  padding: 16px 16px 24px;
   background: #fbf8f5;
   border-top: 1px solid #dad2c4;
   position: sticky;
@@ -491,18 +479,6 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
     right: 0;
     left: 0;
     bottom: 0;
-  }
-}
-
-@media (max-width: 768px) {
-  .c4 {
-    padding: 10% 24px 8px;
-  }
-}
-
-@media (max-width: 768px) {
-  .c11 {
-    padding: 16px 24px 24px;
   }
 }
 
@@ -657,12 +633,12 @@ exports[`Modal > renders correctly with default props 1`] = `
 }
 
 .c4 {
-  padding: 24px 24px 8px;
+  padding: 24px 16px 8px;
   background: #fbf8f5;
 }
 
 .c10 {
-  padding: 0 24px 24px;
+  padding: 0 16px 24px;
 }
 
 .c6 {
@@ -708,18 +684,6 @@ exports[`Modal > renders correctly with default props 1`] = `
     right: 0;
     left: 0;
     bottom: 0;
-  }
-}
-
-@media (max-width: 768px) {
-  .c4 {
-    padding: 10% 24px 8px;
-  }
-}
-
-@media (max-width: 768px) {
-  .c10 {
-    padding: 0 24px 10%;
   }
 }
 
@@ -857,7 +821,7 @@ exports[`Modal > renders correctly with sticky header 1`] = `
 }
 
 .c4 {
-  padding: 24px 24px 8px;
+  padding: 24px 16px 8px;
   background: #fbf8f5;
   position: sticky;
   top: 0;
@@ -865,7 +829,7 @@ exports[`Modal > renders correctly with sticky header 1`] = `
 }
 
 .c10 {
-  padding: 0 24px 24px;
+  padding: 0 16px 24px;
 }
 
 .c6 {
@@ -911,18 +875,6 @@ exports[`Modal > renders correctly with sticky header 1`] = `
     right: 0;
     left: 0;
     bottom: 0;
-  }
-}
-
-@media (max-width: 768px) {
-  .c4 {
-    padding: 10% 24px 8px;
-  }
-}
-
-@media (max-width: 768px) {
-  .c10 {
-    padding: 0 24px 10%;
   }
 }
 

--- a/src/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Modal/__snapshots__/Modal.test.tsx.snap
@@ -208,7 +208,9 @@ exports[`Modal > renders correctly with a footer 1`] = `
   }
 }
 
-<body>
+<body
+  style="top: 0px; padding-right: 1024px; overflow: hidden;"
+>
   <div />
   <div
     class="c0"
@@ -487,7 +489,9 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
   }
 }
 
-<body>
+<body
+  style="top: 0px; padding-right: 1024px; overflow: hidden;"
+>
   <div />
   <div
     class="c0"
@@ -698,7 +702,9 @@ exports[`Modal > renders correctly with default props 1`] = `
   }
 }
 
-<body>
+<body
+  style="padding-right: 1024px; overflow: hidden; top: 0px;"
+>
   <div />
   <div
     class="c0"
@@ -895,7 +901,9 @@ exports[`Modal > renders correctly with sticky header 1`] = `
   }
 }
 
-<body>
+<body
+  style="top: 0px; padding-right: 1024px; overflow: hidden;"
+>
   <div />
   <div
     class="c0"

--- a/src/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Modal/__snapshots__/Modal.test.tsx.snap
@@ -1,19 +1,19 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Modal > renders correctly with a footer 1`] = `
-.c3 {
+.c4 {
   display: flex;
 }
 
-.c5 {
-  display: flex;
-}
-
-.c8 {
+.c6 {
   display: flex;
 }
 
 .c9 {
+  display: flex;
+}
+
+.c10 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -21,12 +21,12 @@ exports[`Modal > renders correctly with a footer 1`] = `
   height: 32px;
 }
 
-.c9 svg {
+.c10 svg {
   width: 100%;
   height: 100%;
 }
 
-.c7 {
+.c8 {
   font-size: 20px;
   font-weight: 500;
   line-height: 28px;
@@ -58,6 +58,8 @@ exports[`Modal > renders correctly with a footer 1`] = `
 }
 
 .c2 {
+  display: flex;
+  flex-direction: column;
   background: #fbf8f5;
   box-sizing: border-box;
   border-radius: 16px;
@@ -65,37 +67,43 @@ exports[`Modal > renders correctly with a footer 1`] = `
   max-width: 600px;
   position: fixed;
   max-height: calc(100vh - 64px);
-  overflow: auto;
-  overscroll-behavior-y: none;
+  overflow: hidden;
   outline: none;
   transition: all 0.3s ease-in-out;
 }
 
-.c4 {
+.c3 {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior-y: none;
+}
+
+.c5 {
   padding: 24px 16px 8px;
   background: #fbf8f5;
 }
 
-.c10 {
+.c11 {
   padding: 0 16px 0;
 }
 
-.c11 {
+.c12 {
   display: flex;
   gap: 8px;
   padding: 16px 16px 24px;
   background: #fbf8f5;
 }
 
-.c11>* {
+.c12>* {
   flex: 1;
 }
 
-.c6 {
+.c7 {
   align-self: center;
 }
 
-.c12 {
+.c13 {
   position: relative;
   background-color: #ff88c8;
   box-shadow: none;
@@ -112,20 +120,20 @@ exports[`Modal > renders correctly with a footer 1`] = `
   background-color: #dad2c4;
 }
 
-.c12:focus-visible {
+.c13:focus-visible {
   outline: 2px solid #292924;
   outline-offset: 2px;
 }
 
-.c12:hover {
+.c13:hover {
   background-color: #beb4a0;
 }
 
-.c12:active {
+.c13:active {
   background-color: #9d927b;
 }
 
-.c15 {
+.c16 {
   position: relative;
   background-color: #ff88c8;
   box-shadow: none;
@@ -141,57 +149,57 @@ exports[`Modal > renders correctly with a footer 1`] = `
   width: auto;
 }
 
-.c15:focus-visible {
+.c16:focus-visible {
   outline: 2px solid #292924;
   outline-offset: 2px;
 }
 
-.c15:hover {
+.c16:hover {
   background-color: #f759a9;
 }
 
-.c15:active {
+.c16:active {
   background-color: #e43e93;
 }
 
-.c13 {
+.c14 {
   display: flex;
   align-items: center;
   justify-content: center;
   opacity: 1;
 }
 
-.c14 {
+.c15 {
   padding: 16px 0;
   flex-grow: 1;
 }
 
 @media (min-width: 0px) {
-  .c3 {
+  .c4 {
     justify-content: space-between;
   }
 }
 
 @media (min-width: 0px) {
-  .c3 {
+  .c4 {
     align-items: flex-start;
   }
 }
 
 @media (min-width: 0px) {
-  .c5 {
+  .c6 {
     flex-direction: column;
   }
 }
 
 @media (min-width: 0px) {
-  .c8 {
+  .c9 {
     align-items: center;
   }
 }
 
 @media (min-width: 0px) {
-  .c8 {
+  .c9 {
     gap: 8px;
   }
 }
@@ -226,82 +234,86 @@ exports[`Modal > renders correctly with a footer 1`] = `
       tabindex="-1"
     >
       <div
-        class="c3 c4"
+        class="c3"
       >
         <div
-          class="c5 c6"
+          class="c4 c5"
         >
-          <h2
-            class="c7"
-            cursor="inherit"
-            id="_r_6_"
-            title=""
+          <div
+            class="c6 c7"
           >
-            Modal Title
-          </h2>
-        </div>
-        <div
-          class="c8"
-        >
-          <button
-            class="c9"
-            role="button"
-            style="background: rgb(218, 210, 196); border-radius: 100%; padding: 6px; border: medium; cursor: pointer;"
-            title="Close modal"
-          >
-            <svg
-              aria-hidden="true"
-              class="svg-inline--fa fa-xmark"
-              color="#292924"
-              data-icon="xmark"
-              data-prefix="far"
-              role="img"
-              viewBox="0 0 384 512"
+            <h2
+              class="c8"
+              cursor="inherit"
+              id="_r_6_"
+              title=""
             >
-              <path
-                d="M7.5 105c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l151 151 151-151c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9l-151 151 151 151c9.4 9.4 9.4 24.6 0 33.9s-24.6 9.4-33.9 0l-151-151-151 151c-9.4 9.4-24.6 9.4-33.9 0s-9.4-24.6 0-33.9l151-151-151-151z"
-                fill="currentColor"
-              />
-            </svg>
-          </button>
+              Modal Title
+            </h2>
+          </div>
+          <div
+            class="c9"
+          >
+            <button
+              class="c10"
+              role="button"
+              style="background: rgb(218, 210, 196); border-radius: 100%; padding: 6px; border: medium; cursor: pointer;"
+              title="Close modal"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark"
+                color="#292924"
+                data-icon="xmark"
+                data-prefix="far"
+                role="img"
+                viewBox="0 0 384 512"
+              >
+                <path
+                  d="M7.5 105c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l151 151 151-151c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9l-151 151 151 151c9.4 9.4 9.4 24.6 0 33.9s-24.6 9.4-33.9 0l-151-151-151 151c-9.4 9.4-24.6 9.4-33.9 0s-9.4-24.6 0-33.9l151-151-151-151z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
         </div>
-      </div>
-      <div
-        class="c5 c10"
-      >
-        <div>
-          Modal Content ...
+        <div
+          class="c6 c11"
+        >
+          <div>
+            Modal Content ...
+          </div>
         </div>
-      </div>
-      <div
-        class="c11"
-      >
-        <button
+        <div
           class="c12"
         >
-          <div
+          <button
             class="c13"
           >
             <div
-              class="c14 childrenContainer"
+              class="c14"
             >
-              Find out more
+              <div
+                class="c15 childrenContainer"
+              >
+                Find out more
+              </div>
             </div>
-          </div>
-        </button>
-        <button
-          class="c15"
-        >
-          <div
-            class="c13"
+          </button>
+          <button
+            class="c16"
           >
             <div
-              class="c14 childrenContainer"
+              class="c14"
             >
-              Got it
+              <div
+                class="c15 childrenContainer"
+              >
+                Got it
+              </div>
             </div>
-          </div>
-        </button>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -309,19 +321,19 @@ exports[`Modal > renders correctly with a footer 1`] = `
 `;
 
 exports[`Modal > renders correctly with a sticky footer 1`] = `
-.c3 {
+.c4 {
   display: flex;
 }
 
-.c5 {
-  display: flex;
-}
-
-.c8 {
+.c6 {
   display: flex;
 }
 
 .c9 {
+  display: flex;
+}
+
+.c10 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -329,12 +341,12 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
   height: 32px;
 }
 
-.c9 svg {
+.c10 svg {
   width: 100%;
   height: 100%;
 }
 
-.c7 {
+.c8 {
   font-size: 20px;
   font-weight: 500;
   line-height: 28px;
@@ -366,6 +378,8 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
 }
 
 .c2 {
+  display: flex;
+  flex-direction: column;
   background: #fbf8f5;
   box-sizing: border-box;
   border-radius: 16px;
@@ -373,22 +387,28 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
   max-width: 600px;
   position: fixed;
   max-height: calc(100vh - 64px);
-  overflow: auto;
-  overscroll-behavior-y: none;
+  overflow: hidden;
   outline: none;
   transition: all 0.3s ease-in-out;
 }
 
-.c4 {
+.c3 {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior-y: none;
+}
+
+.c5 {
   padding: 24px 16px 8px;
   background: #fbf8f5;
 }
 
-.c10 {
+.c11 {
   padding: 0 16px 0;
 }
 
-.c11 {
+.c12 {
   display: flex;
   gap: 8px;
   padding: 16px 16px 24px;
@@ -398,15 +418,15 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
   z-index: 1;
 }
 
-.c11>* {
+.c12>* {
   flex: 1;
 }
 
-.c6 {
+.c7 {
   align-self: center;
 }
 
-.c12 {
+.c13 {
   position: relative;
   background-color: #ff88c8;
   box-shadow: none;
@@ -422,57 +442,57 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
   width: auto;
 }
 
-.c12:focus-visible {
+.c13:focus-visible {
   outline: 2px solid #292924;
   outline-offset: 2px;
 }
 
-.c12:hover {
+.c13:hover {
   background-color: #f759a9;
 }
 
-.c12:active {
+.c13:active {
   background-color: #e43e93;
 }
 
-.c13 {
+.c14 {
   display: flex;
   align-items: center;
   justify-content: center;
   opacity: 1;
 }
 
-.c14 {
+.c15 {
   padding: 16px 0;
   flex-grow: 1;
 }
 
 @media (min-width: 0px) {
-  .c3 {
+  .c4 {
     justify-content: space-between;
   }
 }
 
 @media (min-width: 0px) {
-  .c3 {
+  .c4 {
     align-items: flex-start;
   }
 }
 
 @media (min-width: 0px) {
-  .c5 {
+  .c6 {
     flex-direction: column;
   }
 }
 
 @media (min-width: 0px) {
-  .c8 {
+  .c9 {
     align-items: center;
   }
 }
 
 @media (min-width: 0px) {
-  .c8 {
+  .c9 {
     gap: 8px;
   }
 }
@@ -507,69 +527,73 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
       tabindex="-1"
     >
       <div
-        class="c3 c4"
+        class="c3"
       >
         <div
-          class="c5 c6"
-        >
-          <h2
-            class="c7"
-            cursor="inherit"
-            id="_r_9_"
-            title=""
-          >
-            Modal Title
-          </h2>
-        </div>
-        <div
-          class="c8"
-        >
-          <button
-            class="c9"
-            role="button"
-            style="background: rgb(218, 210, 196); border-radius: 100%; padding: 6px; border: medium; cursor: pointer;"
-            title="Close modal"
-          >
-            <svg
-              aria-hidden="true"
-              class="svg-inline--fa fa-xmark"
-              color="#292924"
-              data-icon="xmark"
-              data-prefix="far"
-              role="img"
-              viewBox="0 0 384 512"
-            >
-              <path
-                d="M7.5 105c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l151 151 151-151c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9l-151 151 151 151c9.4 9.4 9.4 24.6 0 33.9s-24.6 9.4-33.9 0l-151-151-151 151c-9.4 9.4-24.6 9.4-33.9 0s-9.4-24.6 0-33.9l151-151-151-151z"
-                fill="currentColor"
-              />
-            </svg>
-          </button>
-        </div>
-      </div>
-      <div
-        class="c5 c10"
-      >
-        <div>
-          Modal Content ...
-        </div>
-      </div>
-      <div
-        class="c11"
-      >
-        <button
-          class="c12"
+          class="c4 c5"
         >
           <div
+            class="c6 c7"
+          >
+            <h2
+              class="c8"
+              cursor="inherit"
+              id="_r_9_"
+              title=""
+            >
+              Modal Title
+            </h2>
+          </div>
+          <div
+            class="c9"
+          >
+            <button
+              class="c10"
+              role="button"
+              style="background: rgb(218, 210, 196); border-radius: 100%; padding: 6px; border: medium; cursor: pointer;"
+              title="Close modal"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark"
+                color="#292924"
+                data-icon="xmark"
+                data-prefix="far"
+                role="img"
+                viewBox="0 0 384 512"
+              >
+                <path
+                  d="M7.5 105c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l151 151 151-151c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9l-151 151 151 151c9.4 9.4 9.4 24.6 0 33.9s-24.6 9.4-33.9 0l-151-151-151 151c-9.4 9.4-24.6 9.4-33.9 0s-9.4-24.6 0-33.9l151-151-151-151z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="c6 c11"
+        >
+          <div>
+            Modal Content ...
+          </div>
+        </div>
+        <div
+          class="c12"
+        >
+          <button
             class="c13"
           >
             <div
-              class="c14 childrenContainer"
+              class="c14"
             >
-              Got it
+              <div
+                class="c15 childrenContainer"
+              >
+                Got it
+              </div>
             </div>
-          </div>
-        </button>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -577,19 +601,19 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
 `;
 
 exports[`Modal > renders correctly with default props 1`] = `
-.c3 {
+.c4 {
   display: flex;
 }
 
-.c5 {
-  display: flex;
-}
-
-.c8 {
+.c6 {
   display: flex;
 }
 
 .c9 {
+  display: flex;
+}
+
+.c10 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -597,12 +621,12 @@ exports[`Modal > renders correctly with default props 1`] = `
   height: 32px;
 }
 
-.c9 svg {
+.c10 svg {
   width: 100%;
   height: 100%;
 }
 
-.c7 {
+.c8 {
   font-size: 20px;
   font-weight: 500;
   line-height: 28px;
@@ -634,6 +658,8 @@ exports[`Modal > renders correctly with default props 1`] = `
 }
 
 .c2 {
+  display: flex;
+  flex-direction: column;
   background: #fbf8f5;
   box-sizing: border-box;
   border-radius: 16px;
@@ -641,51 +667,57 @@ exports[`Modal > renders correctly with default props 1`] = `
   max-width: 600px;
   position: fixed;
   max-height: calc(100vh - 64px);
-  overflow: auto;
-  overscroll-behavior-y: none;
+  overflow: hidden;
   outline: none;
   transition: all 0.3s ease-in-out;
 }
 
-.c4 {
+.c3 {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior-y: none;
+}
+
+.c5 {
   padding: 24px 16px 8px;
   background: #fbf8f5;
 }
 
-.c10 {
+.c11 {
   padding: 0 16px 24px;
 }
 
-.c6 {
+.c7 {
   align-self: center;
 }
 
 @media (min-width: 0px) {
-  .c3 {
+  .c4 {
     justify-content: space-between;
   }
 }
 
 @media (min-width: 0px) {
-  .c3 {
+  .c4 {
     align-items: flex-start;
   }
 }
 
 @media (min-width: 0px) {
-  .c5 {
+  .c6 {
     flex-direction: column;
   }
 }
 
 @media (min-width: 0px) {
-  .c8 {
+  .c9 {
     align-items: center;
   }
 }
 
 @media (min-width: 0px) {
-  .c8 {
+  .c9 {
     gap: 8px;
   }
 }
@@ -720,51 +752,55 @@ exports[`Modal > renders correctly with default props 1`] = `
       tabindex="-1"
     >
       <div
-        class="c3 c4"
+        class="c3"
       >
         <div
-          class="c5 c6"
+          class="c4 c5"
         >
-          <h2
-            class="c7"
-            cursor="inherit"
-            id="_r_0_"
-            title=""
+          <div
+            class="c6 c7"
           >
-            Modal Title
-          </h2>
-        </div>
-        <div
-          class="c8"
-        >
-          <button
-            class="c9"
-            role="button"
-            style="background: rgb(218, 210, 196); border-radius: 100%; padding: 6px; border: medium; cursor: pointer;"
-            title="Close modal"
-          >
-            <svg
-              aria-hidden="true"
-              class="svg-inline--fa fa-xmark"
-              color="#292924"
-              data-icon="xmark"
-              data-prefix="far"
-              role="img"
-              viewBox="0 0 384 512"
+            <h2
+              class="c8"
+              cursor="inherit"
+              id="_r_0_"
+              title=""
             >
-              <path
-                d="M7.5 105c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l151 151 151-151c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9l-151 151 151 151c9.4 9.4 9.4 24.6 0 33.9s-24.6 9.4-33.9 0l-151-151-151 151c-9.4 9.4-24.6 9.4-33.9 0s-9.4-24.6 0-33.9l151-151-151-151z"
-                fill="currentColor"
-              />
-            </svg>
-          </button>
+              Modal Title
+            </h2>
+          </div>
+          <div
+            class="c9"
+          >
+            <button
+              class="c10"
+              role="button"
+              style="background: rgb(218, 210, 196); border-radius: 100%; padding: 6px; border: medium; cursor: pointer;"
+              title="Close modal"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark"
+                color="#292924"
+                data-icon="xmark"
+                data-prefix="far"
+                role="img"
+                viewBox="0 0 384 512"
+              >
+                <path
+                  d="M7.5 105c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l151 151 151-151c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9l-151 151 151 151c9.4 9.4 9.4 24.6 0 33.9s-24.6 9.4-33.9 0l-151-151-151 151c-9.4 9.4-24.6 9.4-33.9 0s-9.4-24.6 0-33.9l151-151-151-151z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
         </div>
-      </div>
-      <div
-        class="c5 c10"
-      >
-        <div>
-          Modal Content ...
+        <div
+          class="c6 c11"
+        >
+          <div>
+            Modal Content ...
+          </div>
         </div>
       </div>
     </div>
@@ -773,19 +809,19 @@ exports[`Modal > renders correctly with default props 1`] = `
 `;
 
 exports[`Modal > renders correctly with sticky header 1`] = `
-.c3 {
+.c4 {
   display: flex;
 }
 
-.c5 {
-  display: flex;
-}
-
-.c8 {
+.c6 {
   display: flex;
 }
 
 .c9 {
+  display: flex;
+}
+
+.c10 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -793,12 +829,12 @@ exports[`Modal > renders correctly with sticky header 1`] = `
   height: 32px;
 }
 
-.c9 svg {
+.c10 svg {
   width: 100%;
   height: 100%;
 }
 
-.c7 {
+.c8 {
   font-size: 20px;
   font-weight: 500;
   line-height: 28px;
@@ -830,6 +866,8 @@ exports[`Modal > renders correctly with sticky header 1`] = `
 }
 
 .c2 {
+  display: flex;
+  flex-direction: column;
   background: #fbf8f5;
   box-sizing: border-box;
   border-radius: 16px;
@@ -837,13 +875,19 @@ exports[`Modal > renders correctly with sticky header 1`] = `
   max-width: 600px;
   position: fixed;
   max-height: calc(100vh - 64px);
-  overflow: auto;
-  overscroll-behavior-y: none;
+  overflow: hidden;
   outline: none;
   transition: all 0.3s ease-in-out;
 }
 
-.c4 {
+.c3 {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior-y: none;
+}
+
+.c5 {
   padding: 24px 16px 8px;
   background: #fbf8f5;
   position: sticky;
@@ -851,40 +895,40 @@ exports[`Modal > renders correctly with sticky header 1`] = `
   z-index: 1;
 }
 
-.c10 {
+.c11 {
   padding: 0 16px 24px;
 }
 
-.c6 {
+.c7 {
   align-self: center;
 }
 
 @media (min-width: 0px) {
-  .c3 {
+  .c4 {
     justify-content: space-between;
   }
 }
 
 @media (min-width: 0px) {
-  .c3 {
+  .c4 {
     align-items: flex-start;
   }
 }
 
 @media (min-width: 0px) {
-  .c5 {
+  .c6 {
     flex-direction: column;
   }
 }
 
 @media (min-width: 0px) {
-  .c8 {
+  .c9 {
     align-items: center;
   }
 }
 
 @media (min-width: 0px) {
-  .c8 {
+  .c9 {
     gap: 8px;
   }
 }
@@ -919,51 +963,55 @@ exports[`Modal > renders correctly with sticky header 1`] = `
       tabindex="-1"
     >
       <div
-        class="c3 c4"
+        class="c3"
       >
         <div
-          class="c5 c6"
+          class="c4 c5"
         >
-          <h2
-            class="c7"
-            cursor="inherit"
-            id="_r_3_"
-            title=""
+          <div
+            class="c6 c7"
           >
-            Modal Title
-          </h2>
-        </div>
-        <div
-          class="c8"
-        >
-          <button
-            class="c9"
-            role="button"
-            style="background: rgb(218, 210, 196); border-radius: 100%; padding: 6px; border: medium; cursor: pointer;"
-            title="Close modal"
-          >
-            <svg
-              aria-hidden="true"
-              class="svg-inline--fa fa-xmark"
-              color="#292924"
-              data-icon="xmark"
-              data-prefix="far"
-              role="img"
-              viewBox="0 0 384 512"
+            <h2
+              class="c8"
+              cursor="inherit"
+              id="_r_3_"
+              title=""
             >
-              <path
-                d="M7.5 105c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l151 151 151-151c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9l-151 151 151 151c9.4 9.4 9.4 24.6 0 33.9s-24.6 9.4-33.9 0l-151-151-151 151c-9.4 9.4-24.6 9.4-33.9 0s-9.4-24.6 0-33.9l151-151-151-151z"
-                fill="currentColor"
-              />
-            </svg>
-          </button>
+              Modal Title
+            </h2>
+          </div>
+          <div
+            class="c9"
+          >
+            <button
+              class="c10"
+              role="button"
+              style="background: rgb(218, 210, 196); border-radius: 100%; padding: 6px; border: medium; cursor: pointer;"
+              title="Close modal"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark"
+                color="#292924"
+                data-icon="xmark"
+                data-prefix="far"
+                role="img"
+                viewBox="0 0 384 512"
+              >
+                <path
+                  d="M7.5 105c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l151 151 151-151c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9l-151 151 151 151c9.4 9.4 9.4 24.6 0 33.9s-24.6 9.4-33.9 0l-151-151-151 151c-9.4 9.4-24.6 9.4-33.9 0s-9.4-24.6 0-33.9l151-151-151-151z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
         </div>
-      </div>
-      <div
-        class="c5 c10"
-      >
-        <div>
-          Modal Content ...
+        <div
+          class="c6 c11"
+        >
+          <div>
+            Modal Content ...
+          </div>
         </div>
       </div>
     </div>

--- a/src/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Modal/__snapshots__/Modal.test.tsx.snap
@@ -5,15 +5,15 @@ exports[`Modal > renders correctly with default props 1`] = `
   display: flex;
 }
 
-.c4 {
-  display: flex;
-}
-
-.c7 {
+.c5 {
   display: flex;
 }
 
 .c8 {
+  display: flex;
+}
+
+.c9 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -21,12 +21,12 @@ exports[`Modal > renders correctly with default props 1`] = `
   height: 32px;
 }
 
-.c8 svg {
+.c9 svg {
   width: 100%;
   height: 100%;
 }
 
-.c6 {
+.c7 {
   font-size: 20px;
   font-weight: 500;
   line-height: 28px;
@@ -61,7 +61,6 @@ exports[`Modal > renders correctly with default props 1`] = `
   background: #fbf8f5;
   box-sizing: border-box;
   border-radius: 16px;
-  padding: 24px;
   width: 100%;
   max-width: 600px;
   position: fixed;
@@ -70,14 +69,17 @@ exports[`Modal > renders correctly with default props 1`] = `
   transition: all 0.3s ease-in-out;
 }
 
-.c5 {
-  align-self: center;
+.c4 {
+  padding: 24px 24px 8px;
+  background: #fbf8f5;
 }
 
-@media (min-width: 0px) {
-  .c3 {
-    margin-bottom: 8px;
-  }
+.c10 {
+  padding: 0 24px 24px;
+}
+
+.c6 {
+  align-self: center;
 }
 
 @media (min-width: 0px) {
@@ -93,19 +95,19 @@ exports[`Modal > renders correctly with default props 1`] = `
 }
 
 @media (min-width: 0px) {
-  .c4 {
+  .c5 {
     flex-direction: column;
   }
 }
 
 @media (min-width: 0px) {
-  .c7 {
+  .c8 {
     align-items: center;
   }
 }
 
 @media (min-width: 0px) {
-  .c7 {
+  .c8 {
     gap: 8px;
   }
 }
@@ -114,12 +116,23 @@ exports[`Modal > renders correctly with default props 1`] = `
   .c2 {
     max-width: none;
     border-radius: 16px 16px 0px 0px;
-    padding: 10% 24px;
     max-height: 90vh;
     position: fixed;
     right: 0;
     left: 0;
     bottom: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .c4 {
+    padding: 10% 24px 8px;
+  }
+}
+
+@media (max-width: 768px) {
+  .c10 {
+    padding: 0 24px 10%;
   }
 }
 
@@ -135,13 +148,13 @@ exports[`Modal > renders correctly with default props 1`] = `
       class="c2"
     >
       <div
-        class="c3"
+        class="c3 c4"
       >
         <div
-          class="c4 c5"
+          class="c5 c6"
         >
           <h2
-            class="c6"
+            class="c7"
             cursor="inherit"
             title=""
           >
@@ -149,10 +162,10 @@ exports[`Modal > renders correctly with default props 1`] = `
           </h2>
         </div>
         <div
-          class="c7"
+          class="c8"
         >
           <button
-            class="c8"
+            class="c9"
             role="button"
             style="background: rgb(218, 210, 196); border-radius: 100%; padding: 6px; border: medium; cursor: pointer;"
             title="Close modal"
@@ -175,7 +188,209 @@ exports[`Modal > renders correctly with default props 1`] = `
         </div>
       </div>
       <div
-        class="c4"
+        class="c5 c10"
+      >
+        <div>
+          Modal Content ...
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Modal > renders correctly with sticky header 1`] = `
+.c3 {
+  display: flex;
+}
+
+.c5 {
+  display: flex;
+}
+
+.c8 {
+  display: flex;
+}
+
+.c9 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+}
+
+.c9 svg {
+  width: 100%;
+  height: 100%;
+}
+
+.c7 {
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 28px;
+  text-align: left;
+  color: #292924;
+}
+
+.c0 {
+  display: flex;
+  position: absolute;
+  z-index: 999;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+}
+
+.c1 {
+  position: fixed;
+  background: #292924;
+  cursor: pointer;
+  opacity: 0.4;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.c2 {
+  background: #fbf8f5;
+  box-sizing: border-box;
+  border-radius: 16px;
+  width: 100%;
+  max-width: 600px;
+  position: fixed;
+  max-height: calc(100vh - 64px);
+  overflow: auto;
+  transition: all 0.3s ease-in-out;
+}
+
+.c4 {
+  padding: 24px 24px 8px;
+  background: #fbf8f5;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.c10 {
+  padding: 0 24px 24px;
+}
+
+.c6 {
+  align-self: center;
+}
+
+@media (min-width: 0px) {
+  .c3 {
+    justify-content: space-between;
+  }
+}
+
+@media (min-width: 0px) {
+  .c3 {
+    align-items: flex-start;
+  }
+}
+
+@media (min-width: 0px) {
+  .c5 {
+    flex-direction: column;
+  }
+}
+
+@media (min-width: 0px) {
+  .c8 {
+    align-items: center;
+  }
+}
+
+@media (min-width: 0px) {
+  .c8 {
+    gap: 8px;
+  }
+}
+
+@media (max-width: 768px) {
+  .c2 {
+    max-width: none;
+    border-radius: 16px 16px 0px 0px;
+    max-height: 90vh;
+    position: fixed;
+    right: 0;
+    left: 0;
+    bottom: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .c4 {
+    padding: 10% 24px 8px;
+  }
+}
+
+@media (max-width: 768px) {
+  .c10 {
+    padding: 0 24px 10%;
+  }
+}
+
+<body>
+  <div />
+  <div
+    class="c0"
+  >
+    <div
+      class="c1"
+    />
+    <div
+      class="c2"
+    >
+      <div
+        class="c3 c4"
+      >
+        <div
+          class="c5 c6"
+        >
+          <h2
+            class="c7"
+            cursor="inherit"
+            title=""
+          >
+            Modal Title
+          </h2>
+        </div>
+        <div
+          class="c8"
+        >
+          <button
+            class="c9"
+            role="button"
+            style="background: rgb(218, 210, 196); border-radius: 100%; padding: 6px; border: medium; cursor: pointer;"
+            title="Close modal"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-xmark"
+              color="#292924"
+              data-icon="xmark"
+              data-prefix="far"
+              role="img"
+              viewBox="0 0 384 512"
+            >
+              <path
+                d="M7.5 105c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l151 151 151-151c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9l-151 151 151 151c9.4 9.4 9.4 24.6 0 33.9s-24.6 9.4-33.9 0l-151-151-151 151c-9.4 9.4-24.6 9.4-33.9 0s-9.4-24.6 0-33.9l151-151-151-151z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div
+        class="c5 c10"
       >
         <div>
           Modal Content ...

--- a/src/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Modal/__snapshots__/Modal.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`Modal > renders correctly with a footer 1`] = `
 .c12 {
   display: flex;
   gap: 8px;
-  padding: 16px 16px 24px;
+  padding: 24px 16px 24px;
   background: #fbf8f5;
 }
 
@@ -411,7 +411,7 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
 .c12 {
   display: flex;
   gap: 8px;
-  padding: 16px 16px 24px;
+  padding: 24px 16px 24px;
   background: #fbf8f5;
   position: sticky;
   bottom: 0;

--- a/src/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Modal/__snapshots__/Modal.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`Modal > renders correctly with a footer 1`] = `
 }
 
 .c10 {
-  padding: 0 16px 24px;
+  padding: 0 16px 0;
 }
 
 .c11 {
@@ -84,7 +84,6 @@ exports[`Modal > renders correctly with a footer 1`] = `
   gap: 8px;
   padding: 16px 16px 24px;
   background: #fbf8f5;
-  border-top: 1px solid #dad2c4;
 }
 
 .c11>* {
@@ -377,7 +376,7 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
 }
 
 .c10 {
-  padding: 0 16px 24px;
+  padding: 0 16px 0;
 }
 
 .c11 {
@@ -385,7 +384,6 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
   gap: 8px;
   padding: 16px 16px 24px;
   background: #fbf8f5;
-  border-top: 1px solid #dad2c4;
   position: sticky;
   bottom: 0;
   z-index: 1;

--- a/src/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Modal/__snapshots__/Modal.test.tsx.snap
@@ -216,7 +216,7 @@ exports[`Modal > renders correctly with a footer 1`] = `
 
 @media (max-width: 768px) {
   .c11 {
-    padding: 16px 24px 10%;
+    padding: 16px 24px 16px;
   }
 }
 
@@ -502,7 +502,7 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
 
 @media (max-width: 768px) {
   .c11 {
-    padding: 16px 24px 10%;
+    padding: 16px 24px 16px;
   }
 }
 

--- a/src/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Modal/__snapshots__/Modal.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`Modal > renders correctly with a footer 1`] = `
 }
 
 .c5 {
-  padding: 24px 16px 24px;
+  padding: 24px 16px 16px;
   background: #fbf8f5;
 }
 
@@ -400,7 +400,7 @@ exports[`Modal > renders correctly with a sticky footer 1`] = `
 }
 
 .c5 {
-  padding: 24px 16px 24px;
+  padding: 24px 16px 16px;
   background: #fbf8f5;
 }
 
@@ -680,7 +680,7 @@ exports[`Modal > renders correctly with default props 1`] = `
 }
 
 .c5 {
-  padding: 24px 16px 24px;
+  padding: 24px 16px 16px;
   background: #fbf8f5;
 }
 
@@ -888,7 +888,7 @@ exports[`Modal > renders correctly with sticky header 1`] = `
 }
 
 .c5 {
-  padding: 24px 16px 24px;
+  padding: 24px 16px 16px;
   background: #fbf8f5;
   position: sticky;
   top: 0;

--- a/src/Modal/storybook/Modal.mdx
+++ b/src/Modal/storybook/Modal.mdx
@@ -55,6 +55,13 @@ scroll content outside of the modal, such as the page behind it —
 
 <Canvas of={ModalStories.StickyHeader} />
 
+### Non-sticky footer
+
+Without `stickyFooter`, `footer` scrolls away with the rest of the
+content — compare against the sticky version below.
+
+<Canvas of={ModalStories.NonStickyFooter} />
+
 ### Sticky footer
 
 <Canvas of={ModalStories.StickyFooter} />

--- a/src/Modal/storybook/Modal.mdx
+++ b/src/Modal/storybook/Modal.mdx
@@ -90,12 +90,14 @@ outside the modal to dismiss it.
 
 ## Content guidelines
 
-**Title**
+### Title
+
 - Should be a single, short sentence or question.
 - Can wrap to a second line if necessary.
 - Avoid apologies, extra alarm, or ambiguity.
 
-**Buttons**
+### Buttons
+
 - Describe the action in as few words as possible — ideally one or two.
 - Should summarise the purpose of the modal — if a user skips the title
   and content, the button copy alone should tell them what they're

--- a/src/Modal/storybook/Modal.mdx
+++ b/src/Modal/storybook/Modal.mdx
@@ -1,0 +1,107 @@
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks'
+import * as ModalStories from './Modal.stories'
+
+<Meta of={ModalStories} />
+
+# Modal
+
+Modals are purposefully interruptive. A modal appears in front of content
+to provide critical information or ask for a decision. Modals disable all
+other functionality when they appear, and remain on screen until
+confirmed, dismissed, or a required action has been taken.
+
+<Canvas of={ModalStories.Default} />
+
+## When to use
+
+Use a modal:
+
+- If you want to interrupt the customer's flow.
+- If you want to confirm high-risk actions, like deleting progress.
+- If you want to gather more information and/or additional actions that
+  are relevant to the current task.
+
+Don't use a modal:
+
+- If you can display the content in a less intrusive way within a
+  screen, as part of the main flow.
+- If you want users to interact with the content beneath the modal.
+- For low or medium priority information.
+
+## Types
+
+### Basic content modal
+
+Plain text content, with or without a footer.
+
+<Canvas of={ModalStories.BasicContentModal} />
+
+### Custom content modal
+
+Any React content — images, illustrations, forms, or other components.
+
+<Canvas of={ModalStories.CustomContentModal} />
+
+## Behaviour & interaction
+
+Most modals should avoid scrolling. Even when scrolling is required, the
+title should stay pinned at the top and the buttons pinned at the bottom
+— via the `stickyHeader` and `stickyFooter` props — so the title and
+actions remain visible alongside the content, even upon scroll. Never
+scroll content outside of the modal, such as the page behind it —
+`Modal` already locks background scroll for you.
+
+### Sticky header
+
+<Canvas of={ModalStories.StickyHeader} />
+
+### Sticky footer
+
+<Canvas of={ModalStories.StickyFooter} />
+
+### Sticky header and footer
+
+The recommended combination for any modal with scrollable content.
+
+<Canvas of={ModalStories.StickyHeaderAndFooter} />
+
+### Mobile (drawer)
+
+On narrow viewports, `drawer` (on by default) turns the modal into a
+bottom sheet. Combine it with `stickyHeader`/`stickyFooter` so the title
+and actions stay reachable even though there's little room to tap
+outside the modal to dismiss it.
+
+<Canvas of={ModalStories.MobileDrawer} />
+
+## Anatomy
+
+1. **Title** — a single, short sentence or question. It can wrap to a
+   second line if necessary. Avoid apologies ("Sorry for the
+   interruption"), extra alarm ("Warning!"), or ambiguity ("Are you
+   sure?").
+2. **Close icon** — optional; used when there's no primary button in the
+   footer (pass `cross={false}` to hide it).
+3. **Content** — can be plain text (basic) or any custom React content.
+4. **Buttons** — one, two, or none. The confirming/primary action is
+   always closest to the edge (the last child of `footer`).
+
+<Canvas of={ModalStories.TwoButtonFooter} />
+
+## Content guidelines
+
+**Title**
+- Should be a single, short sentence or question.
+- Can wrap to a second line if necessary.
+- Avoid apologies, extra alarm, or ambiguity.
+
+**Buttons**
+- Describe the action in as few words as possible — ideally one or two.
+- Should summarise the purpose of the modal — if a user skips the title
+  and content, the button copy alone should tell them what they're
+  about to do.
+- Start with a strong, imperative verb, like "Pay", "Send", or "Log in".
+
+## Props
+
+<Controls />

--- a/src/Modal/storybook/Modal.mdx
+++ b/src/Modal/storybook/Modal.mdx
@@ -86,6 +86,8 @@ outside the modal to dismiss it.
 4. **Buttons** — one, two, or none. The confirming/primary action is
    always closest to the edge (the last child of `footer`).
 
+<Canvas of={ModalStories.SingleButtonFooter} />
+
 <Canvas of={ModalStories.TwoButtonFooter} />
 
 ## Content guidelines

--- a/src/Modal/storybook/Modal.stories.tsx
+++ b/src/Modal/storybook/Modal.stories.tsx
@@ -3,7 +3,9 @@ import { FC, useState } from 'react'
 import styled from 'styled-components'
 import { Box } from '../../Box'
 import { Button } from '../../Button'
+import { Text } from '../../Text'
 import { Modal, ModalProps } from '../Modal'
+import { noop } from '../../utils/noop'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowsMaximize } from '@awesome.me/kit-46ca99185c/icons/classic/regular'
 
@@ -31,9 +33,34 @@ const Container: FC<ModalProps> = (props) => {
   )
 }
 
+const LongContent = () => (
+  <Box flex direction="column" gap="space.200">
+    {Array.from({ length: 12 }).map((_, index) => (
+      <Text key={index}>
+        Paragraph {index + 1}: No Claims Discount (NCD) is the UK system that
+        recognises claim-free drivers by giving them a discount. So the more
+        years you drive without making a claim, the bigger your discount will
+        be.
+      </Text>
+    ))}
+  </Box>
+)
+
+const TwoButtonFooterContent = (
+  <>
+    <Button secondary handleClick={noop}>
+      Find out more
+    </Button>
+    <Button primary handleClick={noop}>
+      Got it
+    </Button>
+  </>
+)
+
 const meta: Meta<typeof Modal> = {
   title: 'Modal',
   component: Modal,
+  tags: ['!autodocs'],
   argTypes: {
     rightPanel: {
       description:
@@ -103,4 +130,139 @@ export const Interactive: Story = {
       </Container>
     )
   },
+}
+
+export const BasicContentModal: Story = {
+  args: {
+    title: 'Title of content',
+    showModal: false,
+  },
+  render: (args) => (
+    <Container {...args}>
+      <Text>
+        No Claims Discount (NCD) is the UK system that recognises claim-free
+        drivers by giving them a discount. So the more years you drive without
+        making a claim, the bigger your discount will be.
+      </Text>
+    </Container>
+  ),
+}
+
+export const CustomContentModal: Story = {
+  args: {
+    title: 'Title of content',
+    showModal: false,
+  },
+  render: (args) => (
+    <Container {...args}>
+      <Box flex direction="column" gap="space.200">
+        <Box
+          style={{
+            height: '160px',
+            borderRadius: '12px',
+            background: '#EDE7DE',
+          }}
+        />
+        <Text>
+          No Claims Discount (NCD) is the UK system that recognises claim-free
+          drivers by giving them a discount. Outside the UK, this system is
+          often called Bonus Malus. And we accept them all!
+        </Text>
+      </Box>
+    </Container>
+  ),
+}
+
+export const SingleButtonFooter: Story = {
+  args: {
+    title: 'Title of content',
+    showModal: false,
+    footer: (
+      <Button primary handleClick={noop}>
+        Got it
+      </Button>
+    ),
+  },
+  render: (args) => (
+    <Container {...args}>
+      <Text>
+        No Claims Discount (NCD) is the UK system that recognises claim-free
+        drivers by giving them a discount.
+      </Text>
+    </Container>
+  ),
+}
+
+export const TwoButtonFooter: Story = {
+  args: {
+    title: 'Title of content',
+    showModal: false,
+    footer: TwoButtonFooterContent,
+  },
+  render: (args) => (
+    <Container {...args}>
+      <Text>
+        No Claims Discount (NCD) is the UK system that recognises claim-free
+        drivers by giving them a discount.
+      </Text>
+    </Container>
+  ),
+}
+
+export const StickyHeader: Story = {
+  args: {
+    title: 'Title of content',
+    showModal: false,
+    stickyHeader: true,
+  },
+  render: (args) => (
+    <Container {...args}>
+      <LongContent />
+    </Container>
+  ),
+}
+
+export const StickyFooter: Story = {
+  args: {
+    title: 'Title of content',
+    showModal: false,
+    stickyFooter: true,
+    footer: TwoButtonFooterContent,
+  },
+  render: (args) => (
+    <Container {...args}>
+      <LongContent />
+    </Container>
+  ),
+}
+
+export const StickyHeaderAndFooter: Story = {
+  args: {
+    title: 'Title of content',
+    showModal: false,
+    stickyHeader: true,
+    stickyFooter: true,
+    footer: TwoButtonFooterContent,
+  },
+  render: (args) => (
+    <Container {...args}>
+      <LongContent />
+    </Container>
+  ),
+}
+
+export const MobileDrawer: Story = {
+  args: {
+    title: 'Title of content',
+    showModal: false,
+    drawer: true,
+    stickyHeader: true,
+    stickyFooter: true,
+    footer: TwoButtonFooterContent,
+  },
+  render: (args) => (
+    <Container {...args}>
+      <LongContent />
+    </Container>
+  ),
 }

--- a/src/Modal/storybook/Modal.stories.tsx
+++ b/src/Modal/storybook/Modal.stories.tsx
@@ -16,7 +16,7 @@ const StyledBox = styled(Box)<{ height: string }>`
 `
 
 const Container: FC<ModalProps> = (props) => {
-  const [showModal, setShowModal] = useState(props.showModal ?? false)
+  const [showModal, setShowModal] = useState(false)
   const handleClick = () => {
     setShowModal(!showModal)
   }
@@ -83,7 +83,7 @@ type Story = StoryObj<typeof Modal>
 export const Default: Story = {
   args: {
     title: 'Generic modal',
-    showModal: true,
+    showModal: false,
   },
   render: (args) => {
     return (
@@ -135,7 +135,7 @@ export const Interactive: Story = {
 export const BasicContentModal: Story = {
   args: {
     title: 'Title of content',
-    showModal: true,
+    showModal: false,
   },
   render: (args) => (
     <Container {...args}>
@@ -151,7 +151,7 @@ export const BasicContentModal: Story = {
 export const CustomContentModal: Story = {
   args: {
     title: 'Title of content',
-    showModal: true,
+    showModal: false,
   },
   render: (args) => (
     <Container {...args}>
@@ -196,7 +196,7 @@ export const SingleButtonFooter: Story = {
 export const TwoButtonFooter: Story = {
   args: {
     title: 'Title of content',
-    showModal: true,
+    showModal: false,
     footer: TwoButtonFooterContent,
   },
   render: (args) => (
@@ -212,7 +212,7 @@ export const TwoButtonFooter: Story = {
 export const StickyHeader: Story = {
   args: {
     title: 'Title of content',
-    showModal: true,
+    showModal: false,
     stickyHeader: true,
   },
   render: (args) => (
@@ -225,7 +225,7 @@ export const StickyHeader: Story = {
 export const StickyFooter: Story = {
   args: {
     title: 'Title of content',
-    showModal: true,
+    showModal: false,
     stickyFooter: true,
     footer: TwoButtonFooterContent,
   },
@@ -239,7 +239,7 @@ export const StickyFooter: Story = {
 export const StickyHeaderAndFooter: Story = {
   args: {
     title: 'Title of content',
-    showModal: true,
+    showModal: false,
     stickyHeader: true,
     stickyFooter: true,
     footer: TwoButtonFooterContent,
@@ -254,7 +254,7 @@ export const StickyHeaderAndFooter: Story = {
 export const MobileDrawer: Story = {
   args: {
     title: 'Title of content',
-    showModal: true,
+    showModal: false,
     drawer: true,
     stickyHeader: true,
     stickyFooter: true,

--- a/src/Modal/storybook/Modal.stories.tsx
+++ b/src/Modal/storybook/Modal.stories.tsx
@@ -222,6 +222,27 @@ export const StickyHeader: Story = {
   ),
 }
 
+export const NonStickyFooter: Story = {
+  args: {
+    title: 'Title of content',
+    showModal: false,
+    footer: TwoButtonFooterContent,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'footer without stickyFooter -- scroll the content and the buttons scroll away with it, unlike StickyFooter below.',
+      },
+    },
+  },
+  render: (args) => (
+    <Container {...args}>
+      <LongContent />
+    </Container>
+  ),
+}
+
 export const StickyFooter: Story = {
   args: {
     title: 'Title of content',

--- a/src/Modal/storybook/Modal.stories.tsx
+++ b/src/Modal/storybook/Modal.stories.tsx
@@ -260,6 +260,14 @@ export const MobileDrawer: Story = {
     stickyFooter: true,
     footer: TwoButtonFooterContent,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Same recommended sticky configuration as above — `drawer` (on by default) turns this into a bottom-sheet on narrow screens. Resize your browser below 768px to see the drawer treatment take effect.',
+      },
+    },
+  },
   render: (args) => (
     <Container {...args}>
       <LongContent />

--- a/src/Modal/storybook/Modal.stories.tsx
+++ b/src/Modal/storybook/Modal.stories.tsx
@@ -100,7 +100,6 @@ export const Default: Story = {
 
 export const Interactive: Story = {
   args: {
-    icon: 'calendar',
     title: "Hello world i'm a beautiful modal",
     showModal: false,
     drawer: true,

--- a/src/Modal/storybook/Modal.stories.tsx
+++ b/src/Modal/storybook/Modal.stories.tsx
@@ -16,7 +16,7 @@ const StyledBox = styled(Box)<{ height: string }>`
 `
 
 const Container: FC<ModalProps> = (props) => {
-  const [showModal, setShowModal] = useState(false)
+  const [showModal, setShowModal] = useState(props.showModal ?? false)
   const handleClick = () => {
     setShowModal(!showModal)
   }
@@ -83,7 +83,7 @@ type Story = StoryObj<typeof Modal>
 export const Default: Story = {
   args: {
     title: 'Generic modal',
-    showModal: false,
+    showModal: true,
   },
   render: (args) => {
     return (
@@ -135,7 +135,7 @@ export const Interactive: Story = {
 export const BasicContentModal: Story = {
   args: {
     title: 'Title of content',
-    showModal: false,
+    showModal: true,
   },
   render: (args) => (
     <Container {...args}>
@@ -151,7 +151,7 @@ export const BasicContentModal: Story = {
 export const CustomContentModal: Story = {
   args: {
     title: 'Title of content',
-    showModal: false,
+    showModal: true,
   },
   render: (args) => (
     <Container {...args}>
@@ -196,7 +196,7 @@ export const SingleButtonFooter: Story = {
 export const TwoButtonFooter: Story = {
   args: {
     title: 'Title of content',
-    showModal: false,
+    showModal: true,
     footer: TwoButtonFooterContent,
   },
   render: (args) => (
@@ -212,7 +212,7 @@ export const TwoButtonFooter: Story = {
 export const StickyHeader: Story = {
   args: {
     title: 'Title of content',
-    showModal: false,
+    showModal: true,
     stickyHeader: true,
   },
   render: (args) => (
@@ -225,7 +225,7 @@ export const StickyHeader: Story = {
 export const StickyFooter: Story = {
   args: {
     title: 'Title of content',
-    showModal: false,
+    showModal: true,
     stickyFooter: true,
     footer: TwoButtonFooterContent,
   },
@@ -239,7 +239,7 @@ export const StickyFooter: Story = {
 export const StickyHeaderAndFooter: Story = {
   args: {
     title: 'Title of content',
-    showModal: false,
+    showModal: true,
     stickyHeader: true,
     stickyFooter: true,
     footer: TwoButtonFooterContent,
@@ -254,7 +254,7 @@ export const StickyHeaderAndFooter: Story = {
 export const MobileDrawer: Story = {
   args: {
     title: 'Title of content',
-    showModal: false,
+    showModal: true,
     drawer: true,
     stickyHeader: true,
     stickyFooter: true,

--- a/src/hooks/useBodyScrollLock/index.ts
+++ b/src/hooks/useBodyScrollLock/index.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { RefObject, useEffect } from 'react'
 import {
   clearAllBodyScrollLocks,
   disableBodyScroll,
@@ -14,10 +14,10 @@ const enhancedDisabeBodyScroll = (node: HTMLElement | Element) => {
 }
 
 export function useBodyScrollLock({
-  node,
+  ref,
   showModal,
 }: {
-  node: HTMLDivElement | null
+  ref: RefObject<HTMLDivElement | null>
   showModal: boolean
 }) {
   useEffect(() => {
@@ -25,12 +25,13 @@ export function useBodyScrollLock({
   }, [])
 
   useEffect(() => {
+    if (!showModal) return
+
+    const node = ref.current
     if (node === null) return
 
-    if (showModal) {
-      enhancedDisabeBodyScroll(node)
-    } else {
-      enableBodyScroll(node)
-    }
-  }, [node, showModal])
+    enhancedDisabeBodyScroll(node)
+
+    return () => enableBodyScroll(node)
+  }, [ref, showModal])
 }

--- a/src/hooks/useBodyScrollLock/index.ts
+++ b/src/hooks/useBodyScrollLock/index.ts
@@ -8,7 +8,6 @@ import {
 const enhancedDisabeBodyScroll = (node: HTMLElement | Element) => {
   disableBodyScroll(node, {
     reserveScrollBarGap: true,
-    allowTouchMove: () => true,
   })
 
   document.body.style.top = `-${window.scrollY}px`


### PR DESCRIPTION
## Summary
- Add opt-in `stickyHeader`, `footer`, and `stickyFooter` props to `Modal` — all default off/undefined, so this is non-breaking.
- Add the WAI-ARIA dialog pattern that was entirely missing before: `role="dialog"`, `aria-modal`, `aria-labelledby`, focus trap, focus restore on close, Escape-to-close.
- Fix two pre-existing bugs found via manual testing: `useBodyScrollLock` never actually locked or unlocked body scroll (a ref-timing bug), and `allowTouchMove: () => true` exempted every touch target from the lock, including the page behind the modal.
- Fix a border-radius/native-scrollbar clipping bug and an elastic-overscroll bounce on sticky header/footer.
- Add a hand-authored Storybook MDX docs page (first `.mdx` in this repo) with live story embeds, replacing Modal's auto-generated docs page.

## Details
- Design spec: `docs/superpowers/specs/2026-08-10-modal-sticky-header-footer-design.md`
- Implementation plan: `docs/superpowers/plans/2026-08-10-modal-sticky-header-footer.md`
- RFC (frontend guild): https://app.notion.com/p/3b9c6747c73380cfae97c932ef0defae
- Design system ticket: DES-164

## Test plan
- [ ] `npm test` — full suite (256+ tests, 21 in `Modal.test.tsx` alone)
- [ ] `npm run check-types && npm run lint`
- [ ] `npm run build-storybook`
- [ ] Manual: open `Modal` stories (Sticky Header, Sticky Footer, Sticky Header And Footer, Mobile Drawer, Non-Sticky Footer) and confirm sticky behaviour, no bounce, no scrollbar-clipped corners
- [ ] Manual: confirm background page does not scroll while any modal is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)