### PR TITLE
style: format with prettier

### DIFF
--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -26,11 +26,7 @@ export type AccordionProps = {
   borderColor?: 'oatmeal' | 'custard' | 'cream' | 'coconut' | UsableNewColors
   fullBorder?: boolean
   backgroundColor?:
-    | 'oatmeal'
-    | 'custard'
-    | 'cream'
-    | 'coconut'
-    | UsableNewColors
+    'oatmeal' | 'custard' | 'cream' | 'coconut' | UsableNewColors
   onToggle?: (isOpen: boolean) => void
   children: ReactNode
   defaultIsOpen?: boolean
@@ -123,16 +119,20 @@ const Wrapper = styled(Box)<
     border-bottom: 1px solid ${$borderColor};
     ${$borderTop && `border-top: 1px solid ${$backgroundColor};`}
 
-    ${$fullBorder &&
-    css`
-      border: 1px solid ${$borderColor};
-      border-radius: 16px;
-    `}
+    ${
+      $fullBorder &&
+      css`
+        border: 1px solid ${$borderColor};
+        border-radius: 16px;
+      `
+    }
 
-    ${$filledBackground &&
-    css`
-      background-color: ${$backgroundColor};
-    `}
+    ${
+      $filledBackground &&
+      css`
+        background-color: ${$backgroundColor};
+      `
+    }
   `,
 )
 

--- a/src/Badge/Badge.tsx
+++ b/src/Badge/Badge.tsx
@@ -93,12 +93,14 @@ const Container = styled.div<ContainerProps>((props) => {
     filter: ${props.$disabled ? 'contrast(0.5)' : 'none'};
     z-index: ${props.$zIndex || 0};
 
-    ${!props.$disabled &&
-    css`
-      &:hover {
-        cursor: pointer;
-        box-shadow: 0 0 0px 5px #f0f0f0;
-      }
-    `}
+    ${
+      !props.$disabled &&
+      css`
+        &:hover {
+          cursor: pointer;
+          box-shadow: 0 0 0px 5px #f0f0f0;
+        }
+      `
+    }
   `
 })

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -160,46 +160,54 @@ const Container = styled(Box)<IButton>(
 
     ${focusOutlineStyle}
 
-    ${$primary &&
-    css`
-      &:hover {
-        background-color: ${({ theme }) =>
-          !(disabled || $loading) && theme.color.interactive.primary.hover};
-      }
-      &:active {
-        background-color: ${({ theme }) =>
-          theme.color.interactive.primary.selected};
-      }
-    `}
+    ${
+      $primary &&
+      css`
+        &:hover {
+          background-color: ${({ theme }) =>
+            !(disabled || $loading) && theme.color.interactive.primary.hover};
+        }
+        &:active {
+          background-color: ${({ theme }) =>
+            theme.color.interactive.primary.selected};
+        }
+      `
+    }
 
-    ${$secondary &&
-    css`
-      background-color: ${({ theme }) =>
-        theme.color.interactive.secondary.base};
+    ${
+      $secondary &&
+      css`
+        background-color: ${({ theme }) =>
+          theme.color.interactive.secondary.base};
 
-      &:hover {
-        background-color: ${({ theme }) =>
-          !(disabled || $loading) && theme.color.interactive.secondary.hover};
-      }
-      &:active {
-        background-color: ${({ theme }) =>
-          theme.color.interactive.secondary.selected};
-      }
-    `}
-  ${$fallbackStyle &&
+        &:hover {
+          background-color: ${({ theme }) =>
+            !(disabled || $loading) && theme.color.interactive.secondary.hover};
+        }
+        &:active {
+          background-color: ${({ theme }) =>
+            theme.color.interactive.secondary.selected};
+        }
+      `
+    }
+  ${
+    $fallbackStyle &&
     css`
       background-color: ${({ theme }) => theme.color.interactive.neutral.subtle.base};
 
       &:hover {
         background-color: ${({ theme }) =>
-          !(disabled || $loading) && theme.color.interactive.neutral.subtle.hover};
+          !(disabled || $loading) &&
+          theme.color.interactive.neutral.subtle.hover};
       }
       &:active {
         background-color: ${({ theme }) =>
           theme.color.interactive.neutral.subtle.selected};
       }
-    `}
-  ${$smallButton &&
+    `
+  }
+  ${
+    $smallButton &&
     css`
       padding: 0 10px;
       min-width: 54px;
@@ -212,8 +220,10 @@ const Container = styled(Box)<IButton>(
       span {
         margin: 0 5px 0 0;
       }
-    `}
-  ${$textBtn &&
+    `
+  }
+  ${
+    $textBtn &&
     css`
       background-color: transparent;
       padding: 0;
@@ -228,7 +238,8 @@ const Container = styled(Box)<IButton>(
         background-color: transparent;
         color: ${({ theme }) => theme.color.text.subtle};
       }
-    `}
+    `
+  }
   `,
 )
 

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -67,7 +67,12 @@ export const Card: FC<CardProps> = ({
       {iconComponent}
     </IconContainer>
   ) : leadingIcon ? (
-    <Icon mr="space.150" render={leadingIcon} size={24} color="color.icon.base" />
+    <Icon
+      mr="space.150"
+      render={leadingIcon}
+      size={24}
+      color="color.icon.base"
+    />
   ) : null
 
   return (

--- a/src/Chip/Chip.tsx
+++ b/src/Chip/Chip.tsx
@@ -122,26 +122,34 @@ const Container = styled(Box)<IButton>(
     cursor: ${disabled || $loading ? 'not-allowed' : 'pointer'};
     opacity: ${disabled ? '0.5' : '1'};
 
-    ${$primary &&
-    css`
-      &:hover {
-        border: ${!(disabled || $loading) &&
-        `2px solid ${theme.color.background[200]}`};
-        background-color: ${!(disabled || $loading) &&
-        theme.color.background[200]};
-      }
-    `}
-    ${$secondary &&
-    css`
-      color: ${theme.color.text.inverse};
-      background-color: ${theme.color.surface.base[900]};
-      border: 2px solid ${theme.color.surface.base[900]};
-      &:hover {
-        border: ${!(disabled || $loading) &&
-        `2px solid ${theme.color.text.subtle}`};
-        background-color: ${!(disabled || $loading) && theme.color.text.subtle};
-      }
-    `};
+    ${
+      $primary &&
+      css`
+        &:hover {
+          border: ${
+            !(disabled || $loading) &&
+            `2px solid ${theme.color.background[200]}`
+          };
+          background-color: ${
+            !(disabled || $loading) && theme.color.background[200]
+          };
+        }
+      `
+    }
+    ${
+      $secondary &&
+      css`
+        color: ${theme.color.text.inverse};
+        background-color: ${theme.color.surface.base[900]};
+        border: 2px solid ${theme.color.surface.base[900]};
+        &:hover {
+          border: ${
+            !(disabled || $loading) && `2px solid ${theme.color.text.subtle}`
+          };
+          background-color: ${!(disabled || $loading) && theme.color.text.subtle};
+        }
+      `
+    };
   `,
 )
 

--- a/src/IconStrict/IconStrict.tsx
+++ b/src/IconStrict/IconStrict.tsx
@@ -115,15 +115,17 @@ const IconContainer = styled.div<IIconStrict>(
     background-color: ${$backgroundColor ?? 'none'};
     cursor: ${onClick ? 'pointer' : 'default'};
 
-    ${onClick &&
-    `
+    ${
+      onClick &&
+      `
     &:hover {
       background-color: ${
         $backgroundColor ? darken(0.1, $backgroundColor) : 'none'
       };
     }
       
-    `}
+    `
+    }
 
     ${focusOutlineStyle}
   `,

--- a/src/Link/Link.tsx
+++ b/src/Link/Link.tsx
@@ -81,23 +81,27 @@ const LinkWrapper = styled.a<{ $typo: LinkTypo; $highlight: boolean }>(
     display: inline-flex;
     flex-direction: row;
 
-    ${$typo === 'regular' &&
-    css`
-      font-size: 16px;
-      line-height: 20px;
-    `}
+    ${
+      $typo === 'regular' &&
+      css`
+        font-size: 16px;
+        line-height: 20px;
+      `
+    }
 
-    ${$typo === 'small' &&
-    css`
-      font-size: 14px;
-      line-height: 20px;
-    `}
+    ${
+      $typo === 'small' &&
+      css`
+        font-size: 14px;
+        line-height: 20px;
+      `
+    }
 
     font-weight: ${oldTheme.font.weight.medium};
     text-decoration: underline;
-    color: ${$highlight
-      ? theme.color.interactive.primary.base
-      : theme.color.text.base};
+    color: ${
+      $highlight ? theme.color.interactive.primary.base : theme.color.text.base
+    };
 
     background: none;
     cursor: pointer;

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -164,20 +164,22 @@ const Container = styled.div<IModalContainer>(
     overflow: auto;
     transition: all 0.3s ease-in-out;
 
-    ${$drawer === true &&
-    css`
-      @media (max-width: 768px) {
-        max-width: none;
-        border-radius: 16px 16px 0px 0px;
-        padding: 10% 24px;
-        max-height: 90vh;
+    ${
+      $drawer === true &&
+      css`
+        @media (max-width: 768px) {
+          max-width: none;
+          border-radius: 16px 16px 0px 0px;
+          padding: 10% 24px;
+          max-height: 90vh;
 
-        position: fixed;
-        right: 0;
-        left: 0;
-        bottom: 0;
-      }
-    `}
+          position: fixed;
+          right: 0;
+          left: 0;
+          bottom: 0;
+        }
+      `
+    }
   `,
 )
 

--- a/src/RadioGroup/RadioItem.tsx
+++ b/src/RadioGroup/RadioItem.tsx
@@ -171,42 +171,56 @@ const Wrapper = styled.label<
     $itemWidth,
     theme,
   }) => css`
-    ${($displayType === 'horizontal-card' ||
-      $displayType === 'vertical-card') &&
-    css`
-      border-radius: 12px;
-      background-color: ${$fallbackStyle
-        ? theme.color.surface.base['000']
-        : theme.color.surface.base[300]};
-      padding: ${checked ? '10px' : '12px'};
-      border: ${checked &&
-      ($isError
-        ? `2px solid ${theme.color.feedback.negative[200]}`
-        : `2px solid ${theme.color.border.contrast}`)};
-
-      &:hover {
-        ${!$disabled &&
-        css`
-          background-color: ${$fallbackStyle
-            ? theme.color.surface.base[100]
-            : theme.color.surface.base[400]};
-        `}
-      }
-    `}
-    ${$displayType === 'horizontal-card' &&
-    css`
-      justify-content: center;
-      ${!$itemWidth &&
+    ${
+      ($displayType === 'horizontal-card' ||
+        $displayType === 'vertical-card') &&
       css`
-        @media (min-width: 420px) {
-          width: calc(50% - ${ITEM_GAP / 2}px);
-        }
+        border-radius: 12px;
+        background-color: ${
+          $fallbackStyle
+            ? theme.color.surface.base['000']
+            : theme.color.surface.base[300]
+        };
+        padding: ${checked ? '10px' : '12px'};
+        border: ${
+          checked &&
+          ($isError
+            ? `2px solid ${theme.color.feedback.negative[200]}`
+            : `2px solid ${theme.color.border.contrast}`)
+        };
 
-        @media (min-width: 768px) {
-          width: 201px;
+        &:hover {
+          ${
+            !$disabled &&
+            css`
+              background-color: ${
+                $fallbackStyle
+                  ? theme.color.surface.base[100]
+                  : theme.color.surface.base[400]
+              };
+            `
+          }
         }
-      `}
-    `}
+      `
+    }
+    ${
+      $displayType === 'horizontal-card' &&
+      css`
+        justify-content: center;
+        ${
+          !$itemWidth &&
+          css`
+            @media (min-width: 420px) {
+              width: calc(50% - ${ITEM_GAP / 2}px);
+            }
+
+            @media (min-width: 768px) {
+              width: 201px;
+            }
+          `
+        }
+      `
+    }
   width: ${$itemWidth ?? '100%'};
   `}
 `

--- a/src/RadioGroup/storybook/RadioGroup.stories.tsx
+++ b/src/RadioGroup/storybook/RadioGroup.stories.tsx
@@ -125,11 +125,7 @@ export const WithMultipleTextElements: Story = {
         label: 'Pay now',
         value: 'basic',
         bodyCopy: (
-          <Box
-            direction="column"
-            mt="space.050"
-            gap="space.050"
-          >
+          <Box direction="column" mt="space.050" gap="space.050">
             <Text>£189.38 today</Text>
             <Text typo="body-small" color="color.text.subtle">
               Your remaining 3 monthly payments stay at £39.43
@@ -141,11 +137,7 @@ export const WithMultipleTextElements: Story = {
         label: 'Spread the cost',
         value: 'standard',
         bodyCopy: (
-          <Box
-            direction="column"
-            mt="space.050"
-            gap="space.050"
-          >
+          <Box direction="column" mt="space.050" gap="space.050">
             <Text>£12.50 today</Text>
             <Text typo="body-small" color="color.text.subtle">
               Your remaining 3 monthly payments will increase to £94.22

--- a/src/RadioGroup/types.ts
+++ b/src/RadioGroup/types.ts
@@ -12,10 +12,7 @@ export type IconPosition = 'center' | 'start'
  *
  */
 export type DisplayType =
-  | 'normal'
-  | 'horizontal-normal'
-  | 'vertical-card'
-  | 'horizontal-card'
+  'normal' | 'horizontal-normal' | 'vertical-card' | 'horizontal-card'
 
 export type BaseValueType = string | boolean | null
 

--- a/src/Row/Row.tsx
+++ b/src/Row/Row.tsx
@@ -101,17 +101,23 @@ interface IContainer {
 
 const Container = styled(Box)<IContainer>(
   ({ $type, $iconLeft, $borderTop, $borderBottom, $boldHeading, theme }) => css`
-    border-radius: ${($type === 'first' && `16px 16px 0 0`) ||
-    ($type === 'curved' && `16px`) ||
-    ($type === 'last' && `0 0 16px 16px`) ||
-    0};
+    border-radius: ${
+      ($type === 'first' && `16px 16px 0 0`) ||
+      ($type === 'curved' && `16px`) ||
+      ($type === 'last' && `0 0 16px 16px`) ||
+      0
+    };
 
-    border-top: ${$borderTop && $type !== 'curved' && $type !== 'first'
-      ? `1px solid ${theme.color.border.subtle}`
-      : 'none'};
-    border-bottom: ${$borderBottom && $type !== 'curved' && $type !== 'last'
-      ? `1px solid ${theme.color.border.subtle}`
-      : 'none'};
+    border-top: ${
+      $borderTop && $type !== 'curved' && $type !== 'first'
+        ? `1px solid ${theme.color.border.subtle}`
+        : 'none'
+    };
+    border-bottom: ${
+      $borderBottom && $type !== 'curved' && $type !== 'last'
+        ? `1px solid ${theme.color.border.subtle}`
+        : 'none'
+    };
 
     background-color: ${theme.color.surface.base[300]};
     display: grid;

--- a/src/SupportMessage/SupportMessage.tsx
+++ b/src/SupportMessage/SupportMessage.tsx
@@ -55,11 +55,7 @@ const styles: Record<SupportMessageType, StylesItem> = {
 }
 
 type SupportMessageType =
-  | 'info'
-  | 'fallbackStyle'
-  | 'alert'
-  | 'warning'
-  | 'success'
+  'info' | 'fallbackStyle' | 'alert' | 'warning' | 'success'
 
 export type SupportMessageProps = {
   className?: string

--- a/src/Table/components/commonComponents.tsx
+++ b/src/Table/components/commonComponents.tsx
@@ -146,17 +146,17 @@ export const StyledRow = styled.tr<TransientProps<TableStylesProps>>`
     `}
 
     ${({ $clickableRow, $rowColor, theme }) =>
-    $clickableRow &&
-    css`
-      cursor: pointer;
-      &:hover {
-        background: ${darken(0.1, $rowColor ?? theme.color.surface.base[300])};
-      }
-      &:focus-visible {
-        ${focusOutlineStyle}
-        background: ${darken(0.1, $rowColor ?? theme.color.surface.base[300])};
-      }
-    `}
+      $clickableRow &&
+      css`
+        cursor: pointer;
+        &:hover {
+          background: ${darken(0.1, $rowColor ?? theme.color.surface.base[300])};
+        }
+        &:focus-visible {
+          ${focusOutlineStyle}
+          background: ${darken(0.1, $rowColor ?? theme.color.surface.base[300])};
+        }
+      `}
 `
 
 type StyledSubTableCellProps = {

--- a/src/Table/types.ts
+++ b/src/Table/types.ts
@@ -34,8 +34,7 @@ export type BaseRowAction<T> = {
 }
 
 export type RowAction<T> =
-  | RowActionButtonDefault<T>
-  | RowActionElementOverride<T>
+  RowActionButtonDefault<T> | RowActionElementOverride<T>
 
 export type RowActionButtonDefault<T> = {
   iconButton?: Pick<
@@ -174,8 +173,7 @@ export interface TableProps<T, K = undefined> extends CommonTableProps<T> {
  * For a React element, it will render that as the table footer.
  */
 export type TableFooter<K> =
-  | TableFooterColumnsProps<K>
-  | TableFooterElementProps<K>
+  TableFooterColumnsProps<K> | TableFooterElementProps<K>
 
 export interface TableRowProps<T> extends CommonTableProps<T> {
   rowData: T

--- a/src/fields/components/InternalField.tsx
+++ b/src/fields/components/InternalField.tsx
@@ -75,12 +75,7 @@ export const InternalField = ({
 
       <Box>{children}</Box>
       {fieldType === 'field' && assistiveText && !renderAsTitle && (
-        <Text
-          tag={labelTag}
-          typo="caption"
-          color={textColor}
-          mt="space.050"
-        >
+        <Text tag={labelTag} typo="caption" color={textColor} mt="space.050">
           {assistiveText}
         </Text>
       )}

--- a/src/utils/space.tsx
+++ b/src/utils/space.tsx
@@ -9,10 +9,7 @@ type LegacySpacing = '8px' | '12px' | '16px' | '24px' | '32px' | '48px' | '64px'
 export type ThemeSpacing = Prettify<Flatten<Pick<Theme, 'space'>>>
 
 export type SpacingProp =
-  | '0'
-  | LegacySpacing
-  | ThemeSpacing
-  | { custom: number | string }
+  '0' | LegacySpacing | ThemeSpacing | { custom: number | string }
 
 export const resolveSpacing = (value: SpacingProp | 'auto', theme?: Theme) => {
   if (typeof value === 'string') {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,41 +1,28 @@
 {
-	"compilerOptions": {
-		"outDir": "./dist",
-		"module": "esnext",
-		"target": "esnext",
-		"lib": [
-			"esnext",
-			"dom",
-			"dom.iterable"
-		],
-		"types": [
-			"react",
-			"node",
-			"vitest/globals",
-			"./src/styled.ts"
-		],
-		"sourceMap": true,
-		"inlineSources": true,
-		"jsx": "react-jsx",
-		"declaration": true,
-		"moduleResolution": "Bundler",
-		"forceConsistentCasingInFileNames": true,
-		"strict": true,
-		"noUnusedLocals": true,
-		"allowSyntheticDefaultImports": true,
-		"experimentalDecorators": true,
-		"skipLibCheck": true
-	},
-	"include": [
-		"src/**/*",
-		"src/global.d.ts",
-		"src/styled.ts",
-		"vite.config.ts",
-		"vitest.config.ts"
-	],
-	"exclude": [
-		"node_modules",
-		"dist",
-		"scripts"
-	]
+  "compilerOptions": {
+    "outDir": "./dist",
+    "module": "esnext",
+    "target": "esnext",
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "types": ["react", "node", "vitest/globals", "./src/styled.ts"],
+    "sourceMap": true,
+    "inlineSources": true,
+    "jsx": "react-jsx",
+    "declaration": true,
+    "moduleResolution": "Bundler",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*",
+    "src/global.d.ts",
+    "src/styled.ts",
+    "vite.config.ts",
+    "vitest.config.ts"
+  ],
+  "exclude": ["node_modules", "dist", "scripts"]
 }


### PR DESCRIPTION
## What does this do?

Runs `prettier --write` across the repo. Whitespace and line-wrapping only — `git diff -w` shows no content changes.

Formatting had drifted because the lint script is `eslint . --fix`: violations were auto-corrected on every local run, so they never surfaced as something to commit. `npx eslint .` on `main` reports **151 `prettier/prettier` errors** across these 18 files, and `prettier --check .` fails on the same set.

Bottom of a 3-PR stack. It's separate from the oxlint migration above it ([#5119](https://github.com/marshmallow-insurance/smores-react/pull/5119)) for two reasons: the drift is pre-existing rather than caused by the migration, and 242 re-wrapped lines inside that PR would bury the config decisions a reviewer actually needs to look at. The migration can't go green until this lands, since it enforces the same rule as an error.

One thing worth knowing for next time: `prettier --write .` needed **two passes** here. Three files (`Button`, `Chip`, `RadioItem`) were still unformatted after the first, so run it until `--check` is clean rather than assuming one pass is enough.

`tsconfig.json` is in the diff because it was indented with tabs.

## Testing

No tests added — formatting has no behaviour. Verified by `git diff -w` being empty of content changes, and the suite staying green at the top of the stack (45 files, 246 tests).