### PR TITLE
Exclude @mrshmllw/* from dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: '/'
     cooldown:
       default-days: 7
+      exclude:
+        - "@mrshmllw/*"
     # Always increase package version to the latest version even if lockfile is the only thing required to change
     versioning-strategy: increase
     schedule:


### PR DESCRIPTION
- Adds `@mrshmllw/*` to the npm `cooldown.exclude` list in `.github/dependabot.yml`
- GitHub's default Dependabot cooldown delays version-bump PRs by several days, which shouldn't apply to our own internal packages (e.g. the smores design system)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgsDSW8daYDiqp2JCZ6ZAc
