### PR TITLE
chore: clean up config left pointing at eslint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,6 @@ updates:
         patterns:
           - "storybook*"
           - "@storybook/*"
-          - "eslint-plugin-storybook*"
         update-types:
           - "major"
           - "minor"
@@ -37,21 +36,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      ts-eslint:
-        patterns:
-          - "@typescript-eslint*"
-          - "@typescript-eslint/*"
-          - "typescript-eslint"
-        update-types:
-          - "minor"
-          - "patch"
       eslint:
         patterns:
           - "eslint"
           - "eslint-plugin-*"
           - "eslint-config-*"
-        exclude-patterns:
-          - "eslint-plugin-storybook"
       testing-library:
         patterns:
           - "@testing-library/*"

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 .idea/
 .vscode/**/*
 !.vscode/extensions.json
+!.vscode/settings.json
 
 logs
 *.log

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "dbaeumer.vscode-eslint",
     "GitHub.copilot",
     "esbenp.prettier-vscode",
     "styled-components.vscode-styled-components",
@@ -9,6 +8,7 @@
     "naumovs.color-highlight",
     "jock.svg",
     "YoavBls.pretty-ts-errors",
-    "Gruntfuggly.todo-tree"
+    "Gruntfuggly.todo-tree",
+    "oxc.oxc-vscode"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}


### PR DESCRIPTION
## What does this do?

Follow-up to the oxlint migration (#5119). Two bits of config still referenced ESLint packages the repo no longer has, so a fresh checkout got an editor set up for a linter that isn't here.

**Editor config**

| | Before | After |
|---|---|---|
| `extensions.json` | recommends `dbaeumer.vscode-eslint` | recommends `oxc.oxc-vscode` |
| `settings.json` | absent | pins the default formatter for TS/TSX |

The default formatter is `esbenp.prettier-vscode`, **not** the oxc extension. Formatting here is enforced by `prettier/prettier` at error level through `jsPlugins`, so pointing format-on-save at oxfmt would produce code this repo's own linter rejects. Moving to `oxc.oxc-vscode` — as `uk-auto-agent-portal-www` does — means migrating formatting to oxfmt first, which is its own piece of work.

`.vscode/**/*` is gitignored, so `settings.json` needed its own negation alongside the one `extensions.json` already had.

**Dependabot groups**

- `ts-eslint` grouped `@typescript-eslint*`; all of those packages went away with the migration, so it now groups nothing
- `eslint-plugin-storybook` went the same way, making the storybook group's pattern for it and the eslint group's exclusion of it both dead

The `eslint` group stays — `eslint-plugin-*` still matches `eslint-plugin-prettier`.

## Testing

No behaviour to test: editor recommendations and dependabot grouping only. `npx oxlint` is still clean (exit 0, 0 errors) and the dependabot YAML parses with the same six groups minus `ts-eslint`.